### PR TITLE
docs(prompt): correct session concurrency claims for Chrome 138 / Edge 138

### DIFF
--- a/.changeset/prompt-session-concurrency-docs.md
+++ b/.changeset/prompt-session-concurrency-docs.md
@@ -1,0 +1,7 @@
+---
+"@web-ai-sdk/prompt": patch
+---
+
+Amends the `createSession()` / `useSession()` docs to match the empirical behavior of Chrome 138 / Edge 138. The 0.3 release notes (and README, JSDoc, and the Prompt API guide on the docs site) leaned on "N parallel chats stream concurrently" or close paraphrases. Token-level interleaving across independent sessions is not actually delivered by the runtime today: the on-device model is single-instance, so the browser drains one `sendStreaming` call fully before starting the next, even across separate `createSession()` instances.
+
+No API change, no behavior change. `createSession()` / `useSession()` still solve the bugs they shipped to solve — isolated history per session, isolated system prompt and sampling, scoped `abort()` and `destroy()` — and the API stays forward-compatible the day a runtime exposes parallel inference. The docs now make the runtime constraint explicit (a new "Concurrency note" in the prompt README and Prompt API guide) and the README / JSDoc copy emphasizes independence-of-state rather than concurrent streaming.

--- a/apps/docs/src/content/docs/guides/prompt.mdx
+++ b/apps/docs/src/content/docs/guides/prompt.mdx
@@ -52,7 +52,9 @@ session.destroy();
 
 The wrapper is intentionally thin. It handles cross-browser smoothing every consumer would otherwise reimplement (delta-vs-cumulative chunk detection, output sanitization, abort wiring, typed unavailability) and forwards everything else to the native instance. It does **not** track conversation history, queue concurrent sends, or wrap `clone()` — those are your data model and UI concerns.
 
-`createSession()` never touches the `ask()` session cache. Two sessions with identical options get two independent instances; N parallel chats stream concurrently. Concurrent `send` / `sendStreaming` calls on the **same** session are NOT queued — the underlying `LanguageModel` is sequential per instance and will reject the overlapping call with `InvalidStateError`. Either `await` the previous send or call `session.abort()` before issuing a new turn.
+`createSession()` never touches the `ask()` session cache. Two sessions with identical options get two independent instances with isolated history, system prompt, sampling, and lifecycle — `abort()` / `destroy()` on one session never touch another. Concurrent `send` / `sendStreaming` calls on the **same** session are NOT queued — the underlying `LanguageModel` is sequential per instance and will reject the overlapping call with `InvalidStateError`. Either `await` the previous send or call `session.abort()` before issuing a new turn.
+
+**Concurrency note.** Each session is an independent `LanguageModel` instance, but the underlying on-device model is single-instance. Chrome 138 / Edge 138 currently schedule `sendStreaming` calls across sessions FIFO: overlapping sends do not interleave token-by-token — the second send waits for the first to drain. This is a constraint of the runtime, not of the API; code written against `createSession()` becomes faster automatically if a future release exposes parallel inference.
 
 ## How it works
 

--- a/packages/detector/CHANGELOG.md
+++ b/packages/detector/CHANGELOG.md
@@ -10,7 +10,7 @@
 
   **`createSession()` + `useSession()` in `@web-ai-sdk/prompt`**
 
-  A thin primitive for chat-shaped apps. Each call returns an independent `LanguageModel` session — never shared via the one-shot cache — so N parallel chats stream concurrently. `session.sendStreaming()` yields **deltas** (one element per new chunk, not cumulative). The wrapper handles cross-browser smoothing (delta-vs-cumulative detection, output sanitization, abort wiring, typed unavailability) and forwards everything else to the native instance. It deliberately does NOT track conversation history, queue concurrent sends, or wrap `clone()` — those are consumer data model and UI concerns.
+  A thin primitive for chat-shaped apps. Each call returns an independent `LanguageModel` session — never shared via the one-shot cache — so per-conversation history, system prompt, sampling, and lifecycle stay isolated, and `abort()` / `destroy()` on one session never touch another. `session.sendStreaming()` yields **deltas** (one element per new chunk, not cumulative). The wrapper handles cross-browser smoothing (delta-vs-cumulative detection, output sanitization, abort wiring, typed unavailability) and forwards everything else to the native instance. It deliberately does NOT track conversation history, queue concurrent sends, or wrap `clone()` — those are consumer data model and UI concerns. Token-level interleaving across sessions is implementation-defined: Chrome 138 / Edge 138 currently serialize `sendStreaming` calls across sessions FIFO (the underlying on-device model is single-instance); the API is forward-compatible for runtimes that expose parallel inference.
 
   ```ts
   import { createSession } from "@web-ai-sdk/prompt";

--- a/packages/prompt/CHANGELOG.md
+++ b/packages/prompt/CHANGELOG.md
@@ -10,7 +10,7 @@
 
   **`createSession()` + `useSession()` in `@web-ai-sdk/prompt`**
 
-  A thin primitive for chat-shaped apps. Each call returns an independent `LanguageModel` session — never shared via the one-shot cache — so N parallel chats stream concurrently. `session.sendStreaming()` yields **deltas** (one element per new chunk, not cumulative). The wrapper handles cross-browser smoothing (delta-vs-cumulative detection, output sanitization, abort wiring, typed unavailability) and forwards everything else to the native instance. It deliberately does NOT track conversation history, queue concurrent sends, or wrap `clone()` — those are consumer data model and UI concerns.
+  A thin primitive for chat-shaped apps. Each call returns an independent `LanguageModel` session — never shared via the one-shot cache — so per-conversation history, system prompt, sampling, and lifecycle stay isolated, and `abort()` / `destroy()` on one session never touch another. `session.sendStreaming()` yields **deltas** (one element per new chunk, not cumulative). The wrapper handles cross-browser smoothing (delta-vs-cumulative detection, output sanitization, abort wiring, typed unavailability) and forwards everything else to the native instance. It deliberately does NOT track conversation history, queue concurrent sends, or wrap `clone()` — those are consumer data model and UI concerns. Token-level interleaving across sessions is implementation-defined: Chrome 138 / Edge 138 currently serialize `sendStreaming` calls across sessions FIFO (the underlying on-device model is single-instance); the API is forward-compatible for runtimes that expose parallel inference.
 
   ```ts
   import { createSession } from "@web-ai-sdk/prompt";

--- a/packages/prompt/README.md
+++ b/packages/prompt/README.md
@@ -32,7 +32,7 @@ const result = await ask({
 console.log(result.response, result.cached);
 ```
 
-`ask()` shares a warm `LanguageModel` instance across same-shape callers so the cold start is paid once per persona. That's right for embeds, widgets, ask-and-display flows. It's the wrong shape for chat (two callers with the same mode would queue, not stream concurrently).
+`ask()` shares a warm `LanguageModel` instance across same-shape callers so the cold start is paid once per persona. That's right for embeds, widgets, ask-and-display flows. It's the wrong shape for chat: two callers with the same mode would share one instance, so conversation history cross-bleeds and `abort()` on one caller kills the other.
 
 ### Chat — `createSession()`
 
@@ -56,7 +56,9 @@ const text = await session.send("And what about the Prompt API?");
 session.destroy();
 ```
 
-Every `createSession()` call returns an independent `LanguageModelInstance`, so N parallel chats stream concurrently. Concurrent `send` / `sendStreaming` calls on the **same** session are NOT queued — the underlying `LanguageModel` is sequential per instance and will reject the overlapping call with `InvalidStateError`. Either `await` the previous send or call `session.abort()` before issuing a new turn. Multi-turn conversation context is tracked by the native instance itself; UI message lists are your data model.
+Every `createSession()` call returns an independent `LanguageModelInstance` with its own history, system prompt, sampling, and lifecycle — `abort()` / `destroy()` on one session never touch another. Concurrent `send` / `sendStreaming` calls on the **same** session are NOT queued — the underlying `LanguageModel` is sequential per instance and will reject the overlapping call with `InvalidStateError`. Either `await` the previous send or call `session.abort()` before issuing a new turn. Multi-turn conversation context is tracked by the native instance itself; UI message lists are your data model.
+
+**Concurrency note.** Each session is an independent `LanguageModel` instance: independent history, system prompt, sampling, and lifecycle. The underlying on-device model is single-instance, so the browser currently schedules `sendStreaming` calls across sessions FIFO. Overlapping sends do not interleave token-by-token in Chrome 138 / Edge 138 — the second send waits for the first to drain. This is a constraint of the runtime, not of the API; code written against `createSession()` becomes faster automatically if a future release exposes parallel inference.
 
 ## React
 
@@ -125,7 +127,7 @@ export function Chat({ persona }: { persona: string }) {
 }
 ```
 
-`useSession` is lifecycle-only: it creates the session on mount, destroys it on unmount, and recreates it when any primitive option changes. It deliberately does **not** track `response` / `history` / streaming status — that's your UI state, you own it. Each `useSession()` call owns its own underlying `LanguageModelInstance`, so N components → N concurrent streams.
+`useSession` is lifecycle-only: it creates the session on mount, destroys it on unmount, and recreates it when any primitive option changes. It deliberately does **not** track `response` / `history` / streaming status — that's your UI state, you own it. Each `useSession()` call owns its own underlying `LanguageModelInstance`, so component state and `abort()` / `destroy()` stay scoped to the owning component. Token-level interleaving across sessions is browser-defined (see the Concurrency note above) — N mounted components in Chrome 138 / Edge 138 still drain through one underlying model FIFO.
 
 ## API
 

--- a/packages/prompt/src/index.ts
+++ b/packages/prompt/src/index.ts
@@ -150,8 +150,8 @@ const warnClobberOnce = (key: string): void => {
  *
  * For chat-shaped apps where turns need to remember each other, prefer
  * `createSession()` (or `useSession()` in React); `ask()` shares warm sessions
- * across same-shape callers, so two chats with the same persona will queue
- * instead of streaming concurrently.
+ * across same-shape callers, so two chats with the same persona would share
+ * one instance — with cross-bleeding history and `abort()` killing both.
  */
 export const ask = async (options: AskOptions): Promise<AskResult> => {
   const api = getLanguageModelApi();

--- a/packages/prompt/src/react/index.ts
+++ b/packages/prompt/src/react/index.ts
@@ -40,8 +40,9 @@ export interface UsePromptReturn {
  * (memoize if necessary); the hook keeps them in a ref to avoid stale-closure
  * issues without forcing the consumer to re-render on every change.
  *
- * For multi-turn chat where each conversation needs its own context and
- * streams should run concurrently, prefer `useSession`.
+ * For multi-turn chat where each conversation needs its own context,
+ * system prompt, and lifecycle (so `abort()` on one chat doesn't kill
+ * the others), prefer `useSession`.
  */
 export const usePrompt = (options: UsePromptOptions = {}): UsePromptReturn => {
   const [status, setStatus] = useState<PromptStatus>(() =>
@@ -145,10 +146,17 @@ export interface UseSessionReturn {
 
 /**
  * Lifecycle-only React adapter for `createSession`. Each call owns one
- * underlying `LanguageModel` session — so parallel components stream
- * concurrently — and the session is destroyed on unmount or when any
- * primitive option (`systemPrompt`, `temperature`, `topK`, `language`,
- * `enabled`) changes.
+ * underlying `LanguageModel` session with its own history, system prompt,
+ * sampling, and lifecycle — `abort()` / `destroy()` on one component's
+ * session never touch another's — and the session is destroyed on unmount
+ * or when any primitive option (`systemPrompt`, `temperature`, `topK`,
+ * `language`, `enabled`) changes.
+ *
+ * Token-level interleaving across sessions is browser-defined: the
+ * underlying on-device model is single-instance, so Chrome 138 / Edge 138
+ * currently serialize `sendStreaming` calls across sessions FIFO. The
+ * second component's send waits for the first to drain. The API is
+ * forward-compatible for runtimes that expose parallel inference.
  *
  * The hook intentionally does **not** track `response` / `history` /
  * streaming status. Iterate `session.sendStreaming()` yourself and keep UI

--- a/packages/prompt/src/session.ts
+++ b/packages/prompt/src/session.ts
@@ -4,8 +4,10 @@
  * `ask()` shares warm sessions through `getOrCreateLanguageModel`, which is
  * right for embeds and widgets — the cold start is paid once per persona.
  * It's the wrong shape for chat: two callers with the same mode would share
- * one instance and queue against each other instead of streaming concurrently.
- * `createSession()` bypasses that cache so every caller gets its own instance.
+ * one instance, so conversation history cross-bleeds, `abort()` on one
+ * caller kills the other, and `destroy()` releases memory the other still
+ * needs. `createSession()` bypasses that cache so every caller gets its own
+ * instance with its own history, system prompt, sampling, and lifecycle.
  *
  * The wrapper is intentionally thin. It handles cross-browser smoothing that
  * every consumer would otherwise reimplement (delta-vs-cumulative chunk
@@ -370,9 +372,17 @@ const wrapInstance = (internal: Promise<SessionInternal>): Session => {
 
 /**
  * Create a fresh `LanguageModel` session. Unlike `ask()`, sessions returned
- * here are **never shared**: every call returns an independent instance so
- * streams can run concurrently and turn history doesn't bleed between
- * conversations.
+ * here are **never shared**: every call returns an independent instance with
+ * its own history, system prompt, sampling, and lifecycle. `abort()` /
+ * `destroy()` on one session never affect another.
+ *
+ * Token-level interleaving across sessions is implementation-defined and
+ * currently bottlenecked by the browser's FIFO scheduler — the underlying
+ * on-device model is single-instance, so Chrome 138 / Edge 138 drain one
+ * `sendStreaming` call fully before starting the next, even across
+ * independent sessions. The API is forward-compatible: code written against
+ * `createSession()` becomes faster automatically if a future release
+ * exposes parallel inference.
  *
  * Concurrent `send` / `sendStreaming` calls on the same session are NOT
  * queued; the native `LanguageModel` is sequential per instance and will

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -10,7 +10,7 @@
 
   **`createSession()` + `useSession()` in `@web-ai-sdk/prompt`**
 
-  A thin primitive for chat-shaped apps. Each call returns an independent `LanguageModel` session — never shared via the one-shot cache — so N parallel chats stream concurrently. `session.sendStreaming()` yields **deltas** (one element per new chunk, not cumulative). The wrapper handles cross-browser smoothing (delta-vs-cumulative detection, output sanitization, abort wiring, typed unavailability) and forwards everything else to the native instance. It deliberately does NOT track conversation history, queue concurrent sends, or wrap `clone()` — those are consumer data model and UI concerns.
+  A thin primitive for chat-shaped apps. Each call returns an independent `LanguageModel` session — never shared via the one-shot cache — so per-conversation history, system prompt, sampling, and lifecycle stay isolated, and `abort()` / `destroy()` on one session never touch another. `session.sendStreaming()` yields **deltas** (one element per new chunk, not cumulative). The wrapper handles cross-browser smoothing (delta-vs-cumulative detection, output sanitization, abort wiring, typed unavailability) and forwards everything else to the native instance. It deliberately does NOT track conversation history, queue concurrent sends, or wrap `clone()` — those are consumer data model and UI concerns. Token-level interleaving across sessions is implementation-defined: Chrome 138 / Edge 138 currently serialize `sendStreaming` calls across sessions FIFO (the underlying on-device model is single-instance); the API is forward-compatible for runtimes that expose parallel inference.
 
   ```ts
   import { createSession } from "@web-ai-sdk/prompt";

--- a/packages/summarizer/CHANGELOG.md
+++ b/packages/summarizer/CHANGELOG.md
@@ -10,7 +10,7 @@
 
   **`createSession()` + `useSession()` in `@web-ai-sdk/prompt`**
 
-  A thin primitive for chat-shaped apps. Each call returns an independent `LanguageModel` session — never shared via the one-shot cache — so N parallel chats stream concurrently. `session.sendStreaming()` yields **deltas** (one element per new chunk, not cumulative). The wrapper handles cross-browser smoothing (delta-vs-cumulative detection, output sanitization, abort wiring, typed unavailability) and forwards everything else to the native instance. It deliberately does NOT track conversation history, queue concurrent sends, or wrap `clone()` — those are consumer data model and UI concerns.
+  A thin primitive for chat-shaped apps. Each call returns an independent `LanguageModel` session — never shared via the one-shot cache — so per-conversation history, system prompt, sampling, and lifecycle stay isolated, and `abort()` / `destroy()` on one session never touch another. `session.sendStreaming()` yields **deltas** (one element per new chunk, not cumulative). The wrapper handles cross-browser smoothing (delta-vs-cumulative detection, output sanitization, abort wiring, typed unavailability) and forwards everything else to the native instance. It deliberately does NOT track conversation history, queue concurrent sends, or wrap `clone()` — those are consumer data model and UI concerns. Token-level interleaving across sessions is implementation-defined: Chrome 138 / Edge 138 currently serialize `sendStreaming` calls across sessions FIFO (the underlying on-device model is single-instance); the API is forward-compatible for runtimes that expose parallel inference.
 
   ```ts
   import { createSession } from "@web-ai-sdk/prompt";

--- a/packages/translator/CHANGELOG.md
+++ b/packages/translator/CHANGELOG.md
@@ -10,7 +10,7 @@
 
   **`createSession()` + `useSession()` in `@web-ai-sdk/prompt`**
 
-  A thin primitive for chat-shaped apps. Each call returns an independent `LanguageModel` session — never shared via the one-shot cache — so N parallel chats stream concurrently. `session.sendStreaming()` yields **deltas** (one element per new chunk, not cumulative). The wrapper handles cross-browser smoothing (delta-vs-cumulative detection, output sanitization, abort wiring, typed unavailability) and forwards everything else to the native instance. It deliberately does NOT track conversation history, queue concurrent sends, or wrap `clone()` — those are consumer data model and UI concerns.
+  A thin primitive for chat-shaped apps. Each call returns an independent `LanguageModel` session — never shared via the one-shot cache — so per-conversation history, system prompt, sampling, and lifecycle stay isolated, and `abort()` / `destroy()` on one session never touch another. `session.sendStreaming()` yields **deltas** (one element per new chunk, not cumulative). The wrapper handles cross-browser smoothing (delta-vs-cumulative detection, output sanitization, abort wiring, typed unavailability) and forwards everything else to the native instance. It deliberately does NOT track conversation history, queue concurrent sends, or wrap `clone()` — those are consumer data model and UI concerns. Token-level interleaving across sessions is implementation-defined: Chrome 138 / Edge 138 currently serialize `sendStreaming` calls across sessions FIFO (the underlying on-device model is single-instance); the API is forward-compatible for runtimes that expose parallel inference.
 
   ```ts
   import { createSession } from "@web-ai-sdk/prompt";

--- a/packages/webmcp/CHANGELOG.md
+++ b/packages/webmcp/CHANGELOG.md
@@ -10,7 +10,7 @@
 
   **`createSession()` + `useSession()` in `@web-ai-sdk/prompt`**
 
-  A thin primitive for chat-shaped apps. Each call returns an independent `LanguageModel` session — never shared via the one-shot cache — so N parallel chats stream concurrently. `session.sendStreaming()` yields **deltas** (one element per new chunk, not cumulative). The wrapper handles cross-browser smoothing (delta-vs-cumulative detection, output sanitization, abort wiring, typed unavailability) and forwards everything else to the native instance. It deliberately does NOT track conversation history, queue concurrent sends, or wrap `clone()` — those are consumer data model and UI concerns.
+  A thin primitive for chat-shaped apps. Each call returns an independent `LanguageModel` session — never shared via the one-shot cache — so per-conversation history, system prompt, sampling, and lifecycle stay isolated, and `abort()` / `destroy()` on one session never touch another. `session.sendStreaming()` yields **deltas** (one element per new chunk, not cumulative). The wrapper handles cross-browser smoothing (delta-vs-cumulative detection, output sanitization, abort wiring, typed unavailability) and forwards everything else to the native instance. It deliberately does NOT track conversation history, queue concurrent sends, or wrap `clone()` — those are consumer data model and UI concerns. Token-level interleaving across sessions is implementation-defined: Chrome 138 / Edge 138 currently serialize `sendStreaming` calls across sessions FIFO (the underlying on-device model is single-instance); the API is forward-compatible for runtimes that expose parallel inference.
 
   ```ts
   import { createSession } from "@web-ai-sdk/prompt";


### PR DESCRIPTION
## Summary

- 0.3's `createSession()` / `useSession()` prose ("N parallel chats stream concurrently") is empirically false on Chrome 138 / Edge 138: the on-device Gemini Nano scheduler is single-instance and the browser drains one `sendStreaming` call fully before starting the next, even across independent `LanguageModel` instances. Driven via DevTools, two sessions created 2ms apart with streams fired 51ms apart showed strict FIFO — A's stream completed before B's first chunk arrived.
- Docs-only amendment. No API change, no behavior change, no revert. `createSession()` still solves the bugs it shipped to solve: isolated per-session history, system prompt, sampling, and lifecycle (scoped `abort()` / `destroy()`), and the API remains forward-compatible the day a runtime exposes parallel inference.
- Touches the prompt README, the Prompt API guide on the docs site, the `createSession` / `useSession` / `ask` JSDoc, and the 0.3 release notes fanned across all six package CHANGELOGs. New patch-level changeset describes the amendment; `fixed`-group config fans the patch to all packages.

## Test plan

- [ ] `grep -E "concurrent|parallel|interleav" packages/prompt/` returns only truthful (intra-session FIFO, "doesn't queue concurrent sends") or aspirational ("parallel inference" if a future runtime exposes it) matches.
- [ ] Existing test suite passes unchanged (no `src/` runtime code modified).
- [ ] Docs site preview renders the new Concurrency note paragraph in the Prompt API guide.
- [ ] Release PR opened by changesets includes the amended 0.3-era prose plus the new patch-level entry.