### PR TITLE
chore(changeset): downgrade registerTools deprecation to patch

### DIFF
--- a/.changeset/deprecate-register-tools.md
+++ b/.changeset/deprecate-register-tools.md
@@ -1,5 +1,5 @@
 ---
-"@web-ai-sdk/webmcp": minor
+"@web-ai-sdk/webmcp": patch
 ---
 
-Deprecate `registerTools` — to be removed in 0.4. It was a thin wrapper over `registerTool` (mostly atomic-rollback sugar) and didn't earn its place alongside the primitive. The export still works and is unchanged; the JSDoc and docs now point at the `tools.map(registerTool)` pattern instead.
+Deprecate `registerTools` — to be removed in 0.4. It was a thin wrapper over `registerTool` (mostly atomic-rollback sugar) and didn't earn its place alongside the primitive. The export still works and is unchanged; the JSDoc and docs now point at the `tools.map(registerTool)` pattern instead. The actual removal will be the 0.4 minor bump.


### PR DESCRIPTION
## Summary

Auto-release PR [#16](https://github.com/obetomuniz/web-ai-sdk/pull/16) was bumping `@web-ai-sdk/webmcp` to **0.4.0** because the changeset I added in [#15](https://github.com/obetomuniz/web-ai-sdk/pull/15) was marked `minor`. That's wrong — the deprecation only adds a `@deprecated` JSDoc tag and updates docs; there's no runtime behavior change. It should ship as **0.3.4**.

The 0.4 minor bump is reserved for the actual removal of `registerTools`, which is a breaking change and will come in a later release.

Once this merges, the Changesets bot will regenerate #16 with `0.3.4` instead of `0.4.0`.

## Test plan

- [ ] Confirm PR #16 updates to show `@web-ai-sdk/webmcp@0.3.4` after this merges