### PR TITLE
feat(webmcp): deprecate registerTools in favor of registerTool

### DIFF
--- a/.changeset/deprecate-register-tools.md
+++ b/.changeset/deprecate-register-tools.md
@@ -1,0 +1,5 @@
+---
+"@web-ai-sdk/webmcp": minor
+---
+
+Deprecate `registerTools` — to be removed in 0.4. It was a thin wrapper over `registerTool` (mostly atomic-rollback sugar) and didn't earn its place alongside the primitive. The export still works and is unchanged; the JSDoc and docs now point at the `tools.map(registerTool)` pattern instead.

--- a/apps/docs/src/content/docs/guides/webmcp.mdx
+++ b/apps/docs/src/content/docs/guides/webmcp.mdx
@@ -8,7 +8,7 @@ Building block for the W3C [WebMCP](https://webmachinelearning.github.io/webmcp/
 ## Usage
 
 ```ts
-import { registerTool, registerTools } from "@web-ai-sdk/webmcp";
+import { registerTool } from "@web-ai-sdk/webmcp";
 
 const cleanup = registerTool({
   name: "add_to_cart",
@@ -20,7 +20,16 @@ const cleanup = registerTool({
 cleanup();
 ```
 
-Pass an array to `registerTools` to register many at once with a single cleanup.
+To register many at once, map over the array and combine the cleanups:
+
+```ts
+const cleanups = tools.map(registerTool);
+const cleanup = () => cleanups.forEach((c) => c());
+```
+
+:::caution
+`registerTools(tools)` still exists but is **deprecated** and will be removed in 0.4. Use the `map` pattern above instead.
+:::
 
 ## How it works
 
@@ -28,7 +37,7 @@ Chrome's `navigator.modelContext.registerTool({...}, { signal })` is the spec en
 
 - **Feature detection.** On browsers without `navigator.modelContext`, every entry point is a no-op so consumer code ships unchanged. `isWebMCPAvailable()` returns `false`.
 - **Last-writer-wins on duplicate names.** React effect cleanup is asynchronous; a fast re-render can attempt to register `"foo"` before Chrome processed the prior `abort()`. The wrapper detects the resulting duplicate-name error, queues a microtask retry, and tracks ownership so a stale registration can't squat the name.
-- **One AbortController per call.** `registerTool` and `registerTools` both return a single cleanup function that aborts the underlying controller, unregistering every tool registered in that call atomically.
+- **One AbortController per call.** `registerTool` returns a cleanup function that aborts the underlying controller and unregisters the tool.
 
 ## Annotations
 

--- a/apps/docs/src/content/docs/react/use-web-mcp.mdx
+++ b/apps/docs/src/content/docs/react/use-web-mcp.mdx
@@ -64,7 +64,7 @@ This is necessary because Chrome's `AbortSignal`-driven unregister is asynchrono
 
 ## Cleanup
 
-The hook returns nothing; cleanup is automatic on unmount via `useEffect`'s return value. If you need imperative cleanup (e.g. log out flow), use the vanilla `registerTools(tools)` directly and call the returned cleanup.
+The hook returns nothing; cleanup is automatic on unmount via `useEffect`'s return value. If you need imperative cleanup (e.g. log out flow), call the vanilla `registerTool` directly per tool and combine the cleanups: `const cleanups = tools.map(registerTool)`.
 
 ## Errors and unavailability
 

--- a/apps/landing/src/components/WebMCPDemo.tsx
+++ b/apps/landing/src/components/WebMCPDemo.tsx
@@ -354,7 +354,7 @@ Reply with ONLY valid JSON of the shape {"tool":"name_or_null","args":{},"reason
       <div className="card-head">
         <span className="title">
           <span className={`dot ${running ? "live" : "ok"}`} />
-          webmcp() · agentic
+          registerTool() · agentic
         </span>
         <span>
           {registeredCount} tool{registeredCount === 1 ? "" : "s"} registered

--- a/packages/webmcp/README.md
+++ b/packages/webmcp/README.md
@@ -22,9 +22,9 @@ React adapter is shipped as a subpath export, with no extra install. `react` is 
 ## Vanilla TypeScript / DOM
 
 ```ts
-import { registerTools } from "@web-ai-sdk/webmcp";
+import { registerTool } from "@web-ai-sdk/webmcp";
 
-const cleanup = registerTools([
+const tools = [
   {
     name: "list_blog_posts",
     description: "List published blog posts.",
@@ -59,13 +59,16 @@ const cleanup = registerTools([
       return { ok: true };
     },
   },
-]);
+];
+
+const cleanups = tools.map(registerTool);
+const cleanup = () => cleanups.forEach((c) => c());
 
 // later, e.g. on page teardown
 cleanup();
 ```
 
-`registerTool(tool)` registers a single tool and returns the cleanup. `registerTools([...])` registers many and returns one cleanup that disposes all of them. Re-registering a tool with the same name is safe; the previous registration is dropped first.
+`registerTool(tool)` registers a single tool and returns the cleanup. Re-registering a tool with the same name is safe; the previous registration is dropped first.
 
 ## React
 
@@ -102,9 +105,11 @@ The hook registers on mount, unregisters on unmount, and re-registers when the a
 
 Register a single tool. Returns a cleanup function. No-op on unsupported browsers.
 
-### `registerTools(tools): () => void`
+### `registerTools(tools): () => void` <sup>deprecated</sup>
 
 Register many tools at once. Returns a single cleanup that unregisters all of them.
+
+**Deprecated — will be removed in 0.4.** `registerTool` is the primitive; combine cleanups yourself when you need to register many: `const cleanups = tools.map(registerTool)`.
 
 ### `isWebMCPAvailable(): boolean`
 
@@ -173,7 +178,7 @@ const sendEmail = defineTool({
   },
 });
 
-// `sendEmail` is a plain Tool and can be passed to registerTool / registerTools / useWebMCP.
+// `sendEmail` is a plain Tool and can be passed to registerTool or useWebMCP.
 ```
 
 `defineTool` accepts any [Standard Schema](https://standardschema.dev) V1 validator (Zod 3.24+, Valibot, ArkType, Effect, …) — no SDK dependency on any specific library. The returned object is a plain `Tool`, so it composes with the rest of the API unchanged.

--- a/packages/webmcp/src/index.ts
+++ b/packages/webmcp/src/index.ts
@@ -329,6 +329,12 @@ export const registerTool = <TInput, TOutput>(
  *
  * All tools share one AbortController, so the cleanup tears them down
  * atomically.
+ *
+ * @deprecated Will be removed in 0.4. `registerTool` is the primitive;
+ * combine cleanups yourself when you need to register many at once:
+ *
+ *     const cleanups = tools.map(registerTool);
+ *     const cleanup = () => cleanups.forEach((c) => c());
  */
 export const registerTools = (tools: readonly Tool[]): (() => void) => {
   const mc = getModelContext();


### PR DESCRIPTION
## Summary

- `registerTools` was a thin wrapper over `registerTool` — mostly atomic-rollback sugar that didn't earn its place alongside the primitive. Marked `@deprecated` for removal in **0.4**; users should map over `registerTool` and combine the cleanups (`const cleanups = tools.map(registerTool)`).
- The export still works unchanged. Only the JSDoc, README, guide doc, and React doc are updated to point at the new pattern.
- Fixed the landing demo card title at [WebMCPDemo.tsx:357](apps/landing/src/components/WebMCPDemo.tsx) — it read `webmcp() · agentic`, but no `webmcp()` function exists. Now reads `registerTool() · agentic`, matching the convention of the other cards (`detect()`, `ask()`, `summarize()`, `translate()` — all real exported function names).
- Includes a `minor` changeset so the deprecation lands in the next 0.4 release.

The React `useWebMCP` hook still calls `registerTools` internally — that's fine as a private implementation detail; when we actually drop the export in 0.4, the hook will inline the same `map(registerTool)` pattern.

## Test plan

- [ ] `pnpm -r build` succeeds
- [ ] `pnpm -r test` passes (no behavior changes; deprecation is JSDoc-only)
- [ ] Docs site builds: `pnpm --filter @web-ai-sdk-apps/docs build`
- [ ] Landing builds and the WebMCP demo card title reads `registerTool() · agentic`
- [ ] TypeScript consumers of `registerTools` see the `@deprecated` warning in their IDE