### PR TITLE
feat(prompt): session-resilience primitives (clone, PromptAbortError, omitResponseConstraintInput)

### DIFF
--- a/.changeset/prompt-session-resilience.md
+++ b/.changeset/prompt-session-resilience.md
@@ -1,0 +1,9 @@
+---
+"@web-ai-sdk/prompt": minor
+---
+
+Add session-resilience primitives to `@web-ai-sdk/prompt` so consumers can build a stable on-device agent without reaching into the native API.
+
+- **`Session.clone()`**: surface the native `LanguageModel` clone on the `Session` wrapper. Keep one warm base session (system prompt only) and fork a fresh-history clone per task, the spec's recommended pattern. This avoids both the cross-run "caching" of reusing a single long-lived session and the cold-instance degradation of repeated `create()` / `destroy()`. The clone is wrapped with the same delta-smoothing / abort / typed-error behavior, and its lifecycle is fully independent of the parent. Throws `PromptUnavailableError` if the browser instance lacks `clone()`.
+- **Export `PromptAbortError`**: it was thrown but not exported, forcing brittle `err.name` string matching. `ask()` and sessions now throw the same exported class, so consumers can `instanceof PromptAbortError`.
+- **`omitResponseConstraintInput`** on `SessionSendOptions` and `AskOptions`: forwards to the native prompt call to drop the inlined JSON Schema from the model's context (saves tokens) while the `responseConstraint` still shapes the output.

--- a/apps/docs/src/content/docs/guides/prompt.mdx
+++ b/apps/docs/src/content/docs/guides/prompt.mdx
@@ -101,11 +101,28 @@ const text = await session.send("And what about the Prompt API?");
 session.destroy();
 ```
 
-The wrapper is intentionally thin. It handles cross-browser smoothing every consumer would otherwise reimplement (delta-vs-cumulative chunk detection, output sanitization, abort wiring, typed unavailability) and forwards everything else to the native instance. It does **not** track conversation history, queue concurrent sends, or wrap `clone()` — those are your data model and UI concerns.
+The wrapper is intentionally thin. It handles cross-browser smoothing every consumer would otherwise reimplement (delta-vs-cumulative chunk detection, output sanitization, abort wiring, typed unavailability) and forwards everything else to the native instance. It does **not** track conversation history or queue concurrent sends; those are your data model and UI concerns. It does surface `clone()`, since forking a warm base session is the spec's recommended way to start a fresh task (see [Session resilience](#session-resilience-base--per-task-clone) below).
 
 `createSession()` never touches the `ask()` session cache. Two sessions with identical options get two independent instances with isolated history, system prompt, sampling, and lifecycle — `abort()` / `destroy()` on one session never touch another. Concurrent `send` / `sendStreaming` calls on the **same** session are NOT queued — the underlying `LanguageModel` is sequential per instance and will reject the overlapping call with `InvalidStateError`. Either `await` the previous send or call `session.abort()` before issuing a new turn.
 
 **Concurrency note.** Each session is an independent `LanguageModel` instance, but the underlying on-device model is single-instance. Chrome 148 / Edge 138 currently schedule `sendStreaming` calls across sessions FIFO: overlapping sends do not interleave token-by-token — the second send waits for the first to drain. This is a constraint of the runtime, not of the API; code written against `createSession()` becomes faster automatically if a future release exposes parallel inference.
+
+## Session resilience: base + per-task `clone()`
+
+For agents and multi-task flows there's a lose-lose with naive session handling: reuse one long-lived session and history accumulates (later runs start echoing earlier ones, and you eventually hit `QuotaExceededError`); recreate a session per task and you pay the cold start and can trip Chrome's single-instance degradation. Chrome's [session management guidance](https://developer.chrome.com/docs/ai/session-management) recommends a third way: keep one warm **base** session (system prompt only) and `clone()` it per task. The clone inherits the system prompt and history without re-parsing instructions or paying another `create()`, then gets its own independent history and lifecycle.
+
+```ts
+const base = createSession({ systemPrompt }); // create once; keep warm
+// per task / run:
+const turn = await base.clone();              // fresh history, no re-parse
+try {
+  for await (const delta of turn.sendStreaming(input)) render(delta);
+} finally {
+  turn.destroy();                             // free the clone, keep the base warm
+}
+```
+
+`clone()` throws `SessionDestroyedError` if the base has been destroyed, and `PromptUnavailableError` if the underlying browser instance doesn't support cloning. The clone is fully independent: destroying it never affects the base, and vice versa. The React `useSession` hook returns the `Session` directly, so `session.clone()` is available there too.
 
 ## How it works
 
@@ -166,6 +183,8 @@ const parsed = JSON.parse(result.output ?? "{}");
 
 The wrapper passes `responseConstraint` straight through to `session.prompt()` / `session.promptStreaming()`. Support depends on your Chrome version.
 
+By default the schema is inlined into the prompt context, which costs tokens. Pass `omitResponseConstraintInput: true` (on `ask()` or `SessionSendOptions`) to drop it; the constraint still shapes the output, but you should then include format guidance in the prompt text itself. The flag is only forwarded when `responseConstraint` is also set — the native API throws a `TypeError` otherwise, so the wrapper ignores it on its own.
+
 ## Aborting
 
 `AbortSignal` is supported on every surface. Aborting mid-stream resolves cleanly; an opt-in result cache is not written for aborted runs:
@@ -177,6 +196,19 @@ setTimeout(() => controller.abort(), 1000);
 ```
 
 For sessions, call `session.abort()` to stop the most recent in-flight `send` / `sendStreaming`, or `session.destroy()` to tear down the underlying instance.
+
+Aborted runs reject with `PromptAbortError` (exported from the package). Both `ask()` and sessions throw the same class, so `err instanceof PromptAbortError` works; its `name` is `"AbortError"` for compatibility with standard abort handling.
+
+```ts
+import { ask, PromptAbortError } from "@web-ai-sdk/prompt";
+
+try {
+  await ask({ input: "…", signal });
+} catch (err) {
+  if (err instanceof PromptAbortError) return; // user cancelled
+  throw err;
+}
+```
 
 ## Errors and unavailability
 

--- a/apps/docs/src/content/docs/react/use-session.mdx
+++ b/apps/docs/src/content/docs/react/use-session.mdx
@@ -72,6 +72,26 @@ function ChatPane({ agent }: { agent: Agent }) {
 }
 ```
 
+## Forking with `clone()` (agents / multi-task)
+
+`session` is the vanilla `Session`, so `session.clone()` is available in React too. For agents that run many tasks against one persona, keep the `useSession` base warm (system prompt only) and clone it per task so each run gets fresh history without re-parsing the system prompt. See [Session resilience](/docs/guides/prompt/#session-resilience-base--per-task-clone) for the full rationale.
+
+```tsx
+const { session } = useSession({ systemPrompt });
+
+const runTask = async (input: string) => {
+  if (!session) return;
+  const turn = await session.clone(); // fresh history, base stays warm
+  try {
+    for await (const delta of turn.sendStreaming(input)) render(delta);
+  } finally {
+    turn.destroy();
+  }
+};
+```
+
+Destroying a clone never affects the base session. The hook still owns the base session's lifecycle (destroyed on unmount / option change); clones you create are yours to destroy.
+
 ## Return shape
 
 ```ts
@@ -153,6 +173,7 @@ interface Session {
   send(input: string): Promise<string>;
   sendStreaming(input: string): AsyncIterable<string>; // yields deltas, not cumulative
   abort(): void;
+  clone(options?: { signal?: AbortSignal }): Promise<Session>;
   destroy(): void;
 }
 

--- a/packages/prompt/README.md
+++ b/packages/prompt/README.md
@@ -178,16 +178,42 @@ interface CreateSessionOptions {
   createOptions?: Partial<LanguageModelCreateOptions>;
 }
 
+interface SessionSendOptions {
+  signal?: AbortSignal;
+  responseConstraint?: object;        // JSON Schema for structured output
+  omitResponseConstraintInput?: boolean; // drop the inlined schema to save tokens
+}
+
 interface Session {
   readonly destroyed: boolean;
   send(input: string, options?: SessionSendOptions): Promise<string | null>;
   sendStreaming(input: string, options?: SessionSendOptions): AsyncIterable<string>;
   abort(): void;
+  clone(options?: { signal?: AbortSignal }): Promise<Session>;
   destroy(): void;
 }
 ```
 
 `Session.sendStreaming()` yields **deltas** (each chunk is the new text since the last yield, never cumulative). The wrapper does no extra bookkeeping: no history tracking, no concurrent-send queue, no usage telemetry. Always destroy sessions you no longer need.
+
+`omitResponseConstraintInput` is only forwarded when `responseConstraint` is also set; the native API throws a `TypeError` otherwise. When you omit the schema, include format guidance in the prompt text itself (the model no longer sees the schema).
+
+### Session resilience: base + per-task `clone()`
+
+For agents and multi-task flows, reusing one long-lived session lets history accumulate (later runs "echo" earlier ones, and you eventually hit `QuotaExceededError`), while recreating a session per task pays the cold start and can hit Chrome's single-instance degradation. The spec's [recommended pattern](https://developer.chrome.com/docs/ai/session-management) is to keep one warm **base** session (system prompt only) and `clone()` it per task: the clone inherits the system prompt and history without re-parsing or another `create()`, then gets independent history and lifecycle.
+
+```ts
+const base = createSession({ systemPrompt }); // once; keep warm
+// per task / run:
+const turn = await base.clone();              // fresh history, no re-parse
+try {
+  for await (const delta of turn.sendStreaming(input)) render(delta);
+} finally {
+  turn.destroy();                             // free the clone, keep base
+}
+```
+
+`clone()` throws `SessionDestroyedError` if the base is destroyed and `PromptUnavailableError` if the browser instance doesn't support cloning. Destroying a clone never affects the base, and vice versa.
 
 ### `useSession(options?): UseSessionReturn`
 
@@ -253,7 +279,7 @@ The vanilla `ask()` throws `PromptUnavailableError` when the API is missing or r
 
 `createSession()` returns a `Session` synchronously even if the underlying `create()` rejects; the error surfaces on the first `send` / `sendStreaming`.
 
-`AbortSignal` is supported on every surface. Aborting mid-stream resolves cleanly; the result cache is not written for aborted runs.
+`AbortSignal` is supported on every surface. Aborting mid-stream resolves cleanly; the result cache is not written for aborted runs. Aborts reject with `PromptAbortError` (exported; `instanceof PromptAbortError` works, and its `name` is `"AbortError"`), thrown by both `ask()` and sessions.
 
 ## License
 

--- a/packages/prompt/src/api.ts
+++ b/packages/prompt/src/api.ts
@@ -51,7 +51,8 @@ export interface LanguageModelPromptOptions {
   /**
    * When `responseConstraint` is set, omit the inlined JSON Schema from the
    * model's prompt context. Saves tokens on every call when the schema is
-   * large; the constraint still shapes the output.
+   * large; the constraint still shapes the output. The native API throws a
+   * `TypeError` if this is set without a `responseConstraint`.
    */
   omitResponseConstraintInput?: boolean;
 }

--- a/packages/prompt/src/api.ts
+++ b/packages/prompt/src/api.ts
@@ -48,6 +48,12 @@ export interface LanguageModelCreateOptions {
 export interface LanguageModelPromptOptions {
   signal?: AbortSignal;
   responseConstraint?: object;
+  /**
+   * When `responseConstraint` is set, omit the inlined JSON Schema from the
+   * model's prompt context. Saves tokens on every call when the schema is
+   * large; the constraint still shapes the output.
+   */
+  omitResponseConstraintInput?: boolean;
 }
 
 export interface LanguageModelInstance {

--- a/packages/prompt/src/index.test.ts
+++ b/packages/prompt/src/index.test.ts
@@ -358,6 +358,15 @@ describe("createSession", () => {
     );
     session.destroy();
   });
+
+  it("drops omitResponseConstraintInput when no responseConstraint is set (native would throw)", async () => {
+    const fake = installFakeLanguageModel({ response: "ok" });
+    const session = createSession();
+    await session.send("hi", { omitResponseConstraintInput: true });
+    const opts = fake.promptSpy.mock.calls[0]?.[1] as Record<string, unknown>;
+    expect(opts).not.toHaveProperty("omitResponseConstraintInput");
+    session.destroy();
+  });
 });
 
 describe("Session.clone", () => {

--- a/packages/prompt/src/index.test.ts
+++ b/packages/prompt/src/index.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { __clearSessionCacheForTests } from "./api.js";
 import {
+  PromptAbortError,
   PromptUnavailableError,
   type ResponseCache,
   ask,
@@ -339,5 +340,111 @@ describe("createSession", () => {
     await Promise.all([session.send("a"), session.send("b")]);
     expect(maxActive).toBe(2);
     session.destroy();
+  });
+
+  it("forwards omitResponseConstraintInput to the native prompt options", async () => {
+    const fake = installFakeLanguageModel({ response: "ok" });
+    const session = createSession();
+    await session.send("hi", {
+      responseConstraint: { type: "object" },
+      omitResponseConstraintInput: true,
+    });
+    expect(fake.promptSpy).toHaveBeenCalledWith(
+      "hi",
+      expect.objectContaining({
+        responseConstraint: { type: "object" },
+        omitResponseConstraintInput: true,
+      }),
+    );
+    session.destroy();
+  });
+});
+
+describe("Session.clone", () => {
+  it("forks via the native instance.clone() and the clone works independently", async () => {
+    const parentDestroy = vi.fn();
+    const childDestroy = vi.fn();
+    const cloneSpy = vi.fn(async () => ({
+      prompt: vi.fn(async () => "child reply"),
+      destroy: childDestroy,
+    }));
+    installFakeLanguageModel({
+      sessionFactory: () => ({
+        prompt: vi.fn(async () => "parent reply"),
+        destroy: parentDestroy,
+        clone: cloneSpy,
+      }),
+    });
+
+    const base = createSession({ systemPrompt: "S" });
+    await base.send("warm"); // force the underlying create()
+    const turn = await base.clone();
+    expect(cloneSpy).toHaveBeenCalledTimes(1);
+    expect(await turn.send("go")).toBe("child reply");
+
+    // Destroying the clone tears down the child instance, not the parent.
+    turn.destroy();
+    await Promise.resolve();
+    expect(childDestroy).toHaveBeenCalledTimes(1);
+    expect(parentDestroy).not.toHaveBeenCalled();
+
+    // The base session still works after the clone is gone.
+    expect(await base.send("again")).toBe("parent reply");
+    base.destroy();
+  });
+
+  it("throws PromptUnavailableError when the instance has no clone()", async () => {
+    installFakeLanguageModel({
+      sessionFactory: () => ({ prompt: vi.fn(async () => "x") }),
+    });
+    const base = createSession();
+    await base.send("warm");
+    await expect(base.clone()).rejects.toBeInstanceOf(PromptUnavailableError);
+    base.destroy();
+  });
+
+  it("throws SessionDestroyedError when cloning a destroyed session", async () => {
+    installFakeLanguageModel({
+      sessionFactory: () => ({
+        prompt: vi.fn(async () => "x"),
+        clone: vi.fn(),
+        destroy: vi.fn(),
+      }),
+    });
+    const base = createSession();
+    await base.send("warm");
+    base.destroy();
+    await expect(base.clone()).rejects.toMatchObject({
+      name: "SessionDestroyedError",
+    });
+  });
+});
+
+describe("PromptAbortError", () => {
+  it("is exported and an aborted send rejects with an instance of it", async () => {
+    installFakeLanguageModel({
+      sessionFactory: () => ({
+        prompt: vi.fn(async () => {
+          await new Promise((r) => setTimeout(r, 20));
+          return "late";
+        }),
+        destroy: vi.fn(),
+      }),
+    });
+    const session = createSession();
+    const controller = new AbortController();
+    const pending = session.send("hi", { signal: controller.signal });
+    controller.abort();
+    await expect(pending).rejects.toBeInstanceOf(PromptAbortError);
+    session.destroy();
+  });
+
+  it("is the same error ask() throws on abort (instanceof works)", async () => {
+    installFakeLanguageModel({ chunks: ["a", "b"] });
+    const controller = new AbortController();
+    controller.abort();
+    await expect(
+      ask({ input: "hi", signal: controller.signal, cache: inMemoryCache() }),
+    ).rejects.toBeInstanceOf(PromptAbortError);
   });
 });

--- a/packages/prompt/src/index.ts
+++ b/packages/prompt/src/index.ts
@@ -18,6 +18,7 @@ import {
   type LanguageModelInstance,
   type LanguageModelMessage,
   type LanguageModelParams,
+  type LanguageModelPromptOptions,
   checkAvailability,
   getLanguageModelApi,
   getOrCreateLanguageModel,
@@ -32,6 +33,7 @@ import {
 } from "./cache.js";
 import {
   type CreateSessionOptions,
+  PromptAbortError,
   PromptUnavailableError,
   type Session,
   SessionDestroyedError,
@@ -46,6 +48,7 @@ export {
   isAvailable,
   checkAvailability,
   createSession,
+  PromptAbortError,
   PromptUnavailableError,
   SessionDestroyedError,
 };
@@ -90,6 +93,12 @@ export interface AskOptions {
   /** Optional JSON Schema for structured output. */
   responseConstraint?: object;
   /**
+   * When `responseConstraint` is set, omit the inlined JSON Schema from the
+   * model's prompt context to save tokens. The constraint still shapes the
+   * output.
+   */
+  omitResponseConstraintInput?: boolean;
+  /**
    * Result cache. Off by default; every call hits the model. Pass
    * `"session"` / `"local"` for the matching web-storage shortcut, or any
    * `{ get, set }`-shaped object for a custom backend.
@@ -112,13 +121,6 @@ export interface AskResult {
   output: string | null;
   /** Whether the result came from the cache (no model call). */
   cached: boolean;
-}
-
-class PromptAbortError extends Error {
-  override readonly name = "AbortError";
-  constructor() {
-    super("Prompt aborted");
-  }
 }
 
 /**
@@ -214,10 +216,12 @@ export const ask = async (options: AskOptions): Promise<AskResult> => {
   }
   if (options.signal?.aborted) throw new PromptAbortError();
 
-  const promptOpts: { signal?: AbortSignal; responseConstraint?: object } = {};
+  const promptOpts: LanguageModelPromptOptions = {};
   if (options.signal) promptOpts.signal = options.signal;
   if (options.responseConstraint)
     promptOpts.responseConstraint = options.responseConstraint;
+  if (options.omitResponseConstraintInput)
+    promptOpts.omitResponseConstraintInput = true;
 
   let finalText: string;
   if (typeof session.promptStreaming === "function") {

--- a/packages/prompt/src/index.ts
+++ b/packages/prompt/src/index.ts
@@ -95,7 +95,9 @@ export interface AskOptions {
   /**
    * When `responseConstraint` is set, omit the inlined JSON Schema from the
    * model's prompt context to save tokens. The constraint still shapes the
-   * output.
+   * output. Ignored unless `responseConstraint` is also set (the native API
+   * would otherwise throw). When omitting, include format guidance in the
+   * prompt text itself.
    */
   omitResponseConstraintInput?: boolean;
   /**
@@ -218,10 +220,13 @@ export const ask = async (options: AskOptions): Promise<AskResult> => {
 
   const promptOpts: LanguageModelPromptOptions = {};
   if (options.signal) promptOpts.signal = options.signal;
-  if (options.responseConstraint)
+  if (options.responseConstraint) {
     promptOpts.responseConstraint = options.responseConstraint;
-  if (options.omitResponseConstraintInput)
-    promptOpts.omitResponseConstraintInput = true;
+    // The native call throws a TypeError when omitResponseConstraintInput is
+    // set without a responseConstraint, so only forward it alongside one.
+    if (options.omitResponseConstraintInput)
+      promptOpts.omitResponseConstraintInput = true;
+  }
 
   let finalText: string;
   if (typeof session.promptStreaming === "function") {

--- a/packages/prompt/src/session.ts
+++ b/packages/prompt/src/session.ts
@@ -13,8 +13,10 @@
  * every consumer would otherwise reimplement (delta-vs-cumulative chunk
  * detection, output sanitization, abort composition, typed unavailability)
  * and forwards everything else to the native instance. It does NOT track
- * conversation history, queue concurrent sends, or wrap `clone()` — those
- * are the consumer's data model and UI concerns.
+ * conversation history or queue concurrent sends; those are the consumer's
+ * data model and UI concerns. It does surface `clone()`, since forking a warm
+ * base session is the spec's recommended way to start a fresh task without
+ * re-parsing the system prompt or paying another `create()`.
  */
 
 import {
@@ -23,6 +25,7 @@ import {
   type LanguageModelExpectedInput,
   type LanguageModelExpectedOutput,
   type LanguageModelInstance,
+  type LanguageModelPromptOptions,
   getLanguageModelApi,
 } from "./api.js";
 
@@ -155,6 +158,12 @@ export interface CreateSessionOptions {
 export interface SessionSendOptions {
   signal?: AbortSignal;
   responseConstraint?: object;
+  /**
+   * When `responseConstraint` is set, omit the inlined JSON Schema from the
+   * model's prompt context. Saves tokens on every turn when the schema is
+   * large; the constraint still shapes the output.
+   */
+  omitResponseConstraintInput?: boolean;
 }
 
 export interface Session {
@@ -172,6 +181,19 @@ export interface Session {
   ): AsyncIterable<string>;
   /** Abort the most recent in-flight `send` / `sendStreaming`. No-op when idle. */
   abort(): void;
+  /**
+   * Fork this session. The clone inherits the parent's system prompt and
+   * conversation history up to this point, but gets independent history,
+   * abort, and lifecycle from here on. Cloning a base session (system prompt
+   * only) is the recommended way to start a fresh task without re-parsing
+   * instructions or paying another `create()`.
+   *
+   * Throws `SessionDestroyedError` if the parent is destroyed, and
+   * `PromptUnavailableError` if the underlying browser instance doesn't
+   * support `clone()`. Destroying the clone never affects the parent, and
+   * vice versa.
+   */
+  clone(options?: { signal?: AbortSignal }): Promise<Session>;
   /** Tear down the underlying instance and refuse further sends. Idempotent. */
   destroy(): void;
 }
@@ -266,11 +288,13 @@ const wrapInstance = (internal: Promise<SessionInternal>): Session => {
     ensureLive();
 
     const { controller, cleanup } = setupController(options?.signal);
-    const promptOpts: { signal: AbortSignal; responseConstraint?: object } = {
+    const promptOpts: LanguageModelPromptOptions = {
       signal: controller.signal,
     };
     if (options?.responseConstraint)
       promptOpts.responseConstraint = options.responseConstraint;
+    if (options?.omitResponseConstraintInput)
+      promptOpts.omitResponseConstraintInput = true;
 
     try {
       const raw = await instance.prompt(input, promptOpts);
@@ -298,11 +322,13 @@ const wrapInstance = (internal: Promise<SessionInternal>): Session => {
       ensureLive();
 
       const { controller, cleanup } = setupController(options?.signal);
-      const promptOpts: { signal: AbortSignal; responseConstraint?: object } = {
+      const promptOpts: LanguageModelPromptOptions = {
         signal: controller.signal,
       };
       if (options?.responseConstraint)
         promptOpts.responseConstraint = options.responseConstraint;
+      if (options?.omitResponseConstraintInput)
+        promptOpts.omitResponseConstraintInput = true;
 
       try {
         if (typeof instance.promptStreaming === "function") {
@@ -341,6 +367,33 @@ const wrapInstance = (internal: Promise<SessionInternal>): Session => {
     currentController?.abort();
   };
 
+  const clone = async (cloneOptions?: {
+    signal?: AbortSignal;
+  }): Promise<Session> => {
+    ensureLive();
+    const { instance, api } = await ready;
+    ensureLive();
+    if (typeof instance.clone !== "function") {
+      throw new PromptUnavailableError(
+        "This LanguageModel instance does not support clone() in this browser.",
+      );
+    }
+    try {
+      const cloned = await instance.clone(
+        cloneOptions?.signal ? { signal: cloneOptions.signal } : undefined,
+      );
+      // Wrap the clone with the same smoothing / abort / typed-error behavior.
+      // It owns an independent native instance, so its history, abort, and
+      // destroy lifecycle are fully decoupled from this (parent) session.
+      return wrapInstance(Promise.resolve({ instance: cloned, api }));
+    } catch (err) {
+      if ((err as { name?: string })?.name === "AbortError") {
+        throw new PromptAbortError();
+      }
+      throw err;
+    }
+  };
+
   const destroy = (): void => {
     if (destroyed) return;
     destroyed = true;
@@ -366,6 +419,7 @@ const wrapInstance = (internal: Promise<SessionInternal>): Session => {
     send,
     sendStreaming,
     abort,
+    clone,
     destroy,
   };
 };

--- a/packages/prompt/src/session.ts
+++ b/packages/prompt/src/session.ts
@@ -161,7 +161,9 @@ export interface SessionSendOptions {
   /**
    * When `responseConstraint` is set, omit the inlined JSON Schema from the
    * model's prompt context. Saves tokens on every turn when the schema is
-   * large; the constraint still shapes the output.
+   * large; the constraint still shapes the output. Ignored unless
+   * `responseConstraint` is also set (the native API would otherwise throw).
+   * When omitting, include format guidance in the prompt text itself.
    */
   omitResponseConstraintInput?: boolean;
 }
@@ -291,10 +293,13 @@ const wrapInstance = (internal: Promise<SessionInternal>): Session => {
     const promptOpts: LanguageModelPromptOptions = {
       signal: controller.signal,
     };
-    if (options?.responseConstraint)
+    if (options?.responseConstraint) {
       promptOpts.responseConstraint = options.responseConstraint;
-    if (options?.omitResponseConstraintInput)
-      promptOpts.omitResponseConstraintInput = true;
+      // The native call throws a TypeError when omitResponseConstraintInput
+      // is set without a responseConstraint, so only forward it alongside one.
+      if (options.omitResponseConstraintInput)
+        promptOpts.omitResponseConstraintInput = true;
+    }
 
     try {
       const raw = await instance.prompt(input, promptOpts);
@@ -325,10 +330,13 @@ const wrapInstance = (internal: Promise<SessionInternal>): Session => {
       const promptOpts: LanguageModelPromptOptions = {
         signal: controller.signal,
       };
-      if (options?.responseConstraint)
+      if (options?.responseConstraint) {
         promptOpts.responseConstraint = options.responseConstraint;
-      if (options?.omitResponseConstraintInput)
-        promptOpts.omitResponseConstraintInput = true;
+        // The native call throws a TypeError when omitResponseConstraintInput
+        // is set without a responseConstraint, so only forward it with one.
+        if (options.omitResponseConstraintInput)
+          promptOpts.omitResponseConstraintInput = true;
+      }
 
       try {
         if (typeof instance.promptStreaming === "function") {


### PR DESCRIPTION
## Summary

Adds the small set of `@web-ai-sdk/prompt` capabilities a stable on-device agent needs, so consumers don't have to reach into the native API. Surface verified against the official [Chrome Prompt API docs](https://developer.chrome.com/docs/ai/prompt-api) and the [W3C prompt-api spec](https://webmachinelearning.github.io/prompt-api/) (the base Prompt API is Chrome 148 stable, no flag).

- **`Session.clone()`** — surface the native `LanguageModel` clone on the `Session` wrapper, with the same delta-smoothing / abort / typed-error behavior and a fully independent lifecycle. Enables the spec's base-session + per-task-clone pattern (keep the system prompt warm, fork fresh history per task), sidestepping both single-session history cross-bleed and the cold-instance degradation of repeated `create()`/`destroy()`. Throws `PromptUnavailableError` when the browser instance lacks `clone()`.
- **Export `PromptAbortError`** — it was thrown but not exported, forcing brittle `err.name` string matching. De-duplicated the private copy in `index.ts`; `ask()` and sessions now throw the same exported class (`instanceof` works).
- **`omitResponseConstraintInput`** on `SessionSendOptions` and `AskOptions` — forwarded to the native prompt call to drop the inlined JSON Schema from context and save tokens. Guarded: only forwarded alongside a `responseConstraint`, since the native API throws `TypeError` otherwise.

Docs added in the prompt README, the guide (new "Session resilience" section), and `useSession` (clone is available since the hook returns the raw `Session`).

Ships in the next release (0.5.0 via the fixed group). Independent of #23; both target `main`.

## Test plan

- [x] `pnpm gate` green (lint, build, typecheck, test)
- [x] Prompt package: 43 tests (clone fork/independence/unsupported/destroyed-parent, `PromptAbortError instanceof` for sessions and `ask()`, omit passthrough + dropped-without-constraint)
- [ ] Manual: base + clone-per-task loop in Chrome 148; confirm cross-run echo disappears without recreating the instance