### PR TITLE
docs(browser-support): align Chrome/Edge claims with official docs

### DIFF
--- a/.changeset/browser-support-official-docs.md
+++ b/.changeset/browser-support-official-docs.md
@@ -1,0 +1,17 @@
+---
+"@web-ai-sdk/prompt": patch
+---
+
+Correct browser-support claims across docs, per-package READMEs, the landing support table, and demo unavailability messages so they line up with the official Chrome and Edge documentation as of May 2026.
+
+What changed in the matrix:
+
+- **Prompt API on Chrome**: `138+ · flag` → `148+ · stable`. Per [Chrome at I/O 2026](https://developer.chrome.com/blog/chrome-at-io26) the API graduated to stable in Chrome 148. Chrome 138–147 still works behind `chrome://flags/#prompt-api-for-gemini-nano`.
+- **Prompt API on Edge**: clarified as `138+ · Canary/Dev · partial · flag` — Microsoft's [Edge Prompt API docs](https://learn.microsoft.com/en-us/microsoft-edge/web-platform/prompt-api) ship this only as a developer preview behind `edge://flags/#prompt-api-for-phi-mini`.
+- **Translator API on Edge**: `138+ · stable` → `143+ · Canary/Dev · flag`. Per the [Edge Translator API docs](https://learn.microsoft.com/en-us/microsoft-edge/web-platform/translator-api) it only exists in Canary/Dev behind `edge://flags/#edge-translation-api`.
+- **Language Detector on Edge**: `138+ · stable` → `147+ · Canary/Dev · flag`. Per the [Edge Language Detector docs](https://learn.microsoft.com/en-us/microsoft-edge/web-platform/languagedetector-api) it only exists in Canary/Dev behind `edge://flags/#edge-language-detection-api`.
+- **Summarizer on Edge**: `138+ · partial` → `138+ · stable · partial` (default-on since Edge 138 per the [Edge Writing Assistance APIs docs](https://learn.microsoft.com/en-us/microsoft-edge/web-platform/writing-assistance-apis); the "partial" caveat is about model output quality, not API availability).
+- **WebMCP on Chrome**: `146+ · stable` → `146+ · flag · OT 149+`. Per the [WebMCP docs](https://developer.chrome.com/docs/ai/webmcp) and the Chrome 149 origin trial announcement it is still behind `chrome://flags/#enable-webmcp-testing`; a public origin trial opens in Chrome 149.
+- **WebMCP on Edge**: `146+ · stable` → `147+ · flag`.
+
+No API or behavior change. Updates the browser-support matrix, every published package's README "Status" section, the landing-page support table, the prompt session/concurrency JSDoc that referenced "Chrome 138" instead of 148, and the demo "open in …" unavailability messages so they cite the correct Edge channel + version for each API.

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ pnpm docs            # docs site on http://localhost:6006
 pnpm landing         # marketing landing on http://localhost:5173
 ```
 
-For the AI APIs to actually run, open a supporting browser (Chrome 138+ or Edge 138+) and enable the relevant flags. See [Browser support](./apps/docs/src/content/docs/browser-support.mdx) for the per-package matrix; flag names differ between Chrome and Edge.
+For the AI APIs to actually run, open a supporting browser. On Chrome, Summarizer/Translator/Detector are stable in 138+ and Prompt is stable in 148+ (no flags); WebMCP needs `chrome://flags/#enable-webmcp-testing` through Chrome 148 and joins a public origin trial in Chrome 149. On Edge, only Summarizer is in stable (138+ default-on); Prompt, Translator, Detector, and WebMCP are developer previews in Canary/Dev behind their respective `edge://flags/` toggles. See [Browser support](./apps/docs/src/content/docs/browser-support.mdx) for the per-package matrix and exact flag names.
 
 ## Repo layout
 

--- a/apps/docs/src/components/DetectorDemo.tsx
+++ b/apps/docs/src/components/DetectorDemo.tsx
@@ -17,9 +17,9 @@ export const DetectorDemo = ({
     <div className="demo-card demo-card--narrow">
       {status === "unavailable" && (
         <p className="demo-hint">
-          Language Detector unavailable. Open in Chrome 138+ or Edge 138+ with{" "}
-          <code>chrome://flags/#language-detection-api</code> enabled, or search
-          the flags page for "language detection".
+          Language Detector unavailable. Open in Chrome 138+ (stable) or Edge
+          Canary/Dev 147+ with the language detection flag enabled (search the
+          flags page for "language detection").
         </p>
       )}
       <label className="demo-label">

--- a/apps/docs/src/components/TranslatorDemo.tsx
+++ b/apps/docs/src/components/TranslatorDemo.tsx
@@ -102,8 +102,8 @@ export const TranslatorDemo = ({
       </header>
       {state === "unavailable" && (
         <p className="demo-hint">
-          Translator API unavailable. Open in Chrome 138+ or Edge 138+ to
-          exercise.
+          Translator API unavailable. Open in Chrome 138+ (stable) or Edge
+          Canary/Dev 143+ (with the translation API flag enabled) to exercise.
         </p>
       )}
       {error && <p className="demo-error">{error.message}</p>}

--- a/apps/docs/src/content/docs/browser-support.mdx
+++ b/apps/docs/src/content/docs/browser-support.mdx
@@ -7,20 +7,22 @@ Built-in AI lands engine by engine. Where it isn't there yet, every package is a
 
 | Package | Chrome | Edge | Safari | Firefox |
 | --- | --- | --- | --- | --- |
-| `@web-ai-sdk/prompt` | 138+ · flag | 138+ · partial | no-op fallback | no-op fallback |
-| `@web-ai-sdk/summarizer` | 138+ · stable | 138+ · partial | no-op fallback | no-op fallback |
-| `@web-ai-sdk/translator` | 138+ · stable | 138+ · stable | no-op fallback | no-op fallback |
-| `@web-ai-sdk/detector` | 138+ · stable | 138+ · stable | no-op fallback | no-op fallback |
-| `@web-ai-sdk/webmcp` | 146+ · stable | 146+ · stable | no-op fallback | no-op fallback |
+| `@web-ai-sdk/prompt` | 148+ · stable | 138+ · Canary/Dev · partial · flag | no-op fallback | no-op fallback |
+| `@web-ai-sdk/summarizer` | 138+ · stable | 138+ · stable · partial | no-op fallback | no-op fallback |
+| `@web-ai-sdk/translator` | 138+ · stable | 143+ · Canary/Dev · flag | no-op fallback | no-op fallback |
+| `@web-ai-sdk/detector` | 138+ · stable | 147+ · Canary/Dev · flag | no-op fallback | no-op fallback |
+| `@web-ai-sdk/webmcp` | 146+ · flag · OT 149+ | 147+ · flag | no-op fallback | no-op fallback |
 
-Versions reflect when the underlying platform API became available. Wrapper exports stay stable across all browsers.
+Versions reflect when the underlying platform API became available. Wrapper exports stay stable across all browsers. "OT" means origin trial.
 
 ## Edge specifics
 
-Edge ships the same JS API surface as Chrome but routes through Phi-4-mini (or Phi-Silica on Copilot+ PCs) with a stricter safety pipeline.
+Of the five APIs, only the Summarizer ships in Edge stable (enabled by default since Edge 138, per the [Edge Writing Assistance APIs docs](https://learn.microsoft.com/en-us/microsoft-edge/web-platform/writing-assistance-apis)). The Prompt API is a developer preview in Edge Canary/Dev 138+, and Translator (Edge 143+) and Language Detector (Edge 147+) are Canary/Dev-only as well, each behind its own `edge://flags/` toggle. WebMCP landed in Edge 147 behind a flag.
+
+Prompt and Summarizer route through Phi-4-mini (or Phi-Silica on Copilot+ PCs) with a stricter safety pipeline than Chrome's Gemini Nano; Translator and Language Detector run dedicated on-device models.
 
 - **Partial** means the JS API is present but the on-device model frequently refuses output. Summarizer often returns "low quality output blocked"; prompt may emit C0 control-character placeholders instead of text. The library handles both cases (strips C0/C1, normalizes streaming shape, wraps refusals in typed errors), but the model itself is the bottleneck.
-- Flag names differ: `edge://flags/` → search "Phi mini" instead of "Gemini Nano".
+- Flag names differ: search "Phi mini" on `edge://flags/` for Prompt/Writing Assistance, "translation api" for Translator, "language detection" for Language Detector.
 - Hardware check: `edge://on-device-internals` requires "High" device performance class and all supplementary safety models ("GENERALIZED_SAFETY", "TEXT_SAFETY", "LANGUAGE_DETECTION") in "Ready" state.
 
 Tested on macOS; Windows behavior may differ.
@@ -29,8 +31,8 @@ Tested on macOS; Windows behavior may differ.
 
 | Surface | Flag |
 | --- | --- |
-| Prompt API | `chrome://flags/#prompt-api-for-gemini-nano` |
-| WebMCP | `chrome://flags/#enable-webmcp-testing` |
+| WebMCP | `chrome://flags/#enable-webmcp-testing` (Chrome 146+); [origin trial](https://developer.chrome.com/docs/ai/webmcp) opens in Chrome 149 |
+| Prompt API | Stable in Chrome 148+ (no flag); Chrome 138–147 needs `chrome://flags/#prompt-api-for-gemini-nano` |
 | Summarizer, Translator, Detector | Stable in Chrome 138+ |
 
 After enabling a flag, restart Chrome and wait for the on-device model to download (`chrome://on-device-internals`).

--- a/apps/docs/src/content/docs/guides/prompt.mdx
+++ b/apps/docs/src/content/docs/guides/prompt.mdx
@@ -54,7 +54,7 @@ The wrapper is intentionally thin. It handles cross-browser smoothing every cons
 
 `createSession()` never touches the `ask()` session cache. Two sessions with identical options get two independent instances with isolated history, system prompt, sampling, and lifecycle — `abort()` / `destroy()` on one session never touch another. Concurrent `send` / `sendStreaming` calls on the **same** session are NOT queued — the underlying `LanguageModel` is sequential per instance and will reject the overlapping call with `InvalidStateError`. Either `await` the previous send or call `session.abort()` before issuing a new turn.
 
-**Concurrency note.** Each session is an independent `LanguageModel` instance, but the underlying on-device model is single-instance. Chrome 138 / Edge 138 currently schedule `sendStreaming` calls across sessions FIFO: overlapping sends do not interleave token-by-token — the second send waits for the first to drain. This is a constraint of the runtime, not of the API; code written against `createSession()` becomes faster automatically if a future release exposes parallel inference.
+**Concurrency note.** Each session is an independent `LanguageModel` instance, but the underlying on-device model is single-instance. Chrome 148 / Edge 138 currently schedule `sendStreaming` calls across sessions FIFO: overlapping sends do not interleave token-by-token — the second send waits for the first to drain. This is a constraint of the runtime, not of the API; code written against `createSession()` becomes faster automatically if a future release exposes parallel inference.
 
 ## How it works
 

--- a/apps/landing/src/App.tsx
+++ b/apps/landing/src/App.tsx
@@ -630,12 +630,14 @@ export const App = () => (
                     <span className="scope">@web-ai-sdk/</span>prompt
                   </th>
                   <td>
-                    <span className="v">138+</span>{" "}
-                    <span className="pill">flag</span>
+                    <span className="v">148+</span>{" "}
+                    <span className="pill ok">stable</span>
                   </td>
                   <td>
                     <span className="v">138+</span>{" "}
-                    <span className="pill partial">partial</span>
+                    <span className="pill">Canary/Dev</span>{" "}
+                    <span className="pill partial">partial</span>{" "}
+                    <span className="pill">flag</span>
                   </td>
                   <td>
                     <span className="pill fallback">no-op fallback</span>
@@ -654,6 +656,7 @@ export const App = () => (
                   </td>
                   <td>
                     <span className="v">138+</span>{" "}
+                    <span className="pill ok">stable</span>{" "}
                     <span className="pill partial">partial</span>
                   </td>
                   <td>
@@ -672,8 +675,9 @@ export const App = () => (
                     <span className="pill ok">stable</span>
                   </td>
                   <td>
-                    <span className="v">138+</span>{" "}
-                    <span className="pill ok">stable</span>
+                    <span className="v">143+</span>{" "}
+                    <span className="pill">Canary/Dev</span>{" "}
+                    <span className="pill">flag</span>
                   </td>
                   <td>
                     <span className="pill fallback">no-op fallback</span>
@@ -691,8 +695,9 @@ export const App = () => (
                     <span className="pill ok">stable</span>
                   </td>
                   <td>
-                    <span className="v">138+</span>{" "}
-                    <span className="pill ok">stable</span>
+                    <span className="v">147+</span>{" "}
+                    <span className="pill">Canary/Dev</span>{" "}
+                    <span className="pill">flag</span>
                   </td>
                   <td>
                     <span className="pill fallback">no-op fallback</span>
@@ -707,11 +712,12 @@ export const App = () => (
                   </th>
                   <td>
                     <span className="v">146+</span>{" "}
-                    <span className="pill ok">stable</span>
+                    <span className="pill">flag</span>{" "}
+                    <span className="pill">OT 149+</span>
                   </td>
                   <td>
-                    <span className="v">146+</span>{" "}
-                    <span className="pill ok">stable</span>
+                    <span className="v">147+</span>{" "}
+                    <span className="pill">flag</span>
                   </td>
                   <td>
                     <span className="pill fallback">no-op fallback</span>
@@ -725,15 +731,23 @@ export const App = () => (
           </div>
           <div className="support-note">
             Versions reflect when the underlying platform API became available.
-            Wrapper exports stay stable across all browsers.
+            Wrapper exports stay stable across all browsers. <strong>OT</strong>{" "}
+            = origin trial.
+            <br />
+            On Edge, only the Summarizer ships in stable (enabled by default
+            since Edge 138). Prompt is a developer preview in Edge Canary/Dev
+            138+; Translator (Edge 143+) and Language Detector (Edge 147+) are
+            Canary/Dev-only as well, each behind its own <code>edge://flags/</code>{" "}
+            toggle. WebMCP landed in Edge 147 behind a flag.
             <br />
             <strong>Partial</strong> = JS API is present but the on-device model
-            frequently refuses output. Edge ships the same surface as Chrome but
-            routes through Phi-4-mini (or Phi-Silica on Copilot+ PCs) with a
-            stricter safety pipeline: summarizer often returns "low quality
-            output blocked"; prompt may emit C0 control-character placeholders
-            instead of text. Flag names differ: <code>edge://flags/</code> →
-            search "Phi mini" instead of "Gemini Nano". Hardware check:{" "}
+            frequently refuses output. Prompt and Summarizer route through
+            Phi-4-mini (or Phi-Silica on Copilot+ PCs) with a stricter safety
+            pipeline: summarizer often returns "low quality output blocked";
+            prompt may emit C0 control-character placeholders instead of text.
+            Flag names: search "Phi mini" on <code>edge://flags/</code> for
+            Prompt/Writing Assistance, "translation api" for Translator,
+            "language detection" for Language Detector. Hardware check:{" "}
             <code>edge://on-device-internals</code> requires "High" device
             performance class and all supplementary safety models
             ("GENERALIZED_SAFETY", "TEXT_SAFETY", "LANGUAGE_DETECTION") in

--- a/apps/landing/src/App.tsx
+++ b/apps/landing/src/App.tsx
@@ -737,8 +737,9 @@ export const App = () => (
             On Edge, only the Summarizer ships in stable (enabled by default
             since Edge 138). Prompt is a developer preview in Edge Canary/Dev
             138+; Translator (Edge 143+) and Language Detector (Edge 147+) are
-            Canary/Dev-only as well, each behind its own <code>edge://flags/</code>{" "}
-            toggle. WebMCP landed in Edge 147 behind a flag.
+            Canary/Dev-only as well, each behind its own{" "}
+            <code>edge://flags/</code> toggle. WebMCP landed in Edge 147 behind
+            a flag.
             <br />
             <strong>Partial</strong> = JS API is present but the on-device model
             frequently refuses output. Prompt and Summarizer route through

--- a/apps/landing/src/components/DetectorDemo.tsx
+++ b/apps/landing/src/components/DetectorDemo.tsx
@@ -131,7 +131,7 @@ export const DetectorDemo = () => {
           ) : (
             <span style={{ color: "var(--fg-4)", fontStyle: "italic" }}>
               {available === false
-                ? "Open in Chrome 138+ or Edge 138+ to detect."
+                ? "Open in Chrome 138+ or Edge Canary/Dev 147+ to detect."
                 : status === "pending"
                   ? "Type or paste text above."
                   : status === "loading"

--- a/apps/landing/src/components/PromptDemo.tsx
+++ b/apps/landing/src/components/PromptDemo.tsx
@@ -118,7 +118,7 @@ export const PromptDemo = () => {
           streaming={streaming}
           placeholder={
             available === false
-              ? "Open in Chrome 138+ or Edge 138+ to stream a response."
+              ? "Open in Chrome 148+ or Edge 138+ to stream a response."
               : "Output will stream here…"
           }
         />

--- a/apps/landing/src/components/TranslatorDemo.tsx
+++ b/apps/landing/src/components/TranslatorDemo.tsx
@@ -166,7 +166,7 @@ export const TranslatorDemo = () => {
           streaming={running}
           placeholder={
             available === false
-              ? "Open in Chrome 138+ or Edge 138+ to translate."
+              ? "Open in Chrome 138+ or Edge Canary/Dev 143+ to translate."
               : `Translation (${to}) will appear here.`
           }
         />

--- a/packages/detector/README.md
+++ b/packages/detector/README.md
@@ -4,7 +4,7 @@ Building block for [the Web's Built-in Language Detector API](https://developer.
 
 ## Status
 
-Language Detector ships in Chrome 138+ and Edge 138+. On any other browser this library is a no-op for the React hook (it stays in `"unavailable"`). The vanilla `detect()` throws `DetectorUnavailableError` so callers can branch explicitly.
+Language Detector ships stable in Chrome 138+ on desktop. On Edge it is a developer preview starting at Canary/Dev 147+ behind `edge://flags/#edge-language-detection-api` (per the [Edge Language Detector API docs](https://learn.microsoft.com/en-us/microsoft-edge/web-platform/languagedetector-api)) — not yet in Edge stable. On any other browser this library is a no-op for the React hook (it stays in `"unavailable"`). The vanilla `detect()` throws `DetectorUnavailableError` so callers can branch explicitly.
 
 ## Install
 

--- a/packages/prompt/README.md
+++ b/packages/prompt/README.md
@@ -4,7 +4,7 @@ Building block for the Web's Built-in [Prompt API](https://developer.chrome.com/
 
 ## Status
 
-Prompt API ships in Chrome 138+ (behind `chrome://flags/#prompt-api-for-gemini-nano`) and Edge 138+ (behind `edge://flags/#prompt-api-for-phi-mini`). On any other browser this library is a no-op for the React hook (it stays in `"unavailable"`). The vanilla `ask()` throws `PromptUnavailableError` so callers can branch explicitly.
+Prompt API ships stable in Chrome 148+ — no flag required. Chrome 138–147 still works with `chrome://flags/#prompt-api-for-gemini-nano` enabled. On Edge it remains a developer preview in Canary/Dev 138+ behind `edge://flags/#prompt-api-for-phi-mini`, with Phi-4-mini's stricter safety pipeline often refusing output (see [Browser support](https://web-ai-sdk.dev/browser-support)). On any other browser this library is a no-op for the React hook (it stays in `"unavailable"`). The vanilla `ask()` throws `PromptUnavailableError` so callers can branch explicitly.
 
 ## Install
 
@@ -58,7 +58,7 @@ session.destroy();
 
 Every `createSession()` call returns an independent `LanguageModelInstance` with its own history, system prompt, sampling, and lifecycle — `abort()` / `destroy()` on one session never touch another. Concurrent `send` / `sendStreaming` calls on the **same** session are NOT queued — the underlying `LanguageModel` is sequential per instance and will reject the overlapping call with `InvalidStateError`. Either `await` the previous send or call `session.abort()` before issuing a new turn. Multi-turn conversation context is tracked by the native instance itself; UI message lists are your data model.
 
-**Concurrency note.** Each session is an independent `LanguageModel` instance: independent history, system prompt, sampling, and lifecycle. The underlying on-device model is single-instance, so the browser currently schedules `sendStreaming` calls across sessions FIFO. Overlapping sends do not interleave token-by-token in Chrome 138 / Edge 138 — the second send waits for the first to drain. This is a constraint of the runtime, not of the API; code written against `createSession()` becomes faster automatically if a future release exposes parallel inference.
+**Concurrency note.** Each session is an independent `LanguageModel` instance: independent history, system prompt, sampling, and lifecycle. The underlying on-device model is single-instance, so the browser currently schedules `sendStreaming` calls across sessions FIFO. Overlapping sends do not interleave token-by-token in Chrome 148 / Edge 138 — the second send waits for the first to drain. This is a constraint of the runtime, not of the API; code written against `createSession()` becomes faster automatically if a future release exposes parallel inference.
 
 ## React
 
@@ -127,7 +127,7 @@ export function Chat({ persona }: { persona: string }) {
 }
 ```
 
-`useSession` is lifecycle-only: it creates the session on mount, destroys it on unmount, and recreates it when any primitive option changes. It deliberately does **not** track `response` / `history` / streaming status — that's your UI state, you own it. Each `useSession()` call owns its own underlying `LanguageModelInstance`, so component state and `abort()` / `destroy()` stay scoped to the owning component. Token-level interleaving across sessions is browser-defined (see the Concurrency note above) — N mounted components in Chrome 138 / Edge 138 still drain through one underlying model FIFO.
+`useSession` is lifecycle-only: it creates the session on mount, destroys it on unmount, and recreates it when any primitive option changes. It deliberately does **not** track `response` / `history` / streaming status — that's your UI state, you own it. Each `useSession()` call owns its own underlying `LanguageModelInstance`, so component state and `abort()` / `destroy()` stay scoped to the owning component. Token-level interleaving across sessions is browser-defined (see the Concurrency note above) — N mounted components in Chrome 148 / Edge 138 still drain through one underlying model FIFO.
 
 ## API
 

--- a/packages/prompt/src/react/index.ts
+++ b/packages/prompt/src/react/index.ts
@@ -153,7 +153,7 @@ export interface UseSessionReturn {
  * `language`, `enabled`) changes.
  *
  * Token-level interleaving across sessions is browser-defined: the
- * underlying on-device model is single-instance, so Chrome 138 / Edge 138
+ * underlying on-device model is single-instance, so Chrome 148 / Edge 138
  * currently serialize `sendStreaming` calls across sessions FIFO. The
  * second component's send waits for the first to drain. The API is
  * forward-compatible for runtimes that expose parallel inference.

--- a/packages/prompt/src/session.ts
+++ b/packages/prompt/src/session.ts
@@ -378,7 +378,7 @@ const wrapInstance = (internal: Promise<SessionInternal>): Session => {
  *
  * Token-level interleaving across sessions is implementation-defined and
  * currently bottlenecked by the browser's FIFO scheduler — the underlying
- * on-device model is single-instance, so Chrome 138 / Edge 138 drain one
+ * on-device model is single-instance, so Chrome 148 / Edge 138 drain one
  * `sendStreaming` call fully before starting the next, even across
  * independent sessions. The API is forward-compatible: code written against
  * `createSession()` becomes faster automatically if a future release

--- a/packages/summarizer/README.md
+++ b/packages/summarizer/README.md
@@ -4,7 +4,7 @@ Building block for the Web's Built-in [Summarizer API](https://developer.chrome.
 
 ## Status
 
-Summarizer API is in Chrome 138+ and Edge 138+ stable on desktop. On any other browser this library is a no-op for the React hook (it stays in `"unavailable"`). The vanilla `summarize()` throws `SummarizerUnavailableError` so callers can branch explicitly.
+Summarizer API is stable in Chrome 138+ and Edge 138+ on desktop (enabled by default since Edge 138, per the [Edge Writing Assistance APIs docs](https://learn.microsoft.com/en-us/microsoft-edge/web-platform/writing-assistance-apis)). On Edge the Phi-4-mini safety pipeline frequently returns "low quality output blocked"; the library wraps that as a typed error. On any other browser this library is a no-op for the React hook (it stays in `"unavailable"`). The vanilla `summarize()` throws `SummarizerUnavailableError` so callers can branch explicitly.
 
 ## Install
 

--- a/packages/translator/README.md
+++ b/packages/translator/README.md
@@ -4,7 +4,7 @@ Building block for the Web's Built-in [Translator API](https://developer.chrome.
 
 ## Status
 
-Translator API is in Chrome 138+ and Edge 138+ stable on desktop. On any other browser this library is a no-op. Your app stays callable, and the controller just resolves with `blocksTranslated: 0`.
+Translator API is stable in Chrome 138+ on desktop. On Edge it is a developer preview starting at Canary/Dev 143+ behind `edge://flags/#edge-translation-api` (per the [Edge Translator API docs](https://learn.microsoft.com/en-us/microsoft-edge/web-platform/translator-api)) — not yet in Edge stable. On any other browser this library is a no-op. Your app stays callable, and the controller just resolves with `blocksTranslated: 0`.
 
 ## Install
 

--- a/packages/webmcp/README.md
+++ b/packages/webmcp/README.md
@@ -6,7 +6,7 @@ An ergonomic, framework-agnostic adapter over the native browser API, with safe 
 
 ## Status
 
-WebMCP ships in Chrome 146+ and Edge 146+ behind a flag (`chrome://flags/#enable-webmcp-testing`; the Edge flag has the same name). On any browser that doesn't expose `navigator.modelContext`, this library is a no-op. Your app stays callable, and no tools get registered.
+WebMCP shipped as an early preview in Chrome 146+ behind `chrome://flags/#enable-webmcp-testing`; a public [origin trial](https://developer.chrome.com/docs/ai/webmcp) opens in Chrome 149. Edge added support in 147+ behind the matching `edge://flags/` toggle. On any browser that doesn't expose `navigator.modelContext`, this library is a no-op. Your app stays callable, and no tools get registered.
 
 ## Install
 


### PR DESCRIPTION
## Summary

Audit pass against the current Chrome and Microsoft Edge documentation. The matrix in `browser-support.mdx`, the landing support table, and every published package's README "Status" section now match what `developer.chrome.com` and `learn.microsoft.com` say as of May 2026.

| Claim before | Reality (official source) |
| --- | --- |
| Prompt API · Chrome `138+ · flag` | Stable in Chrome 148+ ([Chrome at I/O 2026](https://developer.chrome.com/blog/chrome-at-io26)) |
| Translator · Edge `138+ · stable` | Canary/Dev 143+ behind `#edge-translation-api` ([Edge docs](https://learn.microsoft.com/en-us/microsoft-edge/web-platform/translator-api)) |
| Detector · Edge `138+ · stable` | Canary/Dev 147+ behind `#edge-language-detection-api` ([Edge docs](https://learn.microsoft.com/en-us/microsoft-edge/web-platform/languagedetector-api)) |
| Summarizer · Edge `138+ · partial` | Stable 138+ (default-on); partial is a model-quality caveat ([Edge docs](https://learn.microsoft.com/en-us/microsoft-edge/web-platform/writing-assistance-apis)) |
| WebMCP · Chrome `146+ · stable` | 146+ behind `#enable-webmcp-testing`; origin trial opens in Chrome 149 ([WebMCP docs](https://developer.chrome.com/docs/ai/webmcp)) |
| WebMCP · Edge `146+ · stable` | 147+ behind matching flag |

Also touched: prompt session/`useSession` JSDoc that still cited "Chrome 138 / Edge 138" for the FIFO scheduler note, and the per-demo "open in …" unavailability messages so each names the correct Edge channel + version.

Includes a `@web-ai-sdk/prompt: patch` changeset — the fixed-group config in `.changeset/config.json` bumps all five published packages in lockstep on merge, so the corrected READMEs reach npm.

No API or behavior change.

## Test plan

- [ ] CI gate passes (lint + build + typecheck + tests — no source-of-truth code changed; the only `.ts` edits are JSDoc).
- [ ] Spot-check the rendered browser-support page on the docs site once Pages redeploys.
- [ ] Spot-check the landing support table renders correctly with the new pill combinations (`Canary/Dev`, `OT 149+`, etc.).