### PR TITLE
feat(prompt): expose context-window introspection on Session (0.5.2)

### DIFF
--- a/.changeset/prompt-session-context-introspection.md
+++ b/.changeset/prompt-session-context-introspection.md
@@ -1,0 +1,8 @@
+---
+"@web-ai-sdk/prompt": patch
+---
+
+Expose context-window introspection on `Session` so consumers can size work to the real model context instead of hardcoding, without reaching past the SDK to `globalThis.LanguageModel`.
+
+- **`Session.contextWindow` / `Session.contextUsage`**: readonly passthroughs of the native instance's token budget (the context window and tokens used so far). These match the Prompt API's current canonical names (the renamed successors of `inputQuota` / `inputUsage`); the wrapper reads the new names and falls back to the deprecated ones on older Chrome builds. Both are `undefined` until the lazily-created instance exists; on a session from `clone()` they are readable the moment `clone()` resolves, which is exactly when a consumer wants to budget a per-run turn against the inherited system prompt.
+- **`Session.onContextOverflow(listener)`**: subscribe to the native `contextoverflow` event (fired when a turn pushes usage past the window and the oldest history is dropped) so consumers can compact or fork a fresh `clone()` before `QuotaExceededError`. Returns an idempotent cleanup function and is a feature-detected no-op when the underlying instance doesn't expose the event.

--- a/apps/docs/src/content/docs/guides/prompt.mdx
+++ b/apps/docs/src/content/docs/guides/prompt.mdx
@@ -126,6 +126,39 @@ try {
 
 `clone()` throws `SessionDestroyedError` if the base has been destroyed, and `PromptUnavailableError` if the underlying browser instance doesn't support cloning. The clone is fully independent: destroying it never affects the base, and vice versa. The React `useSession` hook returns the `Session` directly, so `session.clone()` is available there too.
 
+## Context-window introspection
+
+`Session` surfaces the live token budget the native instance reports, so consumers can size work to the real context window instead of hardcoding a char cap (the exact bypass — reaching past the SDK to `globalThis.LanguageModel` — that this avoids):
+
+- `session.contextWindow` — max input tokens for the session (the context window).
+- `session.contextUsage` — input tokens used so far. On a fresh base-clone this reflects the inherited history (≈ the system prompt), the right baseline to budget a turn against.
+
+These mirror the Prompt API's [`contextWindow` / `contextUsage`](https://developer.chrome.com/docs/ai/prompt-api#session_management) (the renamed successors of `inputQuota` / `inputUsage`); the wrapper reads the new names and falls back to the deprecated ones on older Chrome builds. Both are `undefined` until the underlying instance exists. The instance is created lazily on the first `send` / `sendStreaming`, so read them after a `send` or — cleaner — on a session from `clone()`, whose instance is live the moment `clone()` resolves.
+
+```ts
+const base = createSession({ systemPrompt }); // keep warm
+const turn = await base.clone();               // instance is live here
+const quota = turn.contextWindow;              // e.g. 4096 / 6144 tokens
+const used = turn.contextUsage ?? 0;           // ≈ system prompt
+if (quota) {
+  const available = quota - used - ANSWER_RESERVE_TOKENS;
+  const budgetChars = Math.max(0, available) * 4; // ~4 chars/token
+  // truncate fetched content to budgetChars so it fits in one turn
+}
+// Fall back to a fixed char cap when contextWindow is undefined
+// (older browsers / pre-creation).
+```
+
+`session.onContextOverflow(listener)` subscribes to the native `contextoverflow` event, which fires when a turn pushes usage past the window and the oldest history is dropped. Use it to compact or fork a fresh `clone()` before hitting `QuotaExceededError`. It returns an idempotent cleanup function, and is a no-op (returns a no-op cleanup) when the underlying instance doesn't expose the event.
+
+```ts
+const stop = session.onContextOverflow(() => {
+  // compact, summarize, or start a fresh clone before QuotaExceededError
+});
+// later
+stop();
+```
+
 ## How it works
 
 Chrome's `LanguageModel` exposes `LanguageModel.create({...})` to spin up a session and `session.prompt(input)` / `session.promptStreaming(input)` to run it. The wrapper does the following on top:

--- a/packages/prompt/README.md
+++ b/packages/prompt/README.md
@@ -188,10 +188,13 @@ interface SessionSendOptions {
 
 interface Session {
   readonly destroyed: boolean;
+  readonly contextWindow?: number; // context window in tokens; undefined pre-creation
+  readonly contextUsage?: number;  // tokens used so far; undefined pre-creation
   send(input: string, options?: SessionSendOptions): Promise<string | null>;
   sendStreaming(input: string, options?: SessionSendOptions): AsyncIterable<string>;
   abort(): void;
   clone(options?: { signal?: AbortSignal }): Promise<Session>;
+  onContextOverflow(listener: () => void): () => void; // returns an idempotent cleanup
   destroy(): void;
 }
 ```
@@ -248,6 +251,39 @@ try {
 ```
 
 `clone()` throws `SessionDestroyedError` if the base is destroyed and `PromptUnavailableError` if the browser instance doesn't support cloning. Destroying a clone never affects the base, and vice versa.
+
+### Context-window introspection
+
+`Session` surfaces the live token budget the native instance reports, so consumers can size work to the actual context window instead of hardcoding a char cap. Both are `undefined` until the underlying instance exists — the instance is created lazily on the first `send` / `sendStreaming`, so read them after a `send` or (cleaner) on a session from `clone()`, whose instance is live the moment `clone()` resolves.
+
+- `session.contextWindow` — max input tokens for the session (the context window).
+- `session.contextUsage` — input tokens used so far. On a fresh base-clone this reflects the inherited history (≈ the system prompt), the right baseline to budget a turn against.
+
+These mirror the Prompt API's `contextWindow` / `contextUsage` (the renamed successors of `inputQuota` / `inputUsage`); the wrapper reads the new names and falls back to the deprecated ones on older Chrome builds.
+
+```ts
+const base = createSession({ systemPrompt }); // keep warm
+const turn = await base.clone();               // instance is live here
+const quota = turn.contextWindow;              // e.g. 4096 / 6144 tokens
+const used = turn.contextUsage ?? 0;           // ≈ system prompt
+if (quota) {
+  const available = quota - used - ANSWER_RESERVE_TOKENS;
+  const budgetChars = Math.max(0, available) * 4; // ~4 chars/token
+  // truncate fetched content to budgetChars so it fits in one turn
+}
+// Fall back to a fixed char cap when contextWindow is undefined
+// (older browsers / pre-creation).
+```
+
+`session.onContextOverflow(listener)` subscribes to the native `contextoverflow` event, which fires when a turn pushes usage past the window and the oldest history is dropped. Use it to compact or fork a fresh `clone()` before hitting `QuotaExceededError`. It returns an idempotent cleanup function, and is a no-op (returns a no-op cleanup) when the instance doesn't expose the event.
+
+```ts
+const stop = session.onContextOverflow(() => {
+  // compact, summarize, or start a fresh clone before QuotaExceededError
+});
+// later
+stop();
+```
 
 ### `useSession(options?): UseSessionReturn`
 

--- a/packages/prompt/src/api.ts
+++ b/packages/prompt/src/api.ts
@@ -95,10 +95,37 @@ export interface LanguageModelInstance {
   ): AsyncIterable<string>;
   clone?(options?: { signal?: AbortSignal }): Promise<LanguageModelInstance>;
   destroy?(): void;
+  /**
+   * Input tokens used so far (≈ the system prompt on a fresh clone). This is
+   * the current canonical name; the Prompt API renamed `inputUsage` →
+   * `contextUsage` (`inputUsage` is now extension-only / deprecated).
+   */
+  readonly contextUsage?: number;
+  /**
+   * Max input tokens for the instance, i.e. the context window. Current
+   * canonical name; the Prompt API renamed `inputQuota` → `contextWindow`.
+   */
+  readonly contextWindow?: number;
+  /** @deprecated Renamed to `contextUsage`; extension contexts only now. */
   readonly inputUsage?: number;
+  /** @deprecated Renamed to `contextWindow`; extension contexts only now. */
   readonly inputQuota?: number;
   readonly topK?: number;
   readonly temperature?: number;
+  /**
+   * The native instance is an `EventTarget`. The `contextoverflow` event
+   * fires when a turn pushes `contextUsage` past `contextWindow` and the
+   * oldest history is dropped, letting consumers compact before hitting
+   * `QuotaExceededError`. Optional: older instances may not implement it.
+   */
+  addEventListener?(
+    type: "contextoverflow",
+    listener: (event: Event) => void,
+  ): void;
+  removeEventListener?(
+    type: "contextoverflow",
+    listener: (event: Event) => void,
+  ): void;
 }
 
 export type LanguageModelAvailability =

--- a/packages/prompt/src/index.test.ts
+++ b/packages/prompt/src/index.test.ts
@@ -14,6 +14,12 @@ interface FakeSession {
   promptStreaming?: ReturnType<typeof vi.fn>;
   destroy?: ReturnType<typeof vi.fn>;
   clone?: ReturnType<typeof vi.fn>;
+  contextWindow?: number;
+  contextUsage?: number;
+  inputQuota?: number;
+  inputUsage?: number;
+  addEventListener?: ReturnType<typeof vi.fn>;
+  removeEventListener?: ReturnType<typeof vi.fn>;
 }
 
 interface FakeApi {
@@ -489,6 +495,158 @@ describe("Session.clone", () => {
     await expect(base.clone()).rejects.toMatchObject({
       name: "SessionDestroyedError",
     });
+  });
+});
+
+describe("Session context introspection", () => {
+  it("contextWindow / contextUsage are undefined before the instance is created", () => {
+    installFakeLanguageModel({ response: "ok" });
+    const session = createSession({ systemPrompt: "S" });
+    expect(session.contextWindow).toBeUndefined();
+    expect(session.contextUsage).toBeUndefined();
+    session.destroy();
+  });
+
+  it("reads the native contextWindow / contextUsage after a send", async () => {
+    installFakeLanguageModel({
+      sessionFactory: () => ({
+        prompt: vi.fn(async () => "ok"),
+        destroy: vi.fn(),
+        contextWindow: 4096,
+        contextUsage: 12,
+      }),
+    });
+    const session = createSession({ systemPrompt: "S" });
+    await session.send("warm");
+    expect(session.contextWindow).toBe(4096);
+    expect(session.contextUsage).toBe(12);
+    session.destroy();
+  });
+
+  it("falls back to the deprecated inputQuota / inputUsage on older builds", async () => {
+    installFakeLanguageModel({
+      sessionFactory: () => ({
+        prompt: vi.fn(async () => "ok"),
+        destroy: vi.fn(),
+        inputQuota: 2048,
+        inputUsage: 7,
+      }),
+    });
+    const session = createSession({ systemPrompt: "S" });
+    await session.send("warm");
+    expect(session.contextWindow).toBe(2048);
+    expect(session.contextUsage).toBe(7);
+    session.destroy();
+  });
+
+  it("exposes the clone's budget synchronously the moment clone() resolves", async () => {
+    const cloneSpy = vi.fn(async () => ({
+      prompt: vi.fn(async () => "child reply"),
+      destroy: vi.fn(),
+      contextWindow: 6144,
+      contextUsage: 30,
+    }));
+    installFakeLanguageModel({
+      sessionFactory: () => ({
+        prompt: vi.fn(async () => "parent reply"),
+        destroy: vi.fn(),
+        clone: cloneSpy,
+        contextWindow: 6144,
+        contextUsage: 5,
+      }),
+    });
+
+    const base = createSession({ systemPrompt: "S" });
+    await base.send("warm");
+    const turn = await base.clone();
+    // No extra await: the values must be readable right away so a consumer
+    // can budget the turn's content against the live context window.
+    expect(turn.contextWindow).toBe(6144);
+    expect(turn.contextUsage).toBe(30);
+    turn.destroy();
+    base.destroy();
+  });
+});
+
+describe("Session.onContextOverflow", () => {
+  const makeEmitter = () => {
+    const listeners = new Map<string, Set<(event: Event) => void>>();
+    return {
+      addEventListener: vi.fn((type: string, fn: (event: Event) => void) => {
+        const set = listeners.get(type) ?? new Set();
+        set.add(fn);
+        listeners.set(type, set);
+      }),
+      removeEventListener: vi.fn((type: string, fn: (event: Event) => void) => {
+        listeners.get(type)?.delete(fn);
+      }),
+      emit: (type: string) => {
+        for (const fn of listeners.get(type) ?? []) fn(new Event(type));
+      },
+    };
+  };
+
+  it("fires the listener on a native contextoverflow event and stops after cleanup", async () => {
+    const emitter = makeEmitter();
+    installFakeLanguageModel({
+      sessionFactory: () => ({
+        prompt: vi.fn(async () => "ok"),
+        destroy: vi.fn(),
+        addEventListener: emitter.addEventListener,
+        removeEventListener: emitter.removeEventListener,
+      }),
+    });
+    const session = createSession({ systemPrompt: "S" });
+    await session.send("warm"); // force create() so the listener attaches
+    const onOverflow = vi.fn();
+    const stop = session.onContextOverflow(onOverflow);
+    await Promise.resolve();
+
+    emitter.emit("contextoverflow");
+    expect(onOverflow).toHaveBeenCalledTimes(1);
+
+    stop();
+    emitter.emit("contextoverflow");
+    expect(onOverflow).toHaveBeenCalledTimes(1);
+    expect(emitter.removeEventListener).toHaveBeenCalledTimes(1);
+
+    // Cleanup is idempotent.
+    expect(() => stop()).not.toThrow();
+    session.destroy();
+  });
+
+  it("never attaches when cleanup runs before the instance is created", async () => {
+    const emitter = makeEmitter();
+    installFakeLanguageModel({
+      sessionFactory: () => ({
+        prompt: vi.fn(async () => "ok"),
+        destroy: vi.fn(),
+        addEventListener: emitter.addEventListener,
+        removeEventListener: emitter.removeEventListener,
+      }),
+    });
+    const session = createSession({ systemPrompt: "S" });
+    const stop = session.onContextOverflow(vi.fn());
+    stop(); // before any send → instance not created yet
+    await session.send("warm");
+    await Promise.resolve();
+    expect(emitter.addEventListener).not.toHaveBeenCalled();
+    session.destroy();
+  });
+
+  it("is a no-op (returns a no-op cleanup) when the instance has no events", async () => {
+    installFakeLanguageModel({
+      sessionFactory: () => ({
+        prompt: vi.fn(async () => "ok"),
+        destroy: vi.fn(),
+      }),
+    });
+    const session = createSession();
+    await session.send("warm");
+    const stop = session.onContextOverflow(vi.fn());
+    await Promise.resolve();
+    expect(() => stop()).not.toThrow();
+    session.destroy();
   });
 });
 

--- a/packages/prompt/src/session.ts
+++ b/packages/prompt/src/session.ts
@@ -207,6 +207,32 @@ export interface Session {
    * vice versa.
    */
   clone(options?: { signal?: AbortSignal }): Promise<Session>;
+  /**
+   * Max input tokens for this session (the context window), as reported by
+   * the underlying instance — mirrors the native `contextWindow`. `undefined`
+   * until the instance is created — the instance is created lazily on the
+   * first `send` / `sendStreaming`, so read it after a `send` or (preferably)
+   * on a session from `clone()`, whose instance is live the moment `clone()`
+   * resolves.
+   */
+  readonly contextWindow?: number;
+  /**
+   * Input tokens used so far, as reported by the underlying instance —
+   * mirrors the native `contextUsage`. `undefined` until the instance is
+   * created (see `contextWindow`). On a fresh base-clone this reflects the
+   * inherited history (≈ the system prompt), the right baseline to budget a
+   * turn's content against.
+   */
+  readonly contextUsage?: number;
+  /**
+   * Subscribe to the native `contextoverflow` event, which fires when a turn
+   * pushes usage past the context window and the oldest history is dropped.
+   * Use it to compact or fork a fresh `clone()` before hitting
+   * `QuotaExceededError`. Returns an idempotent cleanup function that detaches
+   * the listener; calling it more than once is safe. A no-op (returns a no-op
+   * cleanup) when the underlying instance doesn't expose the event.
+   */
+  onContextOverflow(listener: () => void): () => void;
   /** Tear down the underlying instance and refuse further sends. Idempotent. */
   destroy(): void;
 }
@@ -247,9 +273,17 @@ interface SessionInternal {
   api: LanguageModelApi;
 }
 
-const wrapInstance = (internal: Promise<SessionInternal>): Session => {
+const wrapInstance = (
+  internal: Promise<SessionInternal>,
+  resolvedInstance?: LanguageModelInstance,
+): Session => {
   let destroyed = false;
   let currentController: AbortController | null = null;
+  // Synchronous handle on the live instance so the `inputQuota` / `inputUsage`
+  // getters can read it without awaiting. Seeded eagerly for clones (whose
+  // instance already exists when `clone()` resolves) and otherwise populated
+  // once the lazy `create()` settles.
+  let liveInstance: LanguageModelInstance | null = resolvedInstance ?? null;
 
   // Wrap the create-failure promise once so awaiters get the typed error.
   const ready: Promise<SessionInternal> = internal.catch((err) => {
@@ -262,6 +296,11 @@ const wrapInstance = (internal: Promise<SessionInternal>): Session => {
   // Swallow the rejection on the internal promise so unhandled-rejection
   // warnings don't fire when callers never touch `ready`.
   ready.catch(() => {});
+  ready
+    .then(({ instance }) => {
+      liveInstance = instance;
+    })
+    .catch(() => {});
 
   const ensureLive = (): void => {
     if (destroyed) throw new SessionDestroyedError();
@@ -387,6 +426,30 @@ const wrapInstance = (internal: Promise<SessionInternal>): Session => {
     currentController?.abort();
   };
 
+  const onContextOverflow = (listener: () => void): (() => void) => {
+    let cancelled = false;
+    let detach: (() => void) | null = null;
+    // The instance may not exist yet (lazy create), so wait for `ready` and
+    // attach then — unless cleanup ran first.
+    ready
+      .then(({ instance }) => {
+        if (cancelled) return;
+        if (typeof instance.addEventListener !== "function") return;
+        const handler = () => listener();
+        instance.addEventListener("contextoverflow", handler);
+        detach = () =>
+          instance.removeEventListener?.("contextoverflow", handler);
+      })
+      .catch(() => {
+        // never created; nothing to detach.
+      });
+    return () => {
+      cancelled = true;
+      detach?.();
+      detach = null;
+    };
+  };
+
   const clone = async (cloneOptions?: {
     signal?: AbortSignal;
   }): Promise<Session> => {
@@ -405,7 +468,9 @@ const wrapInstance = (internal: Promise<SessionInternal>): Session => {
       // Wrap the clone with the same smoothing / abort / typed-error behavior.
       // It owns an independent native instance, so its history, abort, and
       // destroy lifecycle are fully decoupled from this (parent) session.
-      return wrapInstance(Promise.resolve({ instance: cloned, api }));
+      // Pass the instance synchronously so `inputQuota` / `inputUsage` are
+      // readable the moment `clone()` resolves, without awaiting a microtask.
+      return wrapInstance(Promise.resolve({ instance: cloned, api }), cloned);
     } catch (err) {
       if ((err as { name?: string })?.name === "AbortError") {
         throw new PromptAbortError();
@@ -436,10 +501,19 @@ const wrapInstance = (internal: Promise<SessionInternal>): Session => {
     get destroyed() {
       return destroyed;
     },
+    get contextWindow() {
+      // Prefer the current canonical name; fall back to the deprecated
+      // `inputQuota` so older Chrome builds still report a budget.
+      return liveInstance?.contextWindow ?? liveInstance?.inputQuota;
+    },
+    get contextUsage() {
+      return liveInstance?.contextUsage ?? liveInstance?.inputUsage;
+    },
     send,
     sendStreaming,
     abort,
     clone,
+    onContextOverflow,
     destroy,
   };
 };


### PR DESCRIPTION
## Summary

Surfaces the live session token budget on the `@web-ai-sdk/prompt` `Session` so consumers can size work to the real model context instead of hardcoding a char cap, without reaching past the SDK to `globalThis.LanguageModel`. Implements `.ideas/session-context-introspection-handoff.md` plus its "fast-follow" nice-to-have (the overflow event), in one release.

- **`Session.contextWindow` / `Session.contextUsage`** — readonly passthroughs of the native instance's context window and tokens used so far. `undefined` until the lazily-created instance exists; on a session from `clone()` they're readable the moment `clone()` resolves (the seam where a consumer wants to budget a per-run turn against the inherited system prompt).
- **`Session.onContextOverflow(listener)`** — subscribe to the native `contextoverflow` event (fired when a turn pushes usage past the window and the oldest history is dropped) to compact or fork a fresh `clone()` before `QuotaExceededError`. Returns an idempotent cleanup; feature-detected no-op when the instance lacks events.

### Spec alignment note

The handoff doc was written against `inputQuota` / `inputUsage`, but the Prompt API has since **renamed** those to `contextWindow` / `contextUsage` (the old names are now deprecated / extension-context-only). This PR exposes the **current canonical names** and internally reads new-first with a fallback to the deprecated names, so it works across Chrome versions during the transition. The `contextoverflow` event name is current and unchanged.

Refs: [W3C Prompt API](https://webmachinelearning.github.io/prompt-api/) · [chrome.dev session management](https://developer.chrome.com/docs/ai/prompt-api#session_management)

## Test plan

- [x] `pnpm gate` (lint + build + typecheck + test) green
- [x] New tests in `packages/prompt/src/index.test.ts`:
  - `contextWindow` / `contextUsage` are `undefined` pre-creation
  - populated after a `send`
  - fall back to deprecated `inputQuota` / `inputUsage` on older builds
  - readable synchronously the moment `clone()` resolves
  - `onContextOverflow` fires the listener, stops after idempotent cleanup, no-ops when the instance lacks events and when cleanup runs before creation
- [x] Purely additive; no existing signature/behavior/export changed