### PR TITLE
ci(release): provide NPM_TOKEN for first publish of new packages

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,3 +51,10 @@ jobs:
           title: "chore: version packages"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # A brand-new package can't use OIDC Trusted Publishing on its first
+          # publish (you can't configure a Trusted Publisher before the package
+          # exists). changesets/action uses NPM_TOKEN when present and falls
+          # back to OIDC otherwise, so provide a token for the initial publish.
+          # Token auth works for the existing packages too, and provenance is
+          # still generated via the `id-token: write` permission above.
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary

The 0.5.0 release failed because OIDC Trusted Publishing can't authenticate the **first** publish of a package that doesn't exist on npm yet (you can't configure a Trusted Publisher for a non-existent package). Adding `@web-ai-sdk/writer`, `rewriter`, and `proofreader` introduced three such first-time publishes.

The release run confirmed it: `No NPM_TOKEN found, but OIDC is available - using npm trusted publishing`.

Fix: expose the repo's `NPM_TOKEN` secret to the `changesets/action` step. The action uses `NPM_TOKEN` when present and falls back to OIDC otherwise. Token auth covers the existing packages too, and provenance still works via the existing `id-token: write` permission.

After this first token-based publish, Trusted Publishers can be configured for the three new packages and the token dropped to return to pure OIDC if desired.

## Test plan

- [ ] Merge to main re-triggers Release; `changeset publish` (idempotent) publishes the 0.5.0 packages not already on npm
- [ ] `npm view @web-ai-sdk/writer version` returns `0.5.0` (and rewriter/proofreader)