### PR TITLE
docs: frame the SDK as a thin shim over platform primitives

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,6 +32,8 @@ Lifecycle layer on purpose. Each package only manages session lifetime, cleanup,
 
 Decision heuristic for new code: *if it bonds two SDK packages, walks the DOM, or needs a third-party runtime, it doesn't belong in an SDK wrapper.* Higher-level compositions (block-level DOM translation, article skeleton extraction, detect-then-summarize chains) are consumer-code territory; the SDK ships primitives only.
 
+The bias is toward *less* code over time, not more. This is the same trajectory mature utility libraries follow as the platform catches up (lodash → native methods, moment/date-fns → `Temporal`): own only the lifecycle and ergonomics the raw API leaves rough, and let the wrapper thin out as the Built-in AI APIs stabilize. When in doubt about whether something belongs, default to leaving it out.
+
 Full rules in [`CONTRIBUTING.md` § Governance](./CONTRIBUTING.md#governance); user-facing version at [`apps/docs/src/content/docs/architecture.mdx`](./apps/docs/src/content/docs/architecture.mdx) ([web-ai-sdk.dev/docs/architecture/](https://web-ai-sdk.dev/docs/architecture/)).
 
 ---

--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ Browsers are shipping built-in AI APIs behind flags. The shape changes; the life
 
 **We ship that lifecycle layer.** Framework adapters, polyfills, UI primitives stay optional subpaths so they don't constrain your design system, framework, or styling stack. Pick the layers you need; skip the rest.
 
+This is the same shape mature utility libraries converge on as the platform catches up (lodash → native methods, moment/date-fns → `Temporal`): a thin shim over a native primitive that gets *thinner* as the primitive stabilizes. See [Architecture § Lineage](./apps/docs/src/content/docs/architecture.mdx) for the full reasoning.
+
 ## Install
 
 Pick the building blocks you need, or grab the whole suite in one install:

--- a/apps/docs/src/content/docs/architecture.mdx
+++ b/apps/docs/src/content/docs/architecture.mdx
@@ -68,6 +68,15 @@ These are **ergonomic defaults**, not opinions about *how* you build an app. The
 
 What you won't find in the SDK is anything that bonds multiple capabilities together, walks the DOM, or needs a runtime dependency. Those concerns live in consumer code — anything you'd want to compose is yours to write.
 
+## Lineage: thin shims over platform primitives
+
+This shape isn't novel, and that's the point. The most durable JS utility libraries trend toward becoming thin layers over a platform primitive, then shrink as the platform absorbs their surface:
+
+- **lodash** ceded most of its surface to native array and object methods.
+- **moment** is superseded by the `Temporal` proposal; **date-fns** is now [reorienting to be "Temporal-first"](https://x.com/kossnocorp/status/2056306289480020338): document where `Temporal` replaces a function outright, map the gaps it can't cover, and ship the rest as functions that operate directly on `Temporal` objects.
+
+`web-ai-sdk` starts from that endpoint instead of migrating toward it. The Built-in AI APIs are the primitive; the SDK only owns the lifecycle and ergonomics the primitive leaves rough (feature detection, session reuse, stream smoothing, safe cleanup). As the APIs stabilize, the right outcome is for this layer to get *thinner*, not fatter. If a capability graduates to needing nothing but the raw API, the corresponding wrapper has done its job.
+
 ## Summary
 
 The SDK in one line: **one package per browser capability, zero runtime deps, lifecycle layer only.**


### PR DESCRIPTION
## Summary

Adds a short philosophy/lineage framing to the docs, positioning `web-ai-sdk` in the same arc mature JS utility libraries follow as the platform catches up (lodash → native methods, moment/date-fns → `Temporal`): a thin shim over a native primitive that gets *thinner* as the primitive stabilizes.

- **`apps/docs/src/content/docs/architecture.mdx`**: new "Lineage: thin shims over platform primitives" section with the full reasoning, linking the date-fns "Temporal-first" direction as the timely example.
- **`README.md`** ("Why composable"): one-line pointer placing the SDK in that lineage, linking to the Architecture section.
- **`AGENTS.md`** (scope rule): contributor-facing note that the bias is toward *less* code over time, defaulting to leaving things out.

Prose-only across Markdown/MDX, so no Biome/typecheck/test impact.

## Test plan

- [ ] `pnpm docs` renders the new Architecture section and the external link resolves.
- [ ] README and AGENTS cross-references read correctly.