### PR TITLE
docs: introduce SDK/Kit two-layer framing and tighten Edge support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,6 +28,12 @@ Each package exposes:
 
 Lifecycle layer on purpose. Each package only manages session lifetime, cleanup, feature detection, and the gnarly bits (block serialization in translator, skeleton extraction + caching in summarizer, safe register/unregister in webmcp). Framework adapters, polyfills, and UI primitives are opt-in subpaths, not bundled into the core packages.
 
+### Two layers: SDK and Kit
+
+The repo today ships only `@web-ai-sdk/*`. A companion scope `@web-ai-kit/*` (not yet published) is reserved for higher-level compositions on top. Internally we sometimes call these *atoms* and *molecules*: atoms wrap one capability and never depend on anything; molecules compose atoms and depend freely. Decision heuristic for new code: *if it bonds two SDK packages or needs a third-party runtime, it belongs in the future kit, not in an SDK wrapper.*
+
+Full rules in [`CONTRIBUTING.md` § Governance](./CONTRIBUTING.md#governance); user-facing version at [`apps/docs/src/content/docs/architecture.mdx`](./apps/docs/src/content/docs/architecture.mdx) ([web-ai-sdk.dev/docs/architecture/](https://web-ai-sdk.dev/docs/architecture/)).
+
 ---
 
 ## 2. Stack & runtime

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,6 +32,19 @@ See the [README "Repo layout" section](./README.md#repo-layout) for the full tre
 4. **Add a changeset** if you're shipping a user-facing change. `pnpm changeset` opens an interactive picker. Skip this for docs-only or internal changes.
 5. **Open a PR** against `main`. The CI workflow will rerun the gate; the release workflow opens a "Version Packages" PR when there are pending changesets to publish.
 
+## Governance
+
+These rules define what belongs in `@web-ai-sdk/*` and what doesn't. They're the load-bearing constraints behind the [Architecture](./apps/docs/src/content/docs/architecture.mdx) page; if you're proposing a change to the SDK surface, read both.
+
+1. **No runtime dependencies in any `@web-ai-sdk/*` package.** `package.json` `dependencies` must be empty or absent. The one explicit exception is the meta-package `@web-ai-sdk/all`, which depends on the five wrapper packages as workspace deps so a single install ships the suite.
+2. **No `peerDependencies` except an optional `react` peer.** The `/react` subpath adapter is the only published surface allowed to peer on a framework. No Vue / Svelte / Solid / etc. peers; those would each be a new subpath on the same package, not a new package.
+3. **One package = one cohesive capability.** If you can't describe a package in one sentence without "and," it's two packages. The capability can originate from an official Built-in AI API (`LanguageModel`, `Summarizer`, `Translator`, `Detector`), an adjacent web standard (`WebMCP`, and likely `WebGPU` / `WebNN` in the future), or, rarely, a zero-dep SDK-authored primitive with no platform equivalent yet.
+4. **No SDK package may import from another published `@web-ai-sdk/*` package.** Composition across capabilities is the future kit's job by definition, not the SDK's. The meta-package is exempt because re-exporting is its only job.
+5. **Vanilla trunk + `/react` adapter as subpath.** A package's `src/index.ts` is the source of truth. `src/react/index.ts` is a thin wrapper. There is no `@web-ai-sdk/*-react` package and there shouldn't be.
+6. **Ergonomic defaults are allowed inside a package** (warm session pools, opt-in result caches, stream normalization), as long as they're scoped to that one capability and the user can override or disable them.
+
+For the time being these rules are enforced by review, not by CI. If you open a PR that adds `dependencies` or non-`react` `peerDependencies` to a `@web-ai-sdk/*` wrapper, expect to be asked to remove them or to land the work in the future kit instead. Shared infrastructure across packages (feature detection, stream normalization, error classes) will live in a private `@web-ai-sdk/internal` package the first time it's actually needed; until then, copy small helpers between packages rather than designing the shared layer upfront.
+
 ## Adding a new package
 
 1. Copy an existing package whose shape matches what you need (`prompt` if you want streaming + session cache + opt-in result cache, `webmcp` if you want an AbortSignal registry, `translator` if you want DOM-walking).

--- a/README.md
+++ b/README.md
@@ -4,6 +4,14 @@ Building blocks for the Web's Built-in AI APIs.
 
 A small, focused monorepo of framework-agnostic packages that smooth over the gnarly bits of the new `navigator.modelContext`, `Translator`, `Summarizer`, `LanguageModel`, and `LanguageDetector` browser APIs (feature detection, session caching, streaming, lifecycle, safe DOM rebuild) without bringing any UI along.
 
+## Two layers, one philosophy
+
+**`web-ai-sdk`** ships one package per browser capability. Zero runtime dependencies. Vanilla TypeScript by default, with optional React hooks. That's it. The SDK tracks a moving browser spec and intentionally stays out of the way of *how* you build an app.
+
+A companion project, **`web-ai-kit`** *(coming soon)*, will provide higher-level building blocks composed on top of these primitives: agent loops, headless UI, persistent memory, remote MCP clients. Each kit package will evolve on its own timeline; none will be required to use the SDK.
+
+See [`apps/docs/src/content/docs/architecture.mdx`](./apps/docs/src/content/docs/architecture.mdx) (rendered at [`web-ai-sdk.dev/docs/architecture/`](https://web-ai-sdk.dev/docs/architecture/)) for the full model.
+
 | Package                                          | Wraps                                          | Highlights                                                                |
 | ------------------------------------------------ | ---------------------------------------------- | ------------------------------------------------------------------------- |
 | [`@web-ai-sdk/webmcp`](./packages/webmcp)            | `navigator.modelContext` (W3C WebMCP)          | Safe register/unregister, shorthand annotations, `useWebMCP` hook         |
@@ -57,7 +65,7 @@ pnpm docs            # docs site on http://localhost:6006
 pnpm landing         # marketing landing on http://localhost:5173
 ```
 
-For the AI APIs to actually run, open a supporting browser. On Chrome, Summarizer/Translator/Detector are stable in 138+ and Prompt is stable in 148+ (no flags); WebMCP needs `chrome://flags/#enable-webmcp-testing` through Chrome 148 and joins a public origin trial in Chrome 149. On Edge, only Summarizer is in stable (138+ default-on); Prompt, Translator, Detector, and WebMCP are developer previews in Canary/Dev behind their respective `edge://flags/` toggles. See [Browser support](./apps/docs/src/content/docs/browser-support.mdx) for the per-package matrix and exact flag names.
+For the AI APIs to actually run, open a supporting browser. On Chrome, Summarizer/Translator/Detector are stable in 138+ and Prompt is stable in 148+ (no flags); WebMCP needs `chrome://flags/#enable-webmcp-testing` through Chrome 148 and joins a public origin trial in Chrome 149. On Edge, only Summarizer is in stable (138+ default-on); Prompt, Translator, Detector, and WebMCP are developer previews in Canary/Dev behind their respective `edge://flags/` toggles. On Windows the four Built-in AI APIs (Prompt, Summarizer, Translator, Detector) work reliably once flagged; macOS sees higher refusal rates from the Phi-4-mini safety pipeline for Prompt and Summarizer. WebMCP on Edge remains rough on both platforms. See [Browser support](./apps/docs/src/content/docs/browser-support.mdx) for the per-package matrix and exact flag names.
 
 ## Repo layout
 

--- a/apps/docs/astro.config.mjs
+++ b/apps/docs/astro.config.mjs
@@ -61,6 +61,7 @@ export default defineConfig({
           label: "Start",
           items: [
             { label: "Browser support", slug: "browser-support" },
+            { label: "Architecture", slug: "architecture" },
           ],
         },
         {

--- a/apps/docs/src/content/docs/architecture.mdx
+++ b/apps/docs/src/content/docs/architecture.mdx
@@ -1,0 +1,94 @@
+---
+title: Architecture
+description: How web-ai-sdk is organized. One package per browser capability, zero runtime dependencies, vanilla trunk with optional React adapters, and how the companion web-ai-kit fits on top.
+---
+
+`web-ai-sdk` is intentionally narrow. This page explains how the packages are organized, which decisions live inside the SDK and which are deferred to a future companion project, and how to reason about adding a new capability.
+
+## One package per browser capability
+
+Each `@web-ai-sdk/*` package wraps a single cohesive web capability relevant to in-browser AI:
+
+| Package | Wraps |
+| --- | --- |
+| [`@web-ai-sdk/prompt`](/docs/guides/prompt/) | `LanguageModel` (Web Built-in Prompt API) |
+| [`@web-ai-sdk/webmcp`](/docs/guides/webmcp/) | `navigator.modelContext` (W3C WebMCP) |
+| [`@web-ai-sdk/summarizer`](/docs/guides/summarizer/) | `Summarizer` |
+| [`@web-ai-sdk/translator`](/docs/guides/translator/) | `Translator` |
+| [`@web-ai-sdk/detector`](/docs/guides/detector/) | `LanguageDetector` |
+| [`@web-ai-sdk/all`](/docs/guides/meta-package/) | Meta-package; re-exports the five above |
+
+The capability can originate from an official Built-in AI API (`LanguageModel`, `Summarizer`, `Translator`, `Detector`), from an adjacent web standard (`WebMCP` today; `WebGPU` and `WebNN` are likely candidates as their on-device AI uses crystallize), or, rarely, from a zero-dependency SDK-authored primitive with no platform equivalent yet. The rules below are what define an SDK package, not the origin of the underlying capability.
+
+The structural rule is mechanical: **one package = one cohesive capability**. If the description of a package needs the word "and" to be honest about its scope, it's probably two packages.
+
+No SDK package imports from another published SDK package. Composition across capabilities (running a Prompt session over a tool registered with WebMCP, for example) is something you write in your application today, and something the future kit will offer pre-composed.
+
+## Zero-dependency policy
+
+Every `@web-ai-sdk/*` package ships with **no runtime dependencies and no peer dependencies**. The one exception is `react`, which is declared as an *optional* peer for the `/react` subpath adapter only.
+
+This is policy, not aspiration. The reasoning:
+
+- The Built-in AI APIs are still evolving. The SDK tracks a moving spec; we don't want to also be tracking a moving dependency graph.
+- A wrapper that introduces transitive dependencies imports their security surface, their breaking changes, and their abandonment risk. We don't think a `LanguageModel` wrapper should ever pull in a logging library or a polyfill.
+- Zero deps means a `pnpm add @web-ai-sdk/prompt` adds exactly one entry to your lockfile.
+
+When something useful really does need a third-party runtime (say, an IndexedDB-backed memory store or a JSON-RPC transport for a remote MCP server), it belongs in the companion kit, not here.
+
+## Vanilla trunk, React adapter as a subpath
+
+Every package has two entry points:
+
+```ts
+// Vanilla: TypeScript / DOM only, framework-agnostic.
+import { ask, createSession } from "@web-ai-sdk/prompt";
+
+// React: small hook adapter that wraps the vanilla core.
+import { usePrompt, useSession } from "@web-ai-sdk/prompt/react";
+```
+
+The vanilla trunk is the source of truth. The React adapter is a thin layer that wires the vanilla core into hook lifecycles. There is no standalone `@web-ai-sdk/prompt-react` package, and there won't be. Splitting along a framework boundary would force two release cadences for one capability.
+
+If a different framework adapter ever ships, it will follow the same shape: `@web-ai-sdk/<pkg>/<framework>` as a subpath, with the framework declared as an optional peer.
+
+## Ergonomic defaults vs. opinions
+
+The SDK is allowed to be ergonomic *within a single capability*. Examples that live inside `@web-ai-sdk/prompt`:
+
+- **Warm LRU session pool.** `ask()` reuses `LanguageModel.create()` results across same-shape callers. Cold start drops to sub-second. Override the cap with `configurePromptCache({ max })`; clear entries with `clearSession()` / `clearSessions()`.
+- **Optional result cache.** `ask()` accepts a `cache` option that memoizes responses by `(input, systemPrompt, temperature, topK)`. Off by default; you supply the backend (sessionStorage, localStorage, your own `{ get, set }` object).
+- **Delta-vs-cumulative stream normalization.** Chrome emits delta chunks; some Edge backends emit cumulative buffers. The wrapper smooths this so `onUpdate` always sees the cumulative buffer and `sendStreaming()` always yields deltas.
+
+These are **ergonomic defaults**, not opinions about *how* you build an app. They each:
+
+- live entirely inside one capability,
+- can be overridden, disabled, or replaced,
+- and would otherwise be reimplemented by every consumer.
+
+What you won't find in the SDK is anything that bonds multiple capabilities together: an agent loop that drives Prompt with WebMCP tools, a chat UI primitive, a persistent message store. Those are multi-capability compositions, and they belong in the kit, where each can evolve and version on its own timeline without touching the SDK or its users.
+
+## The companion kit
+
+**`web-ai-kit`** *(coming soon)* will be a separate scope and a separate repo. It will ship higher-level building blocks composed on top of the SDK:
+
+- agent loops with tool dispatch, step budgets, and event streams,
+- headless renderers for chat logs and streaming text,
+- IndexedDB / OPFS message stores with pluggable embedders,
+- remote MCP clients for talking to non-browser tool servers.
+
+Each kit package will be installable on its own, will depend on the relevant SDK package(s), and will be free to take third-party dependencies when they earn their place. Crucially: **no kit package will ever be a prerequisite for using an SDK package**. If you only want to call `LanguageModel`, you only need `@web-ai-sdk/prompt`.
+
+Until the kit ships, you can compose these primitives yourself: `ask()` plus `registerTool()` plus a `for await` loop is a tool-using agent in a dozen lines. The kit will eventually offer the polished, reusable version of that pattern; the SDK will keep providing the primitives underneath it.
+
+## Summary
+
+| Question                                                  | SDK              | Kit (future)        |
+| --------------------------------------------------------- | ---------------- | ------------------- |
+| Wraps one browser capability?                             | Yes              | No                  |
+| Composes multiple SDK packages?                           | No               | Yes                 |
+| Allowed runtime dependencies?                             | None             | Yes, when justified |
+| Ergonomic defaults scoped to one capability?              | Yes              | N/A                 |
+| Frame `ask()` retries or chat history or rendering here?  | No               | Yes                 |
+
+New web capabilities (Built-in AI, WebGPU, WebNN, or adjacent standards) land in the SDK as new packages. New usage patterns land in the kit.

--- a/apps/docs/src/content/docs/browser-support.mdx
+++ b/apps/docs/src/content/docs/browser-support.mdx
@@ -7,10 +7,10 @@ Built-in AI lands engine by engine. Where it isn't there yet, every package is a
 
 | Package | Chrome | Edge | Safari | Firefox |
 | --- | --- | --- | --- | --- |
-| `@web-ai-sdk/prompt` | 148+ · stable | 138+ · Canary/Dev · partial · flag | no-op fallback | no-op fallback |
-| `@web-ai-sdk/summarizer` | 138+ · stable | 138+ · stable · partial | no-op fallback | no-op fallback |
-| `@web-ai-sdk/translator` | 138+ · stable | 143+ · Canary/Dev · flag | no-op fallback | no-op fallback |
-| `@web-ai-sdk/detector` | 138+ · stable | 147+ · Canary/Dev · flag | no-op fallback | no-op fallback |
+| `@web-ai-sdk/prompt` | 148+ · stable | 138+ · Canary/Dev | no-op fallback | no-op fallback |
+| `@web-ai-sdk/summarizer` | 138+ · stable | 138+ · stable | no-op fallback | no-op fallback |
+| `@web-ai-sdk/translator` | 138+ · stable | 143+ · Canary/Dev | no-op fallback | no-op fallback |
+| `@web-ai-sdk/detector` | 138+ · stable | 147+ · Canary/Dev | no-op fallback | no-op fallback |
 | `@web-ai-sdk/webmcp` | 146+ · flag · OT 149+ | 147+ · flag | no-op fallback | no-op fallback |
 
 Versions reflect when the underlying platform API became available. Wrapper exports stay stable across all browsers. "OT" means origin trial.
@@ -19,13 +19,15 @@ Versions reflect when the underlying platform API became available. Wrapper expo
 
 Of the five APIs, only the Summarizer ships in Edge stable (enabled by default since Edge 138, per the [Edge Writing Assistance APIs docs](https://learn.microsoft.com/en-us/microsoft-edge/web-platform/writing-assistance-apis)). The Prompt API is a developer preview in Edge Canary/Dev 138+, and Translator (Edge 143+) and Language Detector (Edge 147+) are Canary/Dev-only as well, each behind its own `edge://flags/` toggle. WebMCP landed in Edge 147 behind a flag.
 
-Prompt and Summarizer route through Phi-4-mini (or Phi-Silica on Copilot+ PCs) with a stricter safety pipeline than Chrome's Gemini Nano; Translator and Language Detector run dedicated on-device models.
+Prompt and Summarizer route through Phi-4-mini with a stricter safety pipeline than Chrome's Gemini Nano; Translator and Language Detector run dedicated on-device models.
 
-- **Partial** means the JS API is present but the on-device model frequently refuses output. Summarizer often returns "low quality output blocked"; prompt may emit C0 control-character placeholders instead of text. The library handles both cases (strips C0/C1, normalizes streaming shape, wraps refusals in typed errors), but the model itself is the bottleneck.
-- Flag names differ: search "Phi mini" on `edge://flags/` for Prompt/Writing Assistance, "translation api" for Translator, "language detection" for Language Detector.
-- Hardware check: `edge://on-device-internals` requires "High" device performance class and all supplementary safety models ("GENERALIZED_SAFETY", "TEXT_SAFETY", "LANGUAGE_DETECTION") in "Ready" state.
+- **macOS quirk:** on macOS, the on-device model frequently refuses output for Prompt and Summarizer — summarizer returns "low quality output blocked", prompt may emit C0 control-character placeholders. The library handles both (strips C0/C1, normalizes streaming shape, wraps refusals in typed errors), but the model itself is the bottleneck on that platform. Windows doesn't reproduce this.
+- Flags on `edge://flags/`: "Phi mini" (Prompt, Writing Assistance), "translation api" (Translator), "language detection" (Language Detector).
+- Hardware check: `edge://on-device-internals` must show a "High" device performance class.
 
-Tested on macOS; Windows behavior may differ.
+WebMCP on Edge isn't yet covered by an official Microsoft developer-docs page; the version above reflects empirical Canary/Dev testing.
+
+References: Microsoft Learn — [Prompt](https://learn.microsoft.com/en-us/microsoft-edge/web-platform/prompt-api) · [Writing Assistance](https://learn.microsoft.com/en-us/microsoft-edge/web-platform/writing-assistance-apis) · [Translator](https://learn.microsoft.com/en-us/microsoft-edge/web-platform/translator-api) · [Language Detector](https://learn.microsoft.com/en-us/microsoft-edge/web-platform/languagedetector-api).
 
 ## Enabling on Chrome
 

--- a/apps/docs/src/content/docs/guides/detector.mdx
+++ b/apps/docs/src/content/docs/guides/detector.mdx
@@ -52,7 +52,7 @@ The hint is also forwarded to `availability()` so engines that warn on shape mis
 
 ## Composing with the other packages
 
-Pair the detector with summarizer / translator / prompt to skip the manual `language: "en"` argument when the input language isn't known ahead of time:
+The detector intentionally doesn't reach into the other packages; one package wraps one capability. To skip the manual `language: "en"` argument when the input language isn't known ahead of time, wire the two yourself:
 
 ```ts
 import { detect } from "@web-ai-sdk/detector";
@@ -65,7 +65,7 @@ await summarize({
 });
 ```
 
-A first-class `language: "auto"` shortcut may land in a future release that wires this internally for you.
+A first-class `language: "auto"` shortcut isn't planned for this package. Multi-package compositions like detect-then-summarize, detect-then-translate, or detect-then-prompt are the kind of pattern the future [`web-ai-kit`](/docs/architecture/#the-companion-kit) layer is meant to host, not the SDK wrappers.
 
 ## Aborting
 

--- a/apps/docs/src/content/docs/guides/prompt.mdx
+++ b/apps/docs/src/content/docs/guides/prompt.mdx
@@ -61,9 +61,11 @@ The wrapper is intentionally thin. It handles cross-browser smoothing every cons
 Chrome's `LanguageModel` exposes `LanguageModel.create({...})` to spin up a session and `session.prompt(input)` / `session.promptStreaming(input)` to run it. The wrapper does the following on top:
 
 - **Feature detection.** `isPromptAvailable()` / `checkAvailability()` return `false` / `null` on browsers without the API. The vanilla `ask()` throws `PromptUnavailableError`; the React hook surfaces `status: "unavailable"`.
-- **Session reuse for `ask()`.** A bounded LRU (default 8) caches `LanguageModel.create()` by stringified create options. Cold start ≈ 1-3s; warm calls are sub-second. `createSession()` is never cached.
-- **Optional result cache for `ask()`.** Off by default; every call hits the model. Pass `cache: createSessionStorageCache()` (or any `{ get, set }`-shaped object) to memoize responses by `(input, systemPrompt, temperature, topK)`. Swap the backend (e.g. `localStorage` for cross-tab persistence) via the `cache` option.
+- **Session reuse for `ask()` (ergonomic default, scoped to `ask`).** A bounded LRU (default 8) caches `LanguageModel.create()` by stringified create options. Cold start is roughly 1 to 3 seconds; warm calls are sub-second. Tune the cap with `configurePromptCache({ max })`, drop entries with `clearSession()` / `clearSessions()`. `createSession()` never touches this cache.
+- **Optional result cache for `ask()` (off by default).** Every call hits the model unless you opt in. Pass `cache: createSessionStorageCache()` (or any `{ get, set }`-shaped object) to memoize responses by `(input, systemPrompt, temperature, topK)`. Swap the backend (e.g. `localStorage` for cross-tab persistence) via the `cache` option.
 - **Delta-vs-cumulative chunk detection.** Chrome ships delta chunks; some Edge backends ship cumulative. The wrapper normalizes per-chunk so `onUpdate` (cumulative) and `sendStreaming()` (deltas) work the same across browsers.
+
+The two cache-shaped items above are *ergonomic defaults scoped to `ask()`*, not opinions about how to use a language model. They live here because they smooth `ask()` in particular; multi-package compositions (agent loops, conversation history, tool dispatch) are not part of this package. See [Architecture](/docs/architecture/) for the split.
 
 ## System prompt + sampling
 

--- a/apps/docs/src/content/docs/index.mdx
+++ b/apps/docs/src/content/docs/index.mdx
@@ -19,6 +19,12 @@ hero:
 
 import { Card, CardGrid } from "@astrojs/starlight/components";
 
+## Two layers, one philosophy
+
+**`web-ai-sdk`** ships building blocks for the Web's Built-in AI APIs. One package per browser capability (Prompt, WebMCP, Summarizer, Translator, Detector). Zero runtime dependencies. Vanilla TypeScript by default, with optional React hooks.
+
+A companion project, **`web-ai-kit`** *(coming soon)*, will provide higher-level building blocks composed on top of these primitives: agent loops, headless UI, persistent memory, remote MCP clients. Each kit package will evolve on its own timeline; none will be required to use the SDK. See [Architecture](/docs/architecture/) for the model.
+
 ## Composable wrappers. One philosophy.
 
 <CardGrid>

--- a/apps/landing/src/App.tsx
+++ b/apps/landing/src/App.tsx
@@ -425,9 +425,9 @@ export const App = () => (
               </li>
               <li>
                 <span>
-                  <b>Pairs with the others.</b> Skip the manual{" "}
-                  <code>language: "en"</code> argument; detect first, then
-                  summarize / translate / prompt.
+                  <b>Wire the others.</b> Detect first, then call summarize /
+                  translate / prompt with the result — you skip the manual{" "}
+                  <code>language: "en"</code> argument.
                 </span>
               </li>
             </ul>
@@ -635,9 +635,7 @@ export const App = () => (
                   </td>
                   <td>
                     <span className="v">138+</span>{" "}
-                    <span className="pill">Canary/Dev</span>{" "}
-                    <span className="pill partial">partial</span>{" "}
-                    <span className="pill">flag</span>
+                    <span className="pill">Canary/Dev</span>
                   </td>
                   <td>
                     <span className="pill fallback">no-op fallback</span>
@@ -656,8 +654,7 @@ export const App = () => (
                   </td>
                   <td>
                     <span className="v">138+</span>{" "}
-                    <span className="pill ok">stable</span>{" "}
-                    <span className="pill partial">partial</span>
+                    <span className="pill ok">stable</span>
                   </td>
                   <td>
                     <span className="pill fallback">no-op fallback</span>
@@ -676,8 +673,7 @@ export const App = () => (
                   </td>
                   <td>
                     <span className="v">143+</span>{" "}
-                    <span className="pill">Canary/Dev</span>{" "}
-                    <span className="pill">flag</span>
+                    <span className="pill">Canary/Dev</span>
                   </td>
                   <td>
                     <span className="pill fallback">no-op fallback</span>
@@ -696,8 +692,7 @@ export const App = () => (
                   </td>
                   <td>
                     <span className="v">147+</span>{" "}
-                    <span className="pill">Canary/Dev</span>{" "}
-                    <span className="pill">flag</span>
+                    <span className="pill">Canary/Dev</span>
                   </td>
                   <td>
                     <span className="pill fallback">no-op fallback</span>
@@ -741,18 +736,18 @@ export const App = () => (
             <code>edge://flags/</code> toggle. WebMCP landed in Edge 147 behind
             a flag.
             <br />
-            <strong>Partial</strong> = JS API is present but the on-device model
-            frequently refuses output. Prompt and Summarizer route through
-            Phi-4-mini (or Phi-Silica on Copilot+ PCs) with a stricter safety
-            pipeline: summarizer often returns "low quality output blocked";
-            prompt may emit C0 control-character placeholders instead of text.
-            Flag names: search "Phi mini" on <code>edge://flags/</code> for
-            Prompt/Writing Assistance, "translation api" for Translator,
-            "language detection" for Language Detector. Hardware check:{" "}
-            <code>edge://on-device-internals</code> requires "High" device
-            performance class and all supplementary safety models
-            ("GENERALIZED_SAFETY", "TEXT_SAFETY", "LANGUAGE_DETECTION") in
-            "Ready" state. Tested on macOS; Windows behavior may differ.
+            <strong>macOS quirk:</strong> on macOS, the on-device model
+            frequently refuses output for Prompt and Summarizer — Phi-4-mini's
+            stricter safety pipeline returns "low quality output blocked" or C0
+            control-character placeholders. The library handles both. Windows
+            doesn't reproduce this; the four Built-in AI APIs work reliably
+            there once flagged. Flags on <code>edge://flags/</code>: "Phi mini"
+            (Prompt, Writing Assistance), "translation api" (Translator),
+            "language detection" (Language Detector). Hardware check:{" "}
+            <code>edge://on-device-internals</code> must show a "High" device
+            performance class. WebMCP on Edge isn't yet covered by an official
+            Microsoft developer-docs page; the version above reflects empirical
+            Canary/Dev testing.
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary

- Adds an [Architecture](apps/docs/src/content/docs/architecture.mdx) page codifying the atom/molecule model — `@web-ai-sdk/*` wraps one cohesive web capability with zero runtime deps; a future `@web-ai-kit/*` scope (not yet published) will host multi-package compositions (agent loops, headless UI, persistent memory, remote MCP transports). The model is mirrored on the landing, README, CONTRIBUTING (governance rules), AGENTS, and tightened wording in the Prompt and Detector guides.
- Browser-support claims verified against four official Microsoft Learn pages: dropped the Phi-Silica/Copilot+ PCs claim and the specific safety-model names (not in any official doc); added a References line; noted WebMCP on Edge has no official Microsoft developer-docs page yet.
- Edge support table simplified to one pill per cell (matches Chrome's compact format): redundant `flag` pills dropped from `Canary/Dev` rows, `partial (macOS)` pills dropped in favor of a prose macOS-quirk note. Windows vs macOS behavior split out.

No API changes, no published-code changes, no `@web-ai-kit/*` packages or scopes activated. CI enforcement of governance rules deferred to a follow-up.

## Test plan

- [x] `pnpm --filter @web-ai-sdk-apps/docs build` — 16 pages built; new `/docs/architecture/` page renders.
- [x] `pnpm --filter ./apps/landing build` — landing builds; detector card + Edge support table render correctly.
- [x] `pnpm lint` — biome clean.
- [ ] Manual: visit `/docs/architecture/` and click the in-page links to guides/prompt and guides/detector to verify cross-references resolve.
- [ ] Manual: scan the rendered Edge column on docs and landing — confirm one pill per cell, footnote reads cleanly.
- [ ] Manual: open the four Microsoft Learn links in the References row to confirm they resolve to the right pages.