### PR TITLE
ci(release): revert to pure OIDC; document local first-publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,10 +51,3 @@ jobs:
           title: "chore: version packages"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # A brand-new package can't use OIDC Trusted Publishing on its first
-          # publish (you can't configure a Trusted Publisher before the package
-          # exists). changesets/action uses NPM_TOKEN when present and falls
-          # back to OIDC otherwise, so provide a token for the initial publish.
-          # Token auth works for the existing packages too, and provenance is
-          # still generated via the `id-token: write` permission above.
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -188,6 +188,8 @@ The marketing site uses **Tailwind CSS v4**. Full guardrails: [`apps/landing/REA
 7. `pnpm changeset` to record the new package for the next release.
 8. `pnpm gate` to verify everything is wired up.
 
+Note: a brand-new package's **first** publish must be done locally; CI can't create it. See [Cut a release](#cut-a-release).
+
 ### Add a React-only feature to an existing package
 
 1. Land the logic in `src/index.ts` first. The vanilla core is the source of truth.
@@ -200,9 +202,21 @@ The marketing site uses **Tailwind CSS v4**. Full guardrails: [`apps/landing/REA
 
 ### Cut a release
 
-1. `pnpm changeset` and pick the bump kind for each touched package.
-2. Commit the generated changeset markdown.
-3. Open a PR; on merge, `pnpm release` (or a release workflow) runs `pnpm build && changeset publish`.
+Releases are automated by the [`changesets/action`](.github/workflows/release.yml) and publish through **npm Trusted Publishing (OIDC)** — there is intentionally no `NPM_TOKEN` secret in the workflow.
+
+1. `pnpm changeset` and pick the bump kind for each touched package; commit the generated markdown.
+2. Open a PR. When it merges to `main`, the release workflow opens (or updates) a **"chore: version packages"** PR that runs `pnpm version-packages` (bumps versions, writes CHANGELOGs, consumes the changesets).
+3. Merge the "Version Packages" PR. That triggers `pnpm release` (`pnpm build && changeset publish`), publishing every package whose version isn't yet on npm. `changeset publish` is idempotent, so re-runs are safe.
+
+**The first publish of a brand-new package must be done locally — CI cannot create it.** OIDC Trusted Publishing can't authenticate a package that doesn't exist yet (you can't configure a Trusted Publisher before the package exists), and a CI npm token can't *create* a new package in the `@web-ai-sdk` org either (npm returns a masked `404 Not Found` on the initial `PUT`). So the very first publish of each new package is manual:
+
+```sh
+npm login                 # as a @web-ai-sdk org member (handles 2FA)
+pnpm build
+cd packages/<new> && npm publish --access public --provenance=false
+```
+
+Provenance is disabled for that first manual publish because it requires CI/OIDC; subsequent CI releases generate it. Once the package exists, set up a Trusted Publisher for it at `npmjs.com/package/@web-ai-sdk/<new>/access` (point it at this repo + `release.yml`), and every future version publishes automatically via the workflow above. This is why pre-existing packages release through CI with no token, while a new package's `0.x.0` debut is hand-published.
 
 ---
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,8 +52,9 @@ For the time being these rules are enforced by review, not by CI. If you open a 
 3. Add the package to the Pages docs (`apps/docs/src/content/docs/guides/<name>.mdx`, `apps/docs/src/content/docs/react/use-<name>.mdx`, plus a demo component) and to the landing's package row.
 4. Add a changeset.
 5. Run `pnpm gate`.
+6. **Publish the first version locally.** A brand-new package can't be created by CI (OIDC Trusted Publishing needs the package to already exist, and a CI token can't create new `@web-ai-sdk` packages — npm returns a masked `404`). Do the initial publish by hand: `npm login`, `pnpm build`, then `cd packages/<new> && npm publish --access public --provenance=false`. After that, set up a Trusted Publisher for it on npm and CI handles every later version.
 
-See [`AGENTS.md` § "Add a new tool / wrapper package"](./AGENTS.md#add-a-new-tool--wrapper-package) for the full conventions.
+See [`AGENTS.md` § "Add a new tool / wrapper package"](./AGENTS.md#add-a-new-tool--wrapper-package) and [§ "Cut a release"](./AGENTS.md#cut-a-release) for the full conventions.
 
 ## Reporting bugs
 


### PR DESCRIPTION
## Summary

We discovered (the hard way, on the 0.5.0 release) that a CI npm token **cannot create** brand-new packages in the `@web-ai-sdk` org — npm returns a masked `404 Not Found` on the initial `PUT`, regardless of token scope. OIDC Trusted Publishing can't help either, since you can't configure a Trusted Publisher before the package exists. So the `NPM_TOKEN` we briefly added to `release.yml` (#27) provided no benefit for the only case it targeted.

- **Revert `release.yml`** to token-free OIDC Trusted Publishing (back to the #27-prior state).
- **Document the real constraint**: the *first* publish of any new package must be done locally (`npm login` → `pnpm build` → `npm publish --access public --provenance=false`), after which CI publishes every later version via OIDC. Added to `AGENTS.md` ("Cut a release" + the add-a-package cookbook) and `CONTRIBUTING.md` ("Adding a new package").

Context: the 0.5.0 release published the 6 pre-existing packages via CI; the 3 new ones (writer/rewriter/proofreader) are being hand-published locally per the documented flow.

## Test plan

- [x] `pnpm lint` clean
- [x] `release.yml` env reduced to `GITHUB_TOKEN` only (valid YAML)
- [ ] Merge after the three new packages are published locally, so the release workflow doesn't fail trying to OIDC-create them