### PR TITLE
docs(sdk): drop the llms.txt link from the @web-ai-sdk/all README

### DIFF
--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -2,7 +2,7 @@
 
 One-install meta-package for every `@web-ai-sdk/*` building block: `prompt`, `summarizer`, `translator`, `detector`, `writer`, `rewriter`, `proofreader`, and `webmcp`. Pulls each scoped package in as a regular dependency so consumers don't have to track them individually.
 
-**Docs:** <https://web-ai-sdk.dev/docs/guides/meta-package/> · **All packages & links:** <https://web-ai-sdk.dev/llms.txt>
+**Docs:** <https://web-ai-sdk.dev/docs/guides/meta-package/>
 
 ## Status
 


### PR DESCRIPTION
## Summary

The `@web-ai-sdk/all` README is the npm package page. The `llms.txt` link reads as machine-doc plumbing rather than a reason to install, so drop it and keep the human Docs link.

Only `packages/sdk/README.md` referenced it; the other package READMEs don't.

## Notes

- `@web-ai-sdk/all@0.5.0` is already published, so npm will only reflect this on the next version bump (the current 0.5.0 page keeps the old README). No impact on the three new packages' first publish.