### PR TITLE
fix(landing): sync footer version and improve how-it-works section

### DIFF
--- a/apps/landing/src/App.tsx
+++ b/apps/landing/src/App.tsx
@@ -581,8 +581,8 @@ export const App = () => (
               Same task. Three levels of abstraction.
             </h2>
             <p style={{ maxWidth: "60ch", marginTop: 14 }}>
-              All three tabs do the same thing: detect an article's language
-              and summarize it into key-points. Fifteen lines with the SDK;
+              All three tabs do the same thing: detect an article's language and
+              summarize it into key-points. Fifteen lines with the SDK;
               thirty-seven calling the browser APIs yourself. Same result, less
               to wire up.
             </p>

--- a/apps/landing/src/App.tsx
+++ b/apps/landing/src/App.tsx
@@ -580,10 +580,10 @@ export const App = () => (
               Same task. Three levels of abstraction.
             </h2>
             <p style={{ maxWidth: "60ch", marginTop: 14 }}>
-              All three tabs do the same task; detect the article's language,
-              then summarize it into short key-points in that language. The
-              vanilla TypeScript tab is 14 lines. The raw browser API tab is 36.
-              The difference is what the wrappers do for you.
+              All three tabs do the same thing: detect an article's language
+              and summarize it into key-points. Fifteen lines with the SDK;
+              thirty-seven calling the browser APIs yourself. Same result, less
+              to wire up.
             </p>
           </div>
           <a className="permalink" href="#how">
@@ -888,7 +888,7 @@ export const App = () => (
           </div>
         </div>
         <div className="footer-meta">
-          <span>web-ai-sdk v0.1.0</span>
+          <span>web-ai-sdk v0.4.0</span>
           <span>
             <a href="#top">Back to top ↑</a>
           </span>

--- a/apps/landing/src/App.tsx
+++ b/apps/landing/src/App.tsx
@@ -8,6 +8,7 @@ import { StarWidget } from "./components/StarWidget.js";
 import { SummarizerDemo } from "./components/SummarizerDemo.js";
 import { TranslatorDemo } from "./components/TranslatorDemo.js";
 import { WebMCPDemo } from "./components/WebMCPDemo.js";
+import { SDK_VERSION } from "./sdk-version.js";
 
 const REPO = "obetomuniz/web-ai-sdk";
 
@@ -888,7 +889,7 @@ export const App = () => (
           </div>
         </div>
         <div className="footer-meta">
-          <span>web-ai-sdk v0.4.0</span>
+          <span>web-ai-sdk v{SDK_VERSION}</span>
           <span>
             <a href="#top">Back to top ↑</a>
           </span>

--- a/apps/landing/src/components/HowItWorks.tsx
+++ b/apps/landing/src/components/HowItWorks.tsx
@@ -12,7 +12,6 @@ interface CodeLine {
 interface Tab {
   id: string;
   label: string;
-  lines: number;
   code: CodeLine[];
 }
 
@@ -27,7 +26,6 @@ const TABS: Tab[] = [
   {
     id: "vanilla",
     label: "vanilla TypeScript",
-    lines: 14,
     code: [
       { t: [["com", "// summarize.ts"]] },
       {
@@ -114,7 +112,6 @@ const TABS: Tab[] = [
   {
     id: "react",
     label: "React hook",
-    lines: 15,
     code: [
       { t: [["com", "// ArticleSummary.tsx"]] },
       {
@@ -216,7 +213,6 @@ const TABS: Tab[] = [
   {
     id: "raw",
     label: "raw browser API",
-    lines: 36,
     code: [
       { t: [["com", "// what the wrappers do for you"]] },
       { t: [] },
@@ -494,7 +490,7 @@ export const HowItWorks = () => {
             onClick={() => setTab(t.id)}
           >
             {t.label}
-            <span className="lines">{t.lines}L</span>
+            <span className="lines">{t.code.length}L</span>
           </button>
         ))}
       </div>

--- a/apps/landing/src/sdk-version.ts
+++ b/apps/landing/src/sdk-version.ts
@@ -1,4 +1,6 @@
-import sdkPackage from "../../../packages/sdk/package.json" with { type: "json" };
+import sdkPackage from "../../../packages/sdk/package.json" with {
+  type: "json",
+};
 
 /** Published @web-ai-sdk/all version; kept in sync via Changesets fixed group. */
 export const SDK_VERSION = sdkPackage.version;

--- a/apps/landing/src/sdk-version.ts
+++ b/apps/landing/src/sdk-version.ts
@@ -1,0 +1,4 @@
+import sdkPackage from "../../../packages/sdk/package.json" with { type: "json" };
+
+/** Published @web-ai-sdk/all version; kept in sync via Changesets fixed group. */
+export const SDK_VERSION = sdkPackage.version;


### PR DESCRIPTION
## Summary
- Read the landing footer version from `packages/sdk/package.json` so it stays in sync after Changesets releases
- Fix how-it-works tab line counts by deriving them from displayed code
- Tighten the how-it-works pitch copy (SDK vs raw API line contrast)

## Test plan
- [ ] Open landing page footer and confirm version matches `@web-ai-sdk/all` on npm
- [ ] Check how-it-works tabs show 15L / 17L / 37L badges
- [ ] Verify section copy reads cleanly in the pitch tone
- [ ] `pnpm --filter @web-ai-sdk-apps/landing build`