### PR TITLE
feat(prompt): experimental native tool-calling passthrough

### DIFF
--- a/.changeset/native-tools-passthrough.md
+++ b/.changeset/native-tools-passthrough.md
@@ -1,0 +1,5 @@
+---
+"@web-ai-sdk/prompt": patch
+---
+
+Add experimental native tool-calling passthrough. `ask()`, `createSession()`, and `useSession()` now accept a `tools` array (`LanguageModelTool[]`) that is forwarded verbatim to the browser's `LanguageModel.create()`. This is pass-through only: the SDK does not execute the tools, and current stable Chrome accepts the option but no-ops it (the model may surface its call as `tool_code` text). It begins working automatically on browsers that ship native execution. The `expectedInputs` / `expectedOutputs` unions also widen to allow the `tool-response` / `tool-call` modalities.

--- a/apps/docs/src/content/docs/guides/prompt.mdx
+++ b/apps/docs/src/content/docs/guides/prompt.mdx
@@ -217,6 +217,8 @@ This is **pass-through only** — the SDK forwards `tools` and never calls `exec
 
 The heuristic `tool_code` parser and the tool-execution loop are deliberately left to the consumer layer — parsing is model-dependent (it drifts on names and formats for less-trained tools), so it doesn't belong in a lifecycle wrapper. To declare the native tool modalities, pass `{ type: "tool-response" }` / `{ type: "tool-call" }` through the advanced `expectedInputs` / `expectedOutputs` fields.
 
+`tools` works on `ask()` too (`ask({ input, tools })`). One caveat: `ask()` shares warm sessions through an LRU keyed by `JSON.stringify(createOptions)`, and `JSON.stringify` drops functions — so a tool's `execute` doesn't contribute to the key, only its `name` / `description` / `inputSchema` do. Two `ask()` calls with identical tool metadata but different `execute` closures would share one cached session. That's harmless today (the SDK never runs `execute`), but it matters once native execution lands — so prefer `createSession()` for tool-bearing sessions. It bypasses the cache entirely and matches the base-session + per-run-`clone()` pattern.
+
 ## Aborting
 
 `AbortSignal` is supported on every surface. Aborting mid-stream resolves cleanly; an opt-in result cache is not written for aborted runs:

--- a/apps/docs/src/content/docs/guides/prompt.mdx
+++ b/apps/docs/src/content/docs/guides/prompt.mdx
@@ -38,6 +38,7 @@ interface AskOptions {
   supportedLanguages?: readonly string[];
   expectedInputs?: LanguageModelExpectedInput[];
   expectedOutputs?: LanguageModelExpectedOutput[];
+  tools?: LanguageModelTool[];
   monitor?: (m: CreateMonitor) => void;
   responseConstraint?: object;
   cache?: "session" | "local" | { get, set };
@@ -59,6 +60,7 @@ interface AskOptions {
 | `supportedLanguages` | `readonly string[]` | Languages the model supports for the language hint. Defaults to `["en"]`. |
 | `expectedInputs` | `LanguageModelExpectedInput[]` | Advanced: full passthrough. Overrides the `language` hint. |
 | `expectedOutputs` | `LanguageModelExpectedOutput[]` | Advanced: full passthrough. Overrides the `language` hint. |
+| `tools` | `LanguageModelTool[]` | **Experimental.** Native function-calling passthrough (see [Native tool calling](#native-tool-calling-experimental)). |
 | `monitor` | `(m) => void` | Observe the first-call model download. |
 | `responseConstraint` | `object` | JSON Schema for structured output. |
 | `cache` | `"session" \| "local" \| { get, set }` | Opt-in result cache. |
@@ -184,6 +186,36 @@ const parsed = JSON.parse(result.output ?? "{}");
 The wrapper passes `responseConstraint` straight through to `session.prompt()` / `session.promptStreaming()`. Support depends on your Chrome version.
 
 By default the schema is inlined into the prompt context, which costs tokens. Pass `omitResponseConstraintInput: true` (on `ask()` or `SessionSendOptions`) to drop it; the constraint still shapes the output, but you should then include format guidance in the prompt text itself. The flag is only forwarded when `responseConstraint` is also set — the native API throws a `TypeError` otherwise, so the wrapper ignores it on its own.
+
+## Native tool calling (experimental)
+
+The Prompt API spec defines native [function calling](https://github.com/webmachinelearning/prompt-api#tool-use): register `tools` on the session, and the runtime invokes each tool's `execute` on the model's behalf, then feeds the result back into the conversation. `ask()` and `createSession()` forward a `tools` array straight through to `LanguageModel.create()`:
+
+```ts
+import { createSession, type LanguageModelTool } from "@web-ai-sdk/prompt";
+
+const tools: LanguageModelTool[] = [
+  {
+    name: "fetch_url",
+    description: "Fetch a URL and return its text.",
+    inputSchema: {
+      type: "object",
+      properties: { url: { type: "string" } },
+      required: ["url"],
+    },
+    async execute(args) {
+      const { url } = args as { url: string };
+      return await (await fetch(url)).text();
+    },
+  },
+];
+
+const session = createSession({ systemPrompt, tools });
+```
+
+This is **pass-through only** — the SDK forwards `tools` and never calls `execute` itself. Whether the model actually invokes a tool depends on the browser. Native execution is **not** wired on current stable Chrome: the option is accepted but is a silent no-op, and the model may surface its tool call as plain text (a `tool_code` block) that your own code must parse. The passthrough starts working automatically on browsers that ship native execution; until then, `responseConstraint` remains the robust default.
+
+The heuristic `tool_code` parser and the tool-execution loop are deliberately left to the consumer layer — parsing is model-dependent (it drifts on names and formats for less-trained tools), so it doesn't belong in a lifecycle wrapper. To declare the native tool modalities, pass `{ type: "tool-response" }` / `{ type: "tool-call" }` through the advanced `expectedInputs` / `expectedOutputs` fields.
 
 ## Aborting
 

--- a/packages/prompt/README.md
+++ b/packages/prompt/README.md
@@ -145,6 +145,7 @@ interface AskOptions {
   supportedLanguages?: readonly string[];   // default ["en"]
   expectedInputs?: LanguageModelExpectedInput[];   // advanced passthrough
   expectedOutputs?: LanguageModelExpectedOutput[]; // advanced passthrough
+  tools?: LanguageModelTool[];              // experimental: native function-calling passthrough
   createOptions?: Partial<LanguageModelCreateOptions>;
   responseConstraint?: object;              // JSON Schema for structured output
   cache?: ResponseCache;
@@ -174,6 +175,7 @@ interface CreateSessionOptions {
   supportedLanguages?: readonly string[];
   expectedInputs?: LanguageModelExpectedInput[];
   expectedOutputs?: LanguageModelExpectedOutput[];
+  tools?: LanguageModelTool[]; // experimental: native function-calling passthrough
   // Pass `initialPrompts` here to seed multi-turn context.
   createOptions?: Partial<LanguageModelCreateOptions>;
 }
@@ -197,6 +199,36 @@ interface Session {
 `Session.sendStreaming()` yields **deltas** (each chunk is the new text since the last yield, never cumulative). The wrapper does no extra bookkeeping: no history tracking, no concurrent-send queue, no usage telemetry. Always destroy sessions you no longer need.
 
 `omitResponseConstraintInput` is only forwarded when `responseConstraint` is also set; the native API throws a `TypeError` otherwise. When you omit the schema, include format guidance in the prompt text itself (the model no longer sees the schema).
+
+### Native tool calling (experimental)
+
+The Prompt API spec defines native function calling: register `tools` on the session and the runtime invokes their `execute` on the model's behalf, feeding results back. `ask()` and `createSession()` forward a `tools` array straight through to `LanguageModel.create()`:
+
+```ts
+import { createSession, type LanguageModelTool } from "@web-ai-sdk/prompt";
+
+const tools: LanguageModelTool[] = [
+  {
+    name: "fetch_url",
+    description: "Fetch a URL and return its text.",
+    inputSchema: {
+      type: "object",
+      properties: { url: { type: "string" } },
+      required: ["url"],
+    },
+    async execute(args) {
+      const { url } = args as { url: string };
+      return await (await fetch(url)).text();
+    },
+  },
+];
+
+const session = createSession({ systemPrompt, tools });
+```
+
+This is **pass-through only**: the SDK forwards `tools` and never calls `execute` itself. Whether the model actually invokes a tool depends on the browser. Native execution is **not** wired on current stable Chrome — the option is accepted but is a silent no-op, and the model may surface its tool call as plain text (a `tool_code` block) that your code must parse. The passthrough begins working automatically on browsers that ship native execution; until then, `responseConstraint` remains the robust default. The heuristic `tool_code` parser and the tool-execution loop are deliberately left in the consumer layer.
+
+To declare the native tool modalities, pass them through the advanced `expectedInputs` / `expectedOutputs` fields (`{ type: "tool-response" }` / `{ type: "tool-call" }`).
 
 ### Session resilience: base + per-task `clone()`
 

--- a/packages/prompt/README.md
+++ b/packages/prompt/README.md
@@ -228,6 +228,8 @@ const session = createSession({ systemPrompt, tools });
 
 This is **pass-through only**: the SDK forwards `tools` and never calls `execute` itself. Whether the model actually invokes a tool depends on the browser. Native execution is **not** wired on current stable Chrome — the option is accepted but is a silent no-op, and the model may surface its tool call as plain text (a `tool_code` block) that your code must parse. The passthrough begins working automatically on browsers that ship native execution; until then, `responseConstraint` remains the robust default. The heuristic `tool_code` parser and the tool-execution loop are deliberately left in the consumer layer.
 
+`tools` works on `ask()` too (`ask({ input, tools })`), with one caveat: `ask()` shares warm sessions through an LRU keyed by `JSON.stringify(createOptions)`, and `JSON.stringify` drops functions — so a tool's `execute` doesn't contribute to the key, only its `name` / `description` / `inputSchema` do. Two `ask()` calls with identical tool metadata but different `execute` closures would share one cached session. It's harmless today (the SDK never runs `execute`), but it matters once native execution lands, so prefer `createSession()` for tool-bearing sessions — it bypasses the cache and matches the base-session + per-run-`clone()` pattern.
+
 To declare the native tool modalities, pass them through the advanced `expectedInputs` / `expectedOutputs` fields (`{ type: "tool-response" }` / `{ type: "tool-call" }`).
 
 ### Session resilience: base + per-task `clone()`

--- a/packages/prompt/src/api.ts
+++ b/packages/prompt/src/api.ts
@@ -14,13 +14,30 @@ export interface LanguageModelMessage {
 }
 
 export interface LanguageModelExpectedInput {
-  type: "text" | "image" | "audio";
+  type: "text" | "image" | "audio" | "tool-response";
   languages?: string[];
 }
 
 export interface LanguageModelExpectedOutput {
-  type: "text";
+  type: "text" | "tool-call";
   languages?: string[];
+}
+
+/**
+ * @experimental A native Prompt API tool (function calling), mirroring the
+ * W3C `LanguageModelTool` shape. `execute` is "the function to be invoked by
+ * the user agent on behalf of the language model"; it must resolve to a
+ * string the runtime feeds back into the conversation.
+ *
+ * The SDK only forwards this shape to the native `create()`; it does not call
+ * `execute` itself. See {@link LanguageModelCreateOptions.tools}.
+ */
+export interface LanguageModelTool {
+  name: string;
+  description: string;
+  /** JSON Schema for the arguments. */
+  inputSchema: object;
+  execute(args: unknown): Promise<string> | string;
 }
 
 export interface DownloadProgressEvent extends Event {
@@ -43,6 +60,16 @@ export interface LanguageModelCreateOptions {
   signal?: AbortSignal;
   /** Observe the first-call model download (~1.7 GB on a fresh profile). */
   monitor?: (m: CreateMonitor) => void;
+  /**
+   * @experimental Forwards `tools` to the browser's Prompt API
+   * (function calling). Whether the model actually INVOKES them depends
+   * on the browser: native execution is NOT wired on current stable
+   * Chrome — the option is accepted but a no-op, and the model may
+   * surface its tool call as TEXT (`tool_code`) that the caller must
+   * parse. Pass-through only: the SDK does not execute the tools. Will
+   * begin working automatically on browsers that ship native execution.
+   */
+  tools?: LanguageModelTool[];
 }
 
 export interface LanguageModelPromptOptions {

--- a/packages/prompt/src/index.test.ts
+++ b/packages/prompt/src/index.test.ts
@@ -207,6 +207,34 @@ describe("ask", () => {
     expect(createOpts).toMatchObject({ temperature: 0.2, topK: 5 });
   });
 
+  it("forwards tools to LanguageModel.create() without executing them", async () => {
+    const fake = installFakeLanguageModel({ response: "ok" });
+    const execute = vi.fn(async () => "tool result");
+    const tools = [
+      {
+        name: "get_time",
+        description: "Return the current time.",
+        inputSchema: { type: "object", properties: {} },
+        execute,
+      },
+    ];
+    await ask({ input: "what time is it", tools, cache: inMemoryCache() });
+    const createOpts = fake.create.mock.calls[0]?.[0];
+    expect(createOpts).toMatchObject({ tools });
+    // Pass-through only: the SDK must never invoke execute itself.
+    expect(execute).not.toHaveBeenCalled();
+  });
+
+  it("omits the tools key entirely when no tools are passed", async () => {
+    const fake = installFakeLanguageModel();
+    await ask({ input: "ping", cache: inMemoryCache() });
+    const createOpts = fake.create.mock.calls[0]?.[0] as Record<
+      string,
+      unknown
+    >;
+    expect(createOpts).not.toHaveProperty("tools");
+  });
+
   it("reuses sessions across same-shape calls", async () => {
     const fake = installFakeLanguageModel();
     const cache = inMemoryCache();
@@ -339,6 +367,41 @@ describe("createSession", () => {
     const session = createSession();
     await Promise.all([session.send("a"), session.send("b")]);
     expect(maxActive).toBe(2);
+    session.destroy();
+  });
+
+  it("forwards tools to the underlying LanguageModel.create()", async () => {
+    const fake = installFakeLanguageModel({ response: "ok" });
+    const execute = vi.fn(async () => "tool result");
+    const tools = [
+      {
+        name: "fetch_url",
+        description: "Fetch a URL and return its text.",
+        inputSchema: {
+          type: "object",
+          properties: { url: { type: "string" } },
+          required: ["url"],
+        },
+        execute,
+      },
+    ];
+    const session = createSession({ systemPrompt: "S", tools });
+    await session.send("warm");
+    const createOpts = fake.create.mock.calls[0]?.[0];
+    expect(createOpts).toMatchObject({ tools });
+    expect(execute).not.toHaveBeenCalled();
+    session.destroy();
+  });
+
+  it("does not set a tools key when none are passed", async () => {
+    const fake = installFakeLanguageModel({ response: "ok" });
+    const session = createSession({ systemPrompt: "S" });
+    await session.send("warm");
+    const createOpts = fake.create.mock.calls[0]?.[0] as Record<
+      string,
+      unknown
+    >;
+    expect(createOpts).not.toHaveProperty("tools");
     session.destroy();
   });
 

--- a/packages/prompt/src/index.ts
+++ b/packages/prompt/src/index.ts
@@ -19,6 +19,7 @@ import {
   type LanguageModelMessage,
   type LanguageModelParams,
   type LanguageModelPromptOptions,
+  type LanguageModelTool,
   checkAvailability,
   getLanguageModelApi,
   getOrCreateLanguageModel,
@@ -64,6 +65,7 @@ export type {
   LanguageModelInstance,
   LanguageModelMessage,
   LanguageModelParams,
+  LanguageModelTool,
   ResponseCache,
   DefaultCacheKeyInput,
   Session,
@@ -88,6 +90,16 @@ export interface AskOptions {
   expectedInputs?: LanguageModelExpectedInput[];
   /** Advanced: full `expectedOutputs` passthrough. Overrides the `language` hint. */
   expectedOutputs?: LanguageModelExpectedOutput[];
+  /**
+   * @experimental Forwards `tools` to the browser's Prompt API
+   * (function calling). Whether the model actually INVOKES them depends
+   * on the browser: native execution is NOT wired on current stable
+   * Chrome — the option is accepted but a no-op, and the model may
+   * surface its tool call as TEXT (`tool_code`) that the caller must
+   * parse. Pass-through only: the SDK does not execute the tools. Will
+   * begin working automatically on browsers that ship native execution.
+   */
+  tools?: LanguageModelTool[];
   /** Observe the first-call model download. */
   monitor?: (m: CreateMonitor) => void;
   /** Optional JSON Schema for structured output. */
@@ -185,6 +197,7 @@ export const ask = async (options: AskOptions): Promise<AskResult> => {
       : langHints.expectedOutputs
         ? { expectedOutputs: langHints.expectedOutputs }
         : {}),
+    ...(options.tools ? { tools: options.tools } : {}),
     ...(options.monitor ? { monitor: options.monitor } : {}),
   };
 

--- a/packages/prompt/src/react/index.ts
+++ b/packages/prompt/src/react/index.ts
@@ -165,9 +165,9 @@ export interface UseSessionReturn {
  * state in your own components. The hook only solves the React lifecycle:
  * feature detection, create, destroy, recreate-on-change.
  *
- * Object options (`expectedInputs`, `createOptions`) participate in the
- * effect dependency check by reference; memoize them or accept the recreate
- * cost.
+ * Object options (`expectedInputs`, `tools`, `createOptions`) participate in
+ * the effect dependency check by reference; memoize them or accept the
+ * recreate cost.
  */
 export const useSession = (
   options: UseSessionOptions = {},
@@ -181,6 +181,7 @@ export const useSession = (
     supportedLanguages,
     expectedInputs,
     expectedOutputs,
+    tools,
     createOptions,
   } = options;
 
@@ -210,6 +211,7 @@ export const useSession = (
         supportedLanguages,
         expectedInputs,
         expectedOutputs,
+        tools,
         createOptions,
       });
     } catch (err) {
@@ -238,6 +240,7 @@ export const useSession = (
     supportedLanguages,
     expectedInputs,
     expectedOutputs,
+    tools,
     createOptions,
   ]);
 
@@ -250,5 +253,6 @@ export type {
   ResponseCache,
   CacheOption,
   CreateSessionOptions,
+  LanguageModelTool,
   Session,
 } from "../index.js";

--- a/packages/prompt/src/session.ts
+++ b/packages/prompt/src/session.ts
@@ -26,6 +26,7 @@ import {
   type LanguageModelExpectedOutput,
   type LanguageModelInstance,
   type LanguageModelPromptOptions,
+  type LanguageModelTool,
   getLanguageModelApi,
 } from "./api.js";
 
@@ -148,6 +149,16 @@ export interface CreateSessionOptions {
   /** Advanced: full `expectedOutputs` passthrough. Overrides the `language` hint. */
   expectedOutputs?: LanguageModelExpectedOutput[];
   /**
+   * @experimental Forwards `tools` to the browser's Prompt API
+   * (function calling). Whether the model actually INVOKES them depends
+   * on the browser: native execution is NOT wired on current stable
+   * Chrome — the option is accepted but a no-op, and the model may
+   * surface its tool call as TEXT (`tool_code`) that the caller must
+   * parse. Pass-through only: the SDK does not execute the tools. Will
+   * begin working automatically on browsers that ship native execution.
+   */
+  tools?: LanguageModelTool[];
+  /**
    * Override `LanguageModel.create()` options entirely. Merged on top of
    * defaults. Pass `initialPrompts` here to seed multi-turn context (e.g.
    * restoring a conversation from storage).
@@ -226,6 +237,7 @@ const buildCreateOptions = (
       : langHints.expectedOutputs
         ? { expectedOutputs: langHints.expectedOutputs }
         : {}),
+    ...(options.tools ? { tools: options.tools } : {}),
     ...options.createOptions,
   };
 };


### PR DESCRIPTION
## Summary

Implements the **0.5.1** slice of [`.ideas/native-tool-calling.md`](.ideas/native-tool-calling.md): a minimal, additive `tools` passthrough for `@web-ai-sdk/prompt`, letting consumers forward the W3C Prompt API function-calling shape to the browser instead of reaching for `globalThis.LanguageModel` directly.

- **New `LanguageModelTool` type** (`name` / `description` / `inputSchema` / `execute`), mirroring the W3C `LanguageModelTool` shape, exported from the package root and the `/react` subpath.
- **`tools?` forwarded verbatim** to `LanguageModel.create()` from `ask()`, `createSession()`, and `useSession()`. Only added to the create options when present; behavior is unchanged when omitted.
- **Modality unions widened** so the full native shape is reachable through the existing advanced passthrough: `tool-response` on `expectedInputs`, `tool-call` on `expectedOutputs`.
- **Pass-through only.** The SDK never calls `execute`. Current stable Chrome accepts the option but no-ops it (the model may surface its call as `tool_code` text); it begins working automatically on browsers that ship native execution. `responseConstraint` remains the robust default until then.

The heuristic `tool_code` parser and the tool-execution loop are deliberately **out of scope** and stay in the consumer layer, per the monorepo's scope rule.

## Changes

- `packages/prompt/src/api.ts` — `LanguageModelTool` type, `tools?` on `LanguageModelCreateOptions`, widened modality unions.
- `packages/prompt/src/{session,index}.ts` — forward `tools` from `createSession()` / `ask()`; re-export the type.
- `packages/prompt/src/react/index.ts` — thread `tools` through `useSession` (effect dep included); re-export the type. `usePrompt` inherits it via `AskOptions`.
- Docs: package `README.md` + `apps/docs/.../guides/prompt.mdx` get a "Native tool calling (experimental)" section with the "not executed on stable / may appear as `tool_code` text" caveat.
- `.changeset/native-tools-passthrough.md` — patch bump (0.5.0 → 0.5.1).

## Test plan

- [x] `pnpm gate` (lint + build + typecheck + test) green.
- [x] New tests: `ask()` and `createSession()` forward `tools` to `create()`, never invoke `execute`, and omit the key entirely when no tools are passed (51 prompt-package tests pass).
- [ ] Manual: a consumer can pass `tools` through the SDK instead of `globalThis.LanguageModel`; verify against `locala/native-tools-probe.html` on a build with native execution.