### PR TITLE
docs: surface the platform-relationship framing earlier

### DIFF
--- a/apps/docs/src/content/docs/index.mdx
+++ b/apps/docs/src/content/docs/index.mdx
@@ -23,10 +23,22 @@ import { Card, CardGrid } from "@astrojs/starlight/components";
 
 **`web-ai-sdk`** ships building blocks for the Web's Built-in AI APIs. One package per browser capability (Prompt, WebMCP, Summarizer, Translator, Detector, Writer, Rewriter, Proofreader). Zero runtime dependencies. Vanilla TypeScript by default, with optional React hooks. See [Architecture](/docs/architecture/) for the model.
 
+You can always use the raw browser APIs directly; the SDK doesn't replace or hide them. It just owns the lifecycle layer around them (session reuse, streaming, AbortSignals, feature-detected fallbacks) and is built to get thinner as the platform matures.
+
 Compositions that bond multiple primitives (block-level DOM translation,
 article-aware summarization, detect-then-summarize chains) are
 deliberately out of scope — the SDK wraps one capability per package;
 composition is your code.
+
+## Why not just use the APIs directly?
+
+You can, and nothing here stops you. The browser's built-in AI APIs are the foundation; web-ai-sdk owns the thin, repetitive lifecycle layer you'd otherwise rewrite in every component, and nothing more.
+
+- **It's the same APIs.** Drop down to `LanguageModel`, `Summarizer`, `Writer`, and friends whenever you want. No lock-in, no wrapper objects you can't escape.
+- **What you'd otherwise rebuild.** Feature detection, session reuse, delta-vs-cumulative stream smoothing, AbortSignal cleanup, and feature-detected no-op fallbacks when the API is missing.
+- **It's built to shrink.** As the platform absorbs more, this layer gets thinner, not fatter. The goal is to do less over time, not more.
+
+[Why this layer is designed to get thinner over time →](/docs/architecture/#lineage-thin-shims-over-platform-primitives)
 
 ## Composable wrappers. One philosophy.
 

--- a/apps/landing/src/App.tsx
+++ b/apps/landing/src/App.tsx
@@ -137,6 +137,7 @@ export const App = () => (
           <span className={caret} />
         </a>
         <div className={navLinks}>
+          <a href="#why-raw">Why not raw?</a>
           <a href="#packages">Packages</a>
           <a href="#philosophy">Why composable</a>
           <a href="#how">How</a>
@@ -174,6 +175,11 @@ export const App = () => (
             Vanilla TypeScript by default, with optional React hooks.
           </span>
         </p>
+
+        <a className={`${pkgDocs} w-fit`} href="#how">
+          See the same task: 15 lines with the SDK vs 37 with the raw APIs
+          <span className={pkgDocsArrow}>→</span>
+        </a>
 
         <div className={ctaRow}>
           <a className={`${btnPrimary} group`} href="#start">
@@ -227,6 +233,65 @@ export const App = () => (
         </div>
       </div>
     </header>
+
+    {/* Why not the raw APIs? */}
+    <section className={section} data-section="why-raw">
+      <div className={container}>
+        <div className={`${sectionHead} ${sectionAnchor}`} id="why-raw">
+          <div>
+            <div className={sectionEyebrow}>00 · the question</div>
+            <h2 className="mt-2">Why not just use the APIs directly?</h2>
+          </div>
+          <a className={permalink} href="#why-raw">
+            <span aria-hidden="true">§</span>
+            <span className={srOnly}>
+              Link to the why-not-the-raw-APIs section
+            </span>
+          </a>
+        </div>
+        <div className={`${twoCol} ${reveal}`} data-reveal>
+          <div>
+            <p className={subhead}>
+              You can, and nothing here stops you. The browser's built-in AI
+              APIs are the foundation. <em>web-ai-sdk</em> owns the thin,
+              repetitive lifecycle layer you'd otherwise rewrite in every
+              component, and nothing more.
+            </p>
+            <a
+              className={`${pkgDocs} mt-6`}
+              href={`${DOCS_URL}architecture/#lineage-thin-shims-over-platform-primitives`}
+            >
+              Why this layer is designed to get thinner over time
+              <span className={pkgDocsArrow}>→</span>
+            </a>
+          </div>
+          <ul className={`${pkgBullets} mb-0 self-center`}>
+            <li>
+              <span>
+                <b>It's the same APIs.</b> Drop down to{" "}
+                <code>LanguageModel</code>, <code>Summarizer</code>,{" "}
+                <code>Writer</code> and friends whenever you want. No lock-in,
+                no wrapper objects you can't escape.
+              </span>
+            </li>
+            <li>
+              <span>
+                <b>What you'd otherwise rebuild.</b> Feature detection, session
+                reuse, delta-vs-cumulative stream smoothing, AbortSignal
+                cleanup, and feature-detected no-op fallbacks.
+              </span>
+            </li>
+            <li>
+              <span>
+                <b>It's built to shrink.</b> As the platform absorbs more, this
+                layer gets thinner, not fatter. The goal is to do less over
+                time.
+              </span>
+            </li>
+          </ul>
+        </div>
+      </div>
+    </section>
 
     {/* Packages */}
     <section className={section} data-section="packages">
@@ -879,7 +944,7 @@ export const App = () => (
           <div>
             <div className={sectionEyebrow}>03 · how it works</div>
             <h2 className="mt-2">Same task. Three levels of abstraction.</h2>
-            <p className="mt-3.5 max-w-[60ch]">
+            <p className="mt-3.5">
               All three tabs do the same thing: detect an article's language and
               summarize it into key-points. Fifteen lines with the SDK;
               thirty-seven calling the browser APIs yourself. Same result, less
@@ -904,7 +969,7 @@ export const App = () => (
           <div>
             <div className={sectionEyebrow}>04 · support</div>
             <h2 className="mt-2">Browser support.</h2>
-            <p className="mt-3.5 max-w-[60ch]">
+            <p className="mt-3.5">
               Built-in AI lands engine by engine. Where it isn't there yet, you
               get a feature-detected no-op so your code doesn't crash; render
               whatever fallback UI you want.


### PR DESCRIPTION
## Summary

Answers "what's wrong with using the underlying APIs as they are?" near the top of the funnel, instead of only in the philosophy / how-it-works sections and the buried architecture "Lineage" section.

- **Landing**: new **"Why not just use the APIs directly?"** band before the packages section (two-column lead + three bullets: it's the same APIs / what you'd otherwise rebuild / built to shrink), a hero link to the 15-vs-37 comparison, a nav entry, and an on-ramp link into the architecture "Lineage" section.
- **Docs index**: the same concession added to "What it is", plus a matching "Why not just use the APIs directly?" section.
- Made the how-it-works and browser-support section descriptions full-width.

Copy/markup only. No package changes, so no changeset (the apps are in the Changesets `ignore` list). Does not affect the 0.5.0 version.

## Test plan

- [x] `pnpm lint` clean
- [x] `pnpm build` + landing/docs typecheck (0 errors)
- [ ] Manual: eyeball the landing hero, the new band, and the full-width descriptions