### PR TITLE
feat(pages): close agent-discoverability gaps

### DIFF
--- a/.changeset/agent-discoverability-readme-pointers.md
+++ b/.changeset/agent-discoverability-readme-pointers.md
@@ -1,0 +1,10 @@
+---
+"@web-ai-sdk/all": patch
+"@web-ai-sdk/prompt": patch
+"@web-ai-sdk/webmcp": patch
+"@web-ai-sdk/summarizer": patch
+"@web-ai-sdk/translator": patch
+"@web-ai-sdk/detector": patch
+---
+
+Adds a one-line `**Docs:**` pointer near the top of every package README linking to the canonical guide on web-ai-sdk.dev (and the matching React hook page where applicable). No API or behavior change — purely makes `npm view <pkg> README` self-routing so an agent or reader landing on a registry page can jump straight to the right docs without scanning for an external link.

--- a/apps/docs/astro.config.mjs
+++ b/apps/docs/astro.config.mjs
@@ -36,6 +36,10 @@ export default defineConfig({
         { tag: "meta", attrs: { property: "og:image:alt", content: "web-ai-sdk — npm install @web-ai-sdk/all" } },
         { tag: "meta", attrs: { name: "twitter:card", content: "summary_large_image" } },
         { tag: "meta", attrs: { name: "twitter:image", content: "https://web-ai-sdk.dev/og-image.png" } },
+        // LLM-friendly index. Agents that follow the llmstxt.org convention
+        // can auto-discover /llms.txt and /llms-full.txt from any docs page.
+        { tag: "link", attrs: { rel: "alternate", type: "text/plain", title: "LLM-friendly docs (llms.txt)", href: "https://web-ai-sdk.dev/llms.txt" } },
+        { tag: "link", attrs: { rel: "alternate", type: "text/plain", title: "LLM-friendly docs (full text)", href: "https://web-ai-sdk.dev/llms-full.txt" } },
       ],
       // Match the landing's cinnabar/dark identity. Token overrides live
       // in src/styles/web-ai-sdk.css. Demo card styles in demos.css use

--- a/apps/docs/src/content/docs/guides/detector.mdx
+++ b/apps/docs/src/content/docs/guides/detector.mdx
@@ -3,7 +3,7 @@ title: Detector
 description: Building block for the Web's Built-in LanguageDetector with confidence thresholds, bias hints, and session reuse.
 ---
 
-Building block for [the Web's Built-in Language Detector API](https://developer.chrome.com/docs/ai/language-detection). Detect the language of any text on-device, with confidence scores and a sorted list of alternates. Session reuse, opt-in result caching, AbortSignal-driven cleanup. See [useDetector](../react/use-detector/) for React.
+Building block for [the Web's Built-in Language Detector API](https://developer.chrome.com/docs/ai/language-detection). Detect the language of any text on-device, with confidence scores and a sorted list of alternates. Session reuse, opt-in result caching, AbortSignal-driven cleanup. See [useDetector](/docs/react/use-detector/) for React.
 
 ## Usage
 

--- a/apps/docs/src/content/docs/guides/meta-package.mdx
+++ b/apps/docs/src/content/docs/guides/meta-package.mdx
@@ -66,13 +66,13 @@ For applications, the meta-package is usually the right default.
 | Subpath                            | Re-exports                          |
 | ---------------------------------- | ----------------------------------- |
 | `@web-ai-sdk/all`                  | namespaces for all five packages    |
-| `@web-ai-sdk/all/prompt`           | [`@web-ai-sdk/prompt`](./prompt/)         |
+| `@web-ai-sdk/all/prompt`           | [`@web-ai-sdk/prompt`](/docs/guides/prompt/)         |
 | `@web-ai-sdk/all/prompt/react`     | `@web-ai-sdk/prompt/react`                |
-| `@web-ai-sdk/all/webmcp`           | [`@web-ai-sdk/webmcp`](./webmcp/)         |
+| `@web-ai-sdk/all/webmcp`           | [`@web-ai-sdk/webmcp`](/docs/guides/webmcp/)         |
 | `@web-ai-sdk/all/webmcp/react`     | `@web-ai-sdk/webmcp/react`                |
-| `@web-ai-sdk/all/summarizer`       | [`@web-ai-sdk/summarizer`](./summarizer/) |
+| `@web-ai-sdk/all/summarizer`       | [`@web-ai-sdk/summarizer`](/docs/guides/summarizer/) |
 | `@web-ai-sdk/all/summarizer/react` | `@web-ai-sdk/summarizer/react`            |
-| `@web-ai-sdk/all/translator`       | [`@web-ai-sdk/translator`](./translator/) |
+| `@web-ai-sdk/all/translator`       | [`@web-ai-sdk/translator`](/docs/guides/translator/) |
 | `@web-ai-sdk/all/translator/react` | `@web-ai-sdk/translator/react`            |
-| `@web-ai-sdk/all/detector`         | [`@web-ai-sdk/detector`](./detector/)     |
+| `@web-ai-sdk/all/detector`         | [`@web-ai-sdk/detector`](/docs/guides/detector/)     |
 | `@web-ai-sdk/all/detector/react`   | `@web-ai-sdk/detector/react`              |

--- a/apps/docs/src/content/docs/guides/prompt.mdx
+++ b/apps/docs/src/content/docs/guides/prompt.mdx
@@ -5,7 +5,7 @@ description: One-shot ask() and per-conversation createSession() on the Web's Bu
 
 Building block for the Web's Built-in [Prompt API](https://developer.chrome.com/docs/extensions/ai/prompt-api) (`LanguageModel`). One-shot `ask()` for embeds and widgets, plus a `createSession()` primitive for chat-shaped apps that need independent per-conversation sessions, streaming with deltas, and a multi-turn history.
 
-The package's [README](https://github.com/obetomuniz/web-ai-sdk/tree/main/packages/prompt#readme) covers install and the API table. This page is the conceptual overview of the core (vanilla) surface. The React adapter lives at `@web-ai-sdk/prompt/react`; see [usePrompt](../react/use-prompt/) and `useSession`.
+The package's [README](https://github.com/obetomuniz/web-ai-sdk/tree/main/packages/prompt#readme) covers install and the API table. This page is the conceptual overview of the core (vanilla) surface. The React adapter lives at `@web-ai-sdk/prompt/react`; see [usePrompt](/docs/react/use-prompt/) and [useSession](/docs/react/use-session/).
 
 ## One-shot: `ask()`
 

--- a/apps/docs/src/content/docs/guides/summarizer.mdx
+++ b/apps/docs/src/content/docs/guides/summarizer.mdx
@@ -3,7 +3,7 @@ title: Summarizer
 description: Building block for the Web's Built-in Summarizer with skeleton extraction, session reuse, opt-in result caching, and streaming.
 ---
 
-Building block for the Web's Built-in [Summarizer API](https://developer.chrome.com/docs/ai/summarizer-api). Skeleton extraction, sentence-boundary trim, streaming, and pluggable result caching. The React adapter lives at `@web-ai-sdk/summarizer/react`; see [useSummarizer](../react/use-summarizer/).
+Building block for the Web's Built-in [Summarizer API](https://developer.chrome.com/docs/ai/summarizer-api). Skeleton extraction, sentence-boundary trim, streaming, and pluggable result caching. The React adapter lives at `@web-ai-sdk/summarizer/react`; see [useSummarizer](/docs/react/use-summarizer/).
 
 ## Usage
 

--- a/apps/docs/src/content/docs/guides/translator.mdx
+++ b/apps/docs/src/content/docs/guides/translator.mdx
@@ -3,7 +3,7 @@ title: Translator
 description: Building block for the Web's Built-in Translator with block-level DOM round-trip, casing restoration, and snapshot-based restore.
 ---
 
-Building block for the Web's Built-in [Translator API](https://developer.chrome.com/docs/ai/translator-api) (on-demand language packs). Block-level translation with inline placeholder serialization, casing restoration, and a snapshot-based restore. See [useTranslator](../react/use-translator/) for React.
+Building block for the Web's Built-in [Translator API](https://developer.chrome.com/docs/ai/translator-api) (on-demand language packs). Block-level translation with inline placeholder serialization, casing restoration, and a snapshot-based restore. See [useTranslator](/docs/react/use-translator/) for React.
 
 ## Usage
 

--- a/apps/docs/src/content/docs/guides/webmcp.mdx
+++ b/apps/docs/src/content/docs/guides/webmcp.mdx
@@ -3,7 +3,7 @@ title: WebMCP
 description: Register agent-callable tools on the W3C WebMCP surface (navigator.modelContext) with AbortSignal-based cleanup.
 ---
 
-Building block for the W3C [WebMCP](https://webmachinelearning.github.io/webmcp/) API exposed at `navigator.modelContext`. Register agent-callable tools from any framework; the package is vanilla TypeScript / DOM with an optional React adapter shipped as a subpath export. See [useWebMCP](../react/use-web-mcp/) for React.
+Building block for the W3C [WebMCP](https://webmachinelearning.github.io/webmcp/) API exposed at `navigator.modelContext`. Register agent-callable tools from any framework; the package is vanilla TypeScript / DOM with an optional React adapter shipped as a subpath export. See [useWebMCP](/docs/react/use-web-mcp/) for React.
 
 ## Usage
 

--- a/apps/docs/src/content/docs/index.mdx
+++ b/apps/docs/src/content/docs/index.mdx
@@ -6,10 +6,10 @@ hero:
   tagline: Building blocks for the Web's built-in AI APIs. Composable. No runtime deps. Just lifecycle, streaming, and AbortSignals.
   actions:
     - text: Browser support
-      link: ./browser-support/
+      link: /docs/browser-support/
       icon: right-arrow
     - text: Guides → Prompt
-      link: ./guides/prompt/
+      link: /docs/guides/prompt/
       variant: minimal
     - text: GitHub
       link: https://github.com/obetomuniz/web-ai-sdk
@@ -24,27 +24,27 @@ import { Card, CardGrid } from "@astrojs/starlight/components";
 <CardGrid>
   <Card title="@web-ai-sdk/all" icon="open-book">
     Meta-package — install once, get all five wrappers under a single
-    dependency. [Read the guide →](./guides/meta-package/)
+    dependency. [Read the guide →](/docs/guides/meta-package/)
   </Card>
   <Card title="@web-ai-sdk/prompt" icon="seti:typescript">
     Talk to the on-device language model. Sessions, streaming, AbortSignals.
-    [Read the guide →](./guides/prompt/)
+    [Read the guide →](/docs/guides/prompt/)
   </Card>
   <Card title="@web-ai-sdk/webmcp" icon="puzzle">
     Register tools the browser's model context can call. Real agents, real
-    cleanup, no boilerplate. [Read the guide →](./guides/webmcp/)
+    cleanup, no boilerplate. [Read the guide →](/docs/guides/webmcp/)
   </Card>
   <Card title="@web-ai-sdk/summarizer" icon="document">
     Key-points, TL;DR, headlines. Configurable type and length, streaming.
-    [Read the guide →](./guides/summarizer/)
+    [Read the guide →](/docs/guides/summarizer/)
   </Card>
   <Card title="@web-ai-sdk/translator" icon="translate">
     Pair-based translation with block-level round-trip. Walks the DOM, swaps
-    text, keeps markup intact. [Read the guide →](./guides/translator/)
+    text, keeps markup intact. [Read the guide →](/docs/guides/translator/)
   </Card>
   <Card title="@web-ai-sdk/detector" icon="magnifier">
     Detect the language of any text on-device. Confidence scores plus a sorted
-    list of alternates. [Read the guide →](./guides/detector/)
+    list of alternates. [Read the guide →](/docs/guides/detector/)
   </Card>
 </CardGrid>
 
@@ -57,7 +57,7 @@ pnpm add @web-ai-sdk/prompt        # one block
 pnpm add @web-ai-sdk/all           # all five blocks
 ```
 
-See the [meta-package guide](./guides/meta-package/) for the two import shapes (`@web-ai-sdk/all/prompt` subpath vs `{ prompt } from "@web-ai-sdk/all"` namespaced root).
+See the [meta-package guide](/docs/guides/meta-package/) for the two import shapes (`@web-ai-sdk/all/prompt` subpath vs `{ prompt } from "@web-ai-sdk/all"` namespaced root).
 
 Each package ships:
 

--- a/apps/docs/src/content/docs/react/use-detector.mdx
+++ b/apps/docs/src/content/docs/react/use-detector.mdx
@@ -5,7 +5,7 @@ description: React adapter for @web-ai-sdk/detector. Auto-detects the language o
 
 import { DetectorDemo } from "../../../components/DetectorDemo.tsx";
 
-React adapter for `@web-ai-sdk/detector`. Auto-detects the language of `text` on mount and re-runs whenever the text changes. For the conceptual overview see [Detector](../guides/detector/).
+React adapter for `@web-ai-sdk/detector`. Auto-detects the language of `text` on mount and re-runs whenever the text changes. For the conceptual overview see [Detector](/docs/guides/detector/).
 
 ## Live demo
 
@@ -87,3 +87,35 @@ const result = useDetector({ text, cache });
 ## Aborting
 
 The hook aborts any in-flight call when `text` changes or the component unmounts. You don't need to manage `AbortController` directly.
+
+## Reference
+
+```ts
+import type { UseDetectorOptions, UseDetectorReturn, DetectorStatus } from "@web-ai-sdk/detector/react";
+
+type DetectorStatus = "pending" | "loading" | "done" | "unavailable";
+
+interface UseDetectorOptions extends Omit<DetectOptions, "text" | "signal"> {
+  text: string;            // empty / whitespace-only keeps the hook in "pending"
+  enabled?: boolean;       // default: true
+  // Inherited from DetectOptions:
+  expectedInputLanguages?: readonly string[];
+  minConfidence?: number;
+  createOptions?: LanguageDetectorCreateOptions;
+  cache?: DetectionCache;
+  cacheKey?: string;
+}
+
+interface UseDetectorReturn {
+  status: DetectorStatus;
+  language: string | null;        // top BCP-47 candidate; null below minConfidence
+  confidence: number;             // confidence of the top result
+  all: DetectionResult[];         // full sorted list of candidates
+  error: Error | null;
+  fromCache: boolean;             // true when served by the opt-in cache
+}
+
+declare const useDetector: (options: UseDetectorOptions) => UseDetectorReturn;
+```
+
+Source: [`packages/detector/src/react/index.ts`](https://github.com/obetomuniz/web-ai-sdk/blob/main/packages/detector/src/react/index.ts).

--- a/apps/docs/src/content/docs/react/use-prompt.mdx
+++ b/apps/docs/src/content/docs/react/use-prompt.mdx
@@ -5,7 +5,7 @@ description: React adapter for @web-ai-sdk/prompt with an idle / loading / strea
 
 import { PromptDemo } from "../../../components/PromptDemo.tsx";
 
-React adapter for `@web-ai-sdk/prompt`. Runs single-shot prompts on demand via `ask(input)` and exposes status, streaming response text, and abort / reset controls. For the conceptual overview of the underlying API see [Prompt](../guides/prompt/).
+React adapter for `@web-ai-sdk/prompt`. Runs single-shot prompts on demand via `ask(input)` and exposes status, streaming response text, and abort / reset controls. For the conceptual overview of the underlying API see [Prompt](/docs/guides/prompt/).
 
 ## Live demo
 
@@ -75,4 +75,41 @@ Pass `cache`, `createOptions`, `expectedInputs`, etc. as stable references. The 
 
 ## Multi-turn
 
-`usePrompt` is single-shot per `ask()`. For multi-turn conversation where each chat needs independent context and streams should run concurrently, use [`useSession`](./use-session/) — it returns a per-component, never-shared `LanguageModel` session with `history`, `send`, `abort`, and `clear`.
+`usePrompt` is single-shot per `ask()`. For multi-turn conversation where each chat needs independent context and streams should run concurrently, use [`useSession`](/docs/react/use-session/) — it returns a per-component, never-shared `LanguageModel` session with `history`, `send`, `abort`, and `clear`.
+
+## Reference
+
+```ts
+import type { UsePromptOptions, UsePromptReturn, PromptStatus } from "@web-ai-sdk/prompt/react";
+
+type PromptStatus = "idle" | "loading" | "streaming" | "done" | "unavailable";
+
+interface UsePromptOptions extends Omit<AskOptions, "input" | "onUpdate" | "signal"> {
+  // Inherited from AskOptions (subset shown — see Prompt guide):
+  systemPrompt?: string;
+  temperature?: number;
+  topK?: number;
+  language?: string;
+  supportedLanguages?: readonly string[];
+  expectedInputs?: LanguageModelExpectedInput[];
+  expectedOutputs?: LanguageModelExpectedOutput[];
+  responseConstraint?: object;        // JSON Schema for structured output
+  createOptions?: LanguageModelCreateOptions;
+  cache?: ResponseCache;
+  cacheKey?: string;
+}
+
+interface UsePromptReturn {
+  status: PromptStatus;
+  response: string | null;
+  error: Error | null;
+  fromCache: boolean;
+  ask(input: string): Promise<void>;  // cancels any in-flight request first
+  abort(): void;                      // cancel in-flight; status → "idle"
+  reset(): void;                      // clear response without aborting
+}
+
+declare const usePrompt: (options?: UsePromptOptions) => UsePromptReturn;
+```
+
+Source: [`packages/prompt/src/react/index.ts`](https://github.com/obetomuniz/web-ai-sdk/blob/main/packages/prompt/src/react/index.ts).

--- a/apps/docs/src/content/docs/react/use-session.mdx
+++ b/apps/docs/src/content/docs/react/use-session.mdx
@@ -3,9 +3,9 @@ title: useSession
 description: Lifecycle-only React adapter for createSession. Each call owns one never-shared LanguageModel session; UI state is the consumer's concern.
 ---
 
-Lifecycle-only React adapter for the chat-shaped [`createSession()`](../guides/prompt/#chat-createsession) primitive in `@web-ai-sdk/prompt`. Each `useSession` call owns one underlying `LanguageModelInstance` — so N components produce N concurrent streams. The hook handles feature detection, create, destroy-on-unmount, and recreate-on-options-change. It does **not** track `response`, `history`, or streaming status; iterate `session.sendStreaming()` yourself and keep UI state in your own component.
+Lifecycle-only React adapter for the chat-shaped [`createSession()`](/docs/guides/prompt/#chat-createsession) primitive in `@web-ai-sdk/prompt`. Each `useSession` call owns one underlying `LanguageModelInstance` — so N components produce N concurrent streams. The hook handles feature detection, create, destroy-on-unmount, and recreate-on-options-change. It does **not** track `response`, `history`, or streaming status; iterate `session.sendStreaming()` yourself and keep UI state in your own component.
 
-For ask-and-display flows (embeds, widgets, single-question UIs) prefer [`usePrompt`](./use-prompt/); it shares a warm session across same-shape callers.
+For ask-and-display flows (embeds, widgets, single-question UIs) prefer [`usePrompt`](/docs/react/use-prompt/); it shares a warm session across same-shape callers.
 
 ## Usage
 
@@ -122,3 +122,41 @@ const session = useSession({
 ```
 
 The seeded turns become real context for the model. UI history lives in your own component state.
+
+## Reference
+
+```ts
+import type { UseSessionOptions, UseSessionReturn, SessionStatus } from "@web-ai-sdk/prompt/react";
+
+type SessionStatus = "loading" | "ready" | "unavailable";
+
+interface UseSessionOptions extends CreateSessionOptions {
+  enabled?: boolean;       // default: true; skip session creation when false
+  // Inherited from CreateSessionOptions:
+  systemPrompt?: string;
+  temperature?: number;
+  topK?: number;
+  language?: string;
+  supportedLanguages?: readonly string[];
+  expectedInputs?: LanguageModelExpectedInput[];
+  expectedOutputs?: LanguageModelExpectedOutput[];
+  createOptions?: LanguageModelCreateOptions;
+}
+
+interface UseSessionReturn {
+  status: SessionStatus;
+  error: Error | null;     // creation error, if any
+  session: Session | null; // null until status === "ready"
+}
+
+interface Session {
+  send(input: string): Promise<string>;
+  sendStreaming(input: string): AsyncIterable<string>; // yields deltas, not cumulative
+  abort(): void;
+  destroy(): void;
+}
+
+declare const useSession: (options?: UseSessionOptions) => UseSessionReturn;
+```
+
+Source: [`packages/prompt/src/react/index.ts`](https://github.com/obetomuniz/web-ai-sdk/blob/main/packages/prompt/src/react/index.ts).

--- a/apps/docs/src/content/docs/react/use-summarizer.mdx
+++ b/apps/docs/src/content/docs/react/use-summarizer.mdx
@@ -5,7 +5,7 @@ description: React adapter for @web-ai-sdk/summarizer. Auto-runs on mount and re
 
 import { SummarizerDemo } from "../../../components/SummarizerDemo.tsx";
 
-React adapter for `@web-ai-sdk/summarizer`. Auto-runs on mount, re-runs when `article` / `text` / `language` change, and streams chunks through state updates. For the conceptual overview see [Summarizer](../guides/summarizer/).
+React adapter for `@web-ai-sdk/summarizer`. Auto-runs on mount, re-runs when `article` / `text` / `language` change, and streams chunks through state updates. For the conceptual overview see [Summarizer](/docs/guides/summarizer/).
 
 ## Live demo
 
@@ -61,3 +61,40 @@ The hook exposes the same two caches as the vanilla `summarize()`:
 ## Streaming UX
 
 `result.summary` updates on every chunk during `streaming`. A naive `<p>{result.summary}</p>` already produces a typewriter effect because React re-renders on each state change. If chunks arrive faster than you want to repaint, debounce on the consumer side.
+
+## Reference
+
+```ts
+import type { UseSummarizerOptions, UseSummarizerReturn, SummarizerStatus } from "@web-ai-sdk/summarizer/react";
+
+type SummarizerStatus = "pending" | "loading" | "streaming" | "done" | "unavailable";
+
+interface UseSummarizerOptions extends Omit<SummarizeOptions, "onUpdate" | "signal"> {
+  enabled?: boolean;       // default: true
+  // Inherited from SummarizeOptions (subset shown — see Summarizer guide):
+  article?: HTMLElement;
+  text?: string;
+  language: string;
+  title?: string;
+  description?: string;
+  cache?: SummaryCache;
+  cacheKey?: string;
+  sharedContext?: Record<string, string>;
+  createOptions?: SummarizerCreateOptions; // type, length, format, etc.
+  maxInputChars?: number;
+  minSkeletonChars?: number;
+  supportedLanguages?: readonly string[];
+}
+
+interface UseSummarizerReturn {
+  status: SummarizerStatus;
+  summary: string | null;
+  error: Error | null;
+  fromCache: boolean;
+  dismiss(): void;         // sets status to "unavailable", clears summary
+}
+
+declare const useSummarizer: (options: UseSummarizerOptions) => UseSummarizerReturn;
+```
+
+Source: [`packages/summarizer/src/react/index.ts`](https://github.com/obetomuniz/web-ai-sdk/blob/main/packages/summarizer/src/react/index.ts).

--- a/apps/docs/src/content/docs/react/use-translator.mdx
+++ b/apps/docs/src/content/docs/react/use-translator.mdx
@@ -5,7 +5,7 @@ description: React adapter for @web-ai-sdk/translator. Translates on mount, rest
 
 import { TranslatorDemo } from "../../../components/TranslatorDemo.tsx";
 
-React adapter for `@web-ai-sdk/translator`. Translates the provided roots on mount, restores them on unmount, and exposes a controller for imperative cancel / restore. For the conceptual overview see [Translator](../guides/translator/).
+React adapter for `@web-ai-sdk/translator`. Translates the provided roots on mount, restores them on unmount, and exposes a controller for imperative cancel / restore. For the conceptual overview see [Translator](/docs/guides/translator/).
 
 ## Live demo
 
@@ -59,3 +59,31 @@ unavailable ◄── (no API / same source+target)
 ## Errors and unavailability
 
 On browsers without `Translator`, the hook returns `status: "unavailable"` and never invokes the model. Render whatever fallback UI you want.
+
+## Reference
+
+```ts
+import type { UseTranslatorOptions, UseTranslatorReturn, TranslatorState } from "@web-ai-sdk/translator/react";
+
+type TranslatorState = "unavailable" | "idle" | "working" | "translated";
+
+interface UseTranslatorOptions {
+  sourceLanguage: string;
+  targetLanguage?: string;            // defaults to "en"
+  roots?: RootsOption;                // CSS selector, Element, or Element[]
+  blockSelector?: string;             // override the default block selector
+  opaqueInlineTags?: readonly string[]; // tags to keep verbatim
+}
+
+interface UseTranslatorReturn {
+  state: TranslatorState;
+  progress: TranslateProgress | null; // latest progress event, or null while idle
+  error: Error | null;
+  translate(): void;                  // trigger a translation run
+  restore(): void;                    // roll back translated blocks
+}
+
+declare const useTranslator: (options: UseTranslatorOptions) => UseTranslatorReturn;
+```
+
+Source: [`packages/translator/src/react/index.ts`](https://github.com/obetomuniz/web-ai-sdk/blob/main/packages/translator/src/react/index.ts).

--- a/apps/docs/src/content/docs/react/use-web-mcp.mdx
+++ b/apps/docs/src/content/docs/react/use-web-mcp.mdx
@@ -5,7 +5,7 @@ description: React adapter for @web-ai-sdk/webmcp. Register WebMCP tools on moun
 
 import { WebMCPDemo } from "../../../components/WebMCPDemo.tsx";
 
-React adapter for `@web-ai-sdk/webmcp`. Registers WebMCP tools on mount and unregisters them on unmount via an `AbortSignal`. For the conceptual overview see [WebMCP](../guides/webmcp/).
+React adapter for `@web-ai-sdk/webmcp`. Registers WebMCP tools on mount and unregisters them on unmount via an `AbortSignal`. For the conceptual overview see [WebMCP](/docs/guides/webmcp/).
 
 ## Live demo
 
@@ -69,3 +69,33 @@ The hook returns nothing; cleanup is automatic on unmount via `useEffect`'s retu
 ## Errors and unavailability
 
 On browsers without `navigator.modelContext`, the hook is a no-op. Render whatever fallback UI you want; nothing breaks.
+
+## Reference
+
+```ts
+import type { Tool, ToolAnnotations, DefineToolOptions } from "@web-ai-sdk/webmcp/react";
+
+interface Tool {
+  name: string;
+  description: string;
+  execute: (input: unknown) => Promise<unknown> | unknown;
+  readOnly?: boolean;              // → annotations.readOnlyHint
+  destructive?: boolean;           // → annotations.destructiveHint
+  annotations?: ToolAnnotations;   // raw passthrough; merges on top of shorthand
+  inputSchema?: object;            // JSON Schema or Standard Schema v1
+}
+
+interface ToolAnnotations {
+  readOnlyHint?: boolean;
+  destructiveHint?: boolean;
+  idempotentHint?: boolean;
+  openWorldHint?: boolean;
+}
+
+declare const useWebMCP: (tools: readonly Tool[]) => void;
+
+// Helper for type-safe tool definitions with a Standard Schema.
+declare function defineTool<T extends StandardSchemaV1>(options: DefineToolOptions<T>): Tool;
+```
+
+Source: [`packages/webmcp/src/react/index.ts`](https://github.com/obetomuniz/web-ai-sdk/blob/main/packages/webmcp/src/react/index.ts).

--- a/apps/landing/index.html
+++ b/apps/landing/index.html
@@ -19,6 +19,12 @@
     <!-- Sitemap discovery for crawlers that don't read robots.txt. -->
     <link rel="sitemap" type="application/xml" href="/sitemap.xml" />
 
+    <!-- LLM-friendly index. Agents that follow the llmstxt.org convention can
+         auto-discover /llms.txt (curated link index) and /llms-full.txt
+         (concatenated README bodies). -->
+    <link rel="alternate" type="text/plain" title="LLM-friendly docs (llms.txt)" href="/llms.txt" />
+    <link rel="alternate" type="text/plain" title="LLM-friendly docs (full text)" href="/llms-full.txt" />
+
     <!-- Structured data: WebSite + SoftwareSourceCode. Google's AI Optimization
          Guide says JSON-LD isn't required for AI search but recommends it as
          part of overall SEO. The npm coordinates make this discoverable as a
@@ -82,7 +88,73 @@
     />
   </head>
   <body>
-    <div id="root"></div>
+    <!--
+      Static fallback inside #root. React's createRoot().render() replaces
+      the entire contents of this element on mount, so JS visitors never see
+      this markup — but agents and crawlers that don't execute JS get a
+      readable directory of the project (install, packages, links) instead
+      of an empty page. This pairs with /llms.txt and the custom 404 to
+      make every entry point self-describing on the first fetch.
+    -->
+    <div id="root">
+      <noscript>
+        <style>
+          .ssr-fallback { color-scheme: dark; background: #0f0e0c; color: #f5efe6; min-height: 100vh; }
+        </style>
+      </noscript>
+      <article class="ssr-fallback" style="max-width: 48rem; margin: 0 auto; padding: 3rem 1.25rem; font-family: ui-sans-serif, system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif; line-height: 1.55;">
+        <header>
+          <h1 style="font-size: 2.25rem; margin: 0 0 0.5rem; letter-spacing: -0.01em;">web-ai-sdk</h1>
+          <p style="margin: 0 0 1.5rem; color: #b8b1a4; font-size: 1.05rem;">Building blocks for the Web's built-in AI APIs. Composable. No runtime deps. Just lifecycle, streaming, AbortSignals. Vanilla TypeScript by default, with optional React hooks.</p>
+        </header>
+
+        <section>
+          <h2 style="font-size: 0.85rem; text-transform: uppercase; letter-spacing: 0.1em; color: #b8b1a4; margin: 1.5rem 0 0.5rem;">Install</h2>
+          <pre style="background: rgba(245,239,230,0.06); padding: 0.75rem 1rem; border-radius: 6px; overflow-x: auto; font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 0.95rem; color: #f5efe6;"><code>npm i @web-ai-sdk/all        # all five wrappers
+npm i @web-ai-sdk/prompt     # one wrapper at a time</code></pre>
+        </section>
+
+        <section>
+          <h2 style="font-size: 0.85rem; text-transform: uppercase; letter-spacing: 0.1em; color: #b8b1a4; margin: 1.5rem 0 0.5rem;">Packages</h2>
+          <table style="width: 100%; border-collapse: collapse; font-size: 0.95rem;">
+            <thead>
+              <tr style="text-align: left; color: #b8b1a4; font-weight: 500;">
+                <th style="padding: 0.5rem 0.75rem 0.5rem 0; border-bottom: 1px solid rgba(245,239,230,0.12);">Package</th>
+                <th style="padding: 0.5rem 0.75rem; border-bottom: 1px solid rgba(245,239,230,0.12);">Guide</th>
+                <th style="padding: 0.5rem 0.75rem; border-bottom: 1px solid rgba(245,239,230,0.12);">React hook</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr><td style="padding: 0.5rem 0.75rem 0.5rem 0; border-bottom: 1px solid rgba(245,239,230,0.06); font-family: ui-monospace, SFMono-Regular, Menlo, monospace;">@web-ai-sdk/all</td>            <td style="padding: 0.5rem 0.75rem; border-bottom: 1px solid rgba(245,239,230,0.06);"><a href="/docs/guides/meta-package/" style="color: #e34a2c; text-decoration: none;">Meta-package</a></td><td style="padding: 0.5rem 0.75rem; border-bottom: 1px solid rgba(245,239,230,0.06); color: #b8b1a4;">—</td></tr>
+              <tr><td style="padding: 0.5rem 0.75rem 0.5rem 0; border-bottom: 1px solid rgba(245,239,230,0.06); font-family: ui-monospace, SFMono-Regular, Menlo, monospace;">@web-ai-sdk/prompt</td>          <td style="padding: 0.5rem 0.75rem; border-bottom: 1px solid rgba(245,239,230,0.06);"><a href="/docs/guides/prompt/" style="color: #e34a2c; text-decoration: none;">Prompt</a></td>             <td style="padding: 0.5rem 0.75rem; border-bottom: 1px solid rgba(245,239,230,0.06);"><a href="/docs/react/use-prompt/" style="color: #e34a2c; text-decoration: none;">usePrompt</a> · <a href="/docs/react/use-session/" style="color: #e34a2c; text-decoration: none;">useSession</a></td></tr>
+              <tr><td style="padding: 0.5rem 0.75rem 0.5rem 0; border-bottom: 1px solid rgba(245,239,230,0.06); font-family: ui-monospace, SFMono-Regular, Menlo, monospace;">@web-ai-sdk/webmcp</td>          <td style="padding: 0.5rem 0.75rem; border-bottom: 1px solid rgba(245,239,230,0.06);"><a href="/docs/guides/webmcp/" style="color: #e34a2c; text-decoration: none;">WebMCP</a></td>             <td style="padding: 0.5rem 0.75rem; border-bottom: 1px solid rgba(245,239,230,0.06);"><a href="/docs/react/use-web-mcp/" style="color: #e34a2c; text-decoration: none;">useWebMCP</a></td></tr>
+              <tr><td style="padding: 0.5rem 0.75rem 0.5rem 0; border-bottom: 1px solid rgba(245,239,230,0.06); font-family: ui-monospace, SFMono-Regular, Menlo, monospace;">@web-ai-sdk/summarizer</td>      <td style="padding: 0.5rem 0.75rem; border-bottom: 1px solid rgba(245,239,230,0.06);"><a href="/docs/guides/summarizer/" style="color: #e34a2c; text-decoration: none;">Summarizer</a></td>     <td style="padding: 0.5rem 0.75rem; border-bottom: 1px solid rgba(245,239,230,0.06);"><a href="/docs/react/use-summarizer/" style="color: #e34a2c; text-decoration: none;">useSummarizer</a></td></tr>
+              <tr><td style="padding: 0.5rem 0.75rem 0.5rem 0; border-bottom: 1px solid rgba(245,239,230,0.06); font-family: ui-monospace, SFMono-Regular, Menlo, monospace;">@web-ai-sdk/translator</td>      <td style="padding: 0.5rem 0.75rem; border-bottom: 1px solid rgba(245,239,230,0.06);"><a href="/docs/guides/translator/" style="color: #e34a2c; text-decoration: none;">Translator</a></td>     <td style="padding: 0.5rem 0.75rem; border-bottom: 1px solid rgba(245,239,230,0.06);"><a href="/docs/react/use-translator/" style="color: #e34a2c; text-decoration: none;">useTranslator</a></td></tr>
+              <tr><td style="padding: 0.5rem 0.75rem 0.5rem 0; font-family: ui-monospace, SFMono-Regular, Menlo, monospace;">@web-ai-sdk/detector</td>                                                                                                                                                                <td style="padding: 0.5rem 0.75rem;"><a href="/docs/guides/detector/" style="color: #e34a2c; text-decoration: none;">Detector</a></td>                                                                          <td style="padding: 0.5rem 0.75rem;"><a href="/docs/react/use-detector/" style="color: #e34a2c; text-decoration: none;">useDetector</a></td></tr>
+            </tbody>
+          </table>
+        </section>
+
+        <section>
+          <h2 style="font-size: 0.85rem; text-transform: uppercase; letter-spacing: 0.1em; color: #b8b1a4; margin: 1.5rem 0 0.5rem;">Browser support</h2>
+          <p style="margin: 0 0 0.5rem;">Chrome and Edge 138+ with the Built-in AI flags enabled. See <a href="/docs/browser-support/" style="color: #e34a2c; text-decoration: none;">the support matrix</a> for the per-API breakdown.</p>
+        </section>
+
+        <section>
+          <h2 style="font-size: 0.85rem; text-transform: uppercase; letter-spacing: 0.1em; color: #b8b1a4; margin: 1.5rem 0 0.5rem;">Links</h2>
+          <ul style="list-style: none; padding: 0; margin: 0;">
+            <li style="margin: 0.25rem 0;"><a href="/docs/" style="color: #e34a2c; text-decoration: none;">Documentation</a> — Starlight site with guides, React hooks, browser support.</li>
+            <li style="margin: 0.25rem 0;"><a href="https://github.com/obetomuniz/web-ai-sdk" style="color: #e34a2c; text-decoration: none;">github.com/obetomuniz/web-ai-sdk</a> — source, issues, releases.</li>
+            <li style="margin: 0.25rem 0;"><a href="https://www.npmjs.com/org/web-ai-sdk" style="color: #e34a2c; text-decoration: none;">npmjs.com/org/web-ai-sdk</a> — published packages.</li>
+            <li style="margin: 0.25rem 0;"><a href="/llms.txt" style="color: #e34a2c; text-decoration: none;">/llms.txt</a> · <a href="/llms-full.txt" style="color: #e34a2c; text-decoration: none;">/llms-full.txt</a> · <a href="/sitemap.xml" style="color: #e34a2c; text-decoration: none;">/sitemap.xml</a> — machine-readable index.</li>
+          </ul>
+        </section>
+
+        <footer style="margin-top: 2.5rem; padding-top: 1.5rem; border-top: 1px solid rgba(245,239,230,0.12); color: #b8b1a4; font-size: 0.85rem;">
+          <p style="margin: 0;">This is the static fallback. The interactive landing — live demos, scroll-spy, the full feature tour — renders here when JavaScript is enabled.</p>
+        </footer>
+      </article>
+    </div>
     <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>

--- a/apps/landing/public/404.html
+++ b/apps/landing/public/404.html
@@ -1,0 +1,90 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Not found · web-ai-sdk</title>
+    <meta name="description" content="That page doesn't exist on web-ai-sdk.dev. Here are the canonical entry points: documentation, sitemap, and LLM-friendly index." />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <link rel="canonical" href="https://web-ai-sdk.dev/" />
+
+    <!-- Sitemap + LLM discovery so an agent that lands here can still find the site. -->
+    <link rel="sitemap" type="application/xml" href="/sitemap.xml" />
+    <link rel="alternate" type="text/plain" title="LLM-friendly docs (llms.txt)" href="/llms.txt" />
+    <link rel="alternate" type="text/plain" title="LLM-friendly docs (full text)" href="/llms-full.txt" />
+
+    <style>
+      :root {
+        color-scheme: light dark;
+        --bg: #0f0e0c;
+        --fg: #f5efe6;
+        --muted: #b8b1a4;
+        --accent: #e34a2c;
+        --border: rgba(245, 239, 230, 0.12);
+      }
+      @media (prefers-color-scheme: light) {
+        :root {
+          --bg: #f7f2ea;
+          --fg: #1b1a17;
+          --muted: #5a554b;
+          --border: rgba(27, 26, 23, 0.12);
+        }
+      }
+      html, body { margin: 0; padding: 0; background: var(--bg); color: var(--fg); }
+      body {
+        font-family: ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+        line-height: 1.55;
+        min-height: 100vh;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        padding: 2rem 1rem;
+      }
+      main { max-width: 38rem; width: 100%; }
+      h1 { font-size: 2rem; margin: 0 0 0.25rem; letter-spacing: -0.01em; }
+      h2 { font-size: 0.9rem; text-transform: uppercase; letter-spacing: 0.08em; color: var(--muted); margin: 2rem 0 0.5rem; }
+      p { color: var(--muted); margin: 0 0 1rem; }
+      a { color: var(--accent); text-decoration: none; border-bottom: 1px solid transparent; }
+      a:hover { border-bottom-color: currentColor; }
+      ul { list-style: none; padding: 0; margin: 0; border-top: 1px solid var(--border); }
+      li { border-bottom: 1px solid var(--border); }
+      li a { display: flex; align-items: baseline; gap: 0.75rem; padding: 0.75rem 0; color: var(--fg); border-bottom: none; }
+      li a:hover { color: var(--accent); }
+      li code { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 0.9rem; color: var(--accent); }
+      li small { color: var(--muted); margin-left: auto; font-size: 0.85rem; }
+      .tag { display: inline-block; font-size: 0.75rem; padding: 0.1rem 0.5rem; border-radius: 999px; background: var(--border); color: var(--muted); margin-left: 0.5rem; vertical-align: middle; }
+    </style>
+  </head>
+  <body>
+    <main>
+      <p style="margin: 0; color: var(--muted); font-size: 0.85rem; text-transform: uppercase; letter-spacing: 0.08em;">404 · Not found</p>
+      <h1>That page isn't here.</h1>
+      <p>The URL you followed doesn't exist on <a href="/">web-ai-sdk.dev</a>. The site has two surfaces — a landing page at the root and a Starlight docs site under <code>/docs/</code>. Start with one of the entry points below, or pull the machine-readable index.</p>
+
+      <h2>Entry points</h2>
+      <ul>
+        <li><a href="/"><code>/</code><small>Landing — package matrix, install, demos</small></a></li>
+        <li><a href="/docs/"><code>/docs/</code><small>Documentation home (Starlight)</small></a></li>
+        <li><a href="/docs/browser-support/"><code>/docs/browser-support/</code><small>Chrome / Edge version matrix</small></a></li>
+      </ul>
+
+      <h2>Guides</h2>
+      <ul>
+        <li><a href="/docs/guides/meta-package/"><code>@web-ai-sdk/all</code></a></li>
+        <li><a href="/docs/guides/prompt/"><code>@web-ai-sdk/prompt</code></a></li>
+        <li><a href="/docs/guides/webmcp/"><code>@web-ai-sdk/webmcp</code></a></li>
+        <li><a href="/docs/guides/summarizer/"><code>@web-ai-sdk/summarizer</code></a></li>
+        <li><a href="/docs/guides/translator/"><code>@web-ai-sdk/translator</code></a></li>
+        <li><a href="/docs/guides/detector/"><code>@web-ai-sdk/detector</code></a></li>
+      </ul>
+
+      <h2>Machine-readable</h2>
+      <ul>
+        <li><a href="/llms.txt"><code>/llms.txt</code><small>Curated link index (llmstxt.org)</small></a></li>
+        <li><a href="/llms-full.txt"><code>/llms-full.txt</code><small>Concatenated README bodies</small></a></li>
+        <li><a href="/sitemap.xml"><code>/sitemap.xml</code><small>All site URLs</small></a></li>
+        <li><a href="https://github.com/obetomuniz/web-ai-sdk"><code>github.com/obetomuniz/web-ai-sdk</code><small>Source</small></a></li>
+      </ul>
+    </main>
+  </body>
+</html>

--- a/packages/detector/README.md
+++ b/packages/detector/README.md
@@ -2,6 +2,8 @@
 
 Building block for [the Web's Built-in Language Detector API](https://developer.chrome.com/docs/ai/language-detection). Detect the language of any text on-device, with confidence scores and a sorted list of alternates. Session reuse, pluggable result caching, AbortSignal-driven cleanup.
 
+**Docs:** <https://web-ai-sdk.dev/docs/guides/detector/> · **React:** [`useDetector`](https://web-ai-sdk.dev/docs/react/use-detector/)
+
 ## Status
 
 Language Detector ships stable in Chrome 138+ on desktop. On Edge it is a developer preview starting at Canary/Dev 147+ behind `edge://flags/#edge-language-detection-api` (per the [Edge Language Detector API docs](https://learn.microsoft.com/en-us/microsoft-edge/web-platform/languagedetector-api)) — not yet in Edge stable. On any other browser this library is a no-op for the React hook (it stays in `"unavailable"`). The vanilla `detect()` throws `DetectorUnavailableError` so callers can branch explicitly.

--- a/packages/prompt/README.md
+++ b/packages/prompt/README.md
@@ -2,6 +2,8 @@
 
 Building block for the Web's Built-in [Prompt API](https://developer.chrome.com/docs/extensions/ai/prompt-api) (`LanguageModel`). One-shot `ask()` for embeds and widgets, plus a thin `createSession()` primitive (and React `useSession`) for chat-shaped apps that need independent per-conversation sessions and delta-shaped streaming. The wrapper smooths cross-browser quirks (delta-vs-cumulative chunks, output sanitization, abort wiring); UI state and conversation history are the consumer's concern.
 
+**Docs:** <https://web-ai-sdk.dev/docs/guides/prompt/> · **React:** [`usePrompt`](https://web-ai-sdk.dev/docs/react/use-prompt/) · [`useSession`](https://web-ai-sdk.dev/docs/react/use-session/)
+
 ## Status
 
 Prompt API ships stable in Chrome 148+ — no flag required. Chrome 138–147 still works with `chrome://flags/#prompt-api-for-gemini-nano` enabled. On Edge it remains a developer preview in Canary/Dev 138+ behind `edge://flags/#prompt-api-for-phi-mini`, with Phi-4-mini's stricter safety pipeline often refusing output (see [Browser support](https://web-ai-sdk.dev/browser-support)). On any other browser this library is a no-op for the React hook (it stays in `"unavailable"`). The vanilla `ask()` throws `PromptUnavailableError` so callers can branch explicitly.

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -2,6 +2,8 @@
 
 One-install meta-package for every `@web-ai-sdk/*` building block: `prompt`, `summarizer`, `translator`, `detector`, and `webmcp`. Pulls each scoped package in as a regular dependency so consumers don't have to track them individually.
 
+**Docs:** <https://web-ai-sdk.dev/docs/guides/meta-package/> · **All packages & links:** <https://web-ai-sdk.dev/llms.txt>
+
 ## Status
 
 Each underlying scoped package is independently supported in Chrome / Edge with the corresponding Built-in AI flag enabled. See the per-package READMEs for browser support details:

--- a/packages/summarizer/README.md
+++ b/packages/summarizer/README.md
@@ -2,6 +2,8 @@
 
 Building block for the Web's Built-in [Summarizer API](https://developer.chrome.com/docs/ai/summarizer-api). Skeleton extraction, sentence-boundary trimming, streaming, and sessionStorage caching.
 
+**Docs:** <https://web-ai-sdk.dev/docs/guides/summarizer/> · **React:** [`useSummarizer`](https://web-ai-sdk.dev/docs/react/use-summarizer/)
+
 ## Status
 
 Summarizer API is stable in Chrome 138+ and Edge 138+ on desktop (enabled by default since Edge 138, per the [Edge Writing Assistance APIs docs](https://learn.microsoft.com/en-us/microsoft-edge/web-platform/writing-assistance-apis)). On Edge the Phi-4-mini safety pipeline frequently returns "low quality output blocked"; the library wraps that as a typed error. On any other browser this library is a no-op for the React hook (it stays in `"unavailable"`). The vanilla `summarize()` throws `SummarizerUnavailableError` so callers can branch explicitly.

--- a/packages/translator/README.md
+++ b/packages/translator/README.md
@@ -2,6 +2,8 @@
 
 Building block for the Web's Built-in [Translator API](https://developer.chrome.com/docs/ai/translator-api) (on-demand language packs). Block-level translation with inline placeholder serialization, casing restoration, and a snapshot-based restore.
 
+**Docs:** <https://web-ai-sdk.dev/docs/guides/translator/> · **React:** [`useTranslator`](https://web-ai-sdk.dev/docs/react/use-translator/)
+
 ## Status
 
 Translator API is stable in Chrome 138+ on desktop. On Edge it is a developer preview starting at Canary/Dev 143+ behind `edge://flags/#edge-translation-api` (per the [Edge Translator API docs](https://learn.microsoft.com/en-us/microsoft-edge/web-platform/translator-api)) — not yet in Edge stable. On any other browser this library is a no-op. Your app stays callable, and the controller just resolves with `blocksTranslated: 0`.

--- a/packages/webmcp/README.md
+++ b/packages/webmcp/README.md
@@ -4,6 +4,8 @@ Building block for the W3C [WebMCP](https://webmachinelearning.github.io/webmcp/
 
 An ergonomic, framework-agnostic adapter over the native browser API, with safe register/unregister cleanup and a feature-detected no-op fallback for non-supporting browsers.
 
+**Docs:** <https://web-ai-sdk.dev/docs/guides/webmcp/> · **React:** [`useWebMCP`](https://web-ai-sdk.dev/docs/react/use-web-mcp/)
+
 ## Status
 
 WebMCP shipped as an early preview in Chrome 146+ behind `chrome://flags/#enable-webmcp-testing`; a public [origin trial](https://developer.chrome.com/docs/ai/webmcp) opens in Chrome 149. Edge added support in 147+ behind the matching `edge://flags/` toggle. On any browser that doesn't expose `navigator.modelContext`, this library is a no-op. Your app stays callable, and no tools get registered.


### PR DESCRIPTION
## Summary

A handoff from a downstream agent integrator reported that fetching `web-ai-sdk.dev` cold burned ~6 tool calls before finding the API surface. [PR #4](https://github.com/obetomuniz/web-ai-sdk/pull/4) already shipped `/llms.txt`; this closes the remaining gaps surfaced in the handoff.

- **Landing** — inlined static directory inside `<div id="root">` (h1, install, package matrix with guide + hook links, browser support, machine-readable links). React replaces it on mount so JS visitors are unaffected; no-JS agents now see a real directory instead of an empty body. Added `<link rel="alternate" type="text/plain" href="/llms.txt">` and `/llms-full.txt`. New `apps/landing/public/404.html` (warm-black / cinnabar identity) lists every entry point — replaces the default GH Pages 404.
- **Docs** — same llms.txt / llms-full.txt alternate links wired through Starlight's `<head>`. Rewrote 15 relative MDX links (`./guides/x/`, `../react/use-x/`) to root-absolute `/docs/...`, defensive against broken HTML→md converters. Appended a `## Reference` section to all six `react/use-*.mdx` pages with verbatim TS signatures (Options + Return interfaces, status union, `declare const useX`) sourced from each package's `src/react/index.ts`.
- **READMEs** — one-line `**Docs:** <https://web-ai-sdk.dev/docs/guides/<pkg>/>` pointer right under each H1 in all six published packages so `npm view <pkg> README` is self-routing. Patch-level changeset bumps the fixed group; apps are in the changeset ignore list.

No package code changes.

## Test plan

- [x] `pnpm pages:build` — clean build of landing + docs, sitemap regenerated, llms.txt + llms-full.txt + 404.html land in `_site/`
- [x] `pnpm dlx serve _site -p 4173`
- [x] `curl -sI :4173/llms.txt`, `/llms-full.txt`, `/sitemap.xml` → 200
- [x] `curl -sI :4173/does-not-exist` → 404, body links to `/docs/`, every guide, `/llms.txt`, `/llms-full.txt`, `/sitemap.xml`, GitHub
- [x] `curl -s :4173/` → static fallback contains all six `@web-ai-sdk/*` names, "Install", "Packages"
- [x] `curl -s :4173/` and `/docs/react/use-translator/` → both expose `<link rel="alternate" ... href=".../llms.txt">`
- [x] `curl -s :4173/docs/` → no `href="guides...` (relative) emitted by MDX content
- [x] `curl -s :4173/docs/react/use-translator/` → renders `UseTranslatorOptions`, `UseTranslatorReturn`, `TranslatorState`
- [ ] Visual check of the static landing fallback (disable JS in DevTools and load `/`) — confirm package matrix renders without the React app
- [ ] Visual check of `/404.html` rendering in light + dark mode
- [ ] After merge: re-run the original handoff's `curl` checks against the live `https://web-ai-sdk.dev` once GH Pages redeploys