### PR TITLE
fix(landing): correct nav active state and add back-to-top button

### DIFF
--- a/apps/landing/src/App.tsx
+++ b/apps/landing/src/App.tsx
@@ -1,3 +1,4 @@
+import { BackToTop } from "./components/BackToTop.js";
 import { BrandMark } from "./components/BrandMark.js";
 import { DetectorDemo } from "./components/DetectorDemo.js";
 import { HowItWorks } from "./components/HowItWorks.js";
@@ -1367,5 +1368,6 @@ export const App = () => (
     </footer>
 
     <ScrollSpy />
+    <BackToTop />
   </>
 );

--- a/apps/landing/src/components/BackToTop.tsx
+++ b/apps/landing/src/components/BackToTop.tsx
@@ -1,0 +1,58 @@
+import { useEffect, useState } from "react";
+import { backToTop, backToTopArrow } from "../lib/ui.js";
+
+// Mirror ScrollSpy's marker so the button appears at the exact moment the
+// first nav item ("Why not raw?") starts being highlighted.
+const scrollMarker = (): number => {
+  const styles = getComputedStyle(document.documentElement);
+  const navHeight = Number.parseFloat(styles.getPropertyValue("--nav-height"));
+  return (Number.isFinite(navHeight) ? navHeight : 57) + 24;
+};
+
+export const BackToTop = () => {
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    const firstSection = document.querySelector<HTMLElement>(
+      '[data-section="why-raw"]',
+    );
+    let frame = 0;
+
+    const sync = () => {
+      frame = 0;
+      if (!firstSection) return;
+      setVisible(firstSection.getBoundingClientRect().top <= scrollMarker());
+    };
+
+    const onScroll = () => {
+      if (frame !== 0) return;
+      frame = window.requestAnimationFrame(sync);
+    };
+
+    sync();
+    window.addEventListener("scroll", onScroll, { passive: true });
+    window.addEventListener("resize", onScroll, { passive: true });
+
+    return () => {
+      window.removeEventListener("scroll", onScroll);
+      window.removeEventListener("resize", onScroll);
+      if (frame !== 0) window.cancelAnimationFrame(frame);
+    };
+  }, []);
+
+  return (
+    <button
+      type="button"
+      className={backToTop}
+      data-visible={visible}
+      aria-hidden={!visible}
+      tabIndex={visible ? 0 : -1}
+      onClick={() => window.scrollTo({ top: 0, behavior: "smooth" })}
+    >
+      <span className={backToTopArrow} aria-hidden="true">
+        ↑
+      </span>
+      Back to top
+    </button>
+  );
+};

--- a/apps/landing/src/components/ScrollSpy.tsx
+++ b/apps/landing/src/components/ScrollSpy.tsx
@@ -1,6 +1,13 @@
 import { useEffect } from "react";
 
-const IDS = ["packages", "philosophy", "how", "support", "start"] as const;
+const IDS = [
+  "why-raw",
+  "packages",
+  "philosophy",
+  "how",
+  "support",
+  "start",
+] as const;
 
 const scrollMarker = (): number => {
   const root = document.documentElement;
@@ -24,7 +31,7 @@ export const ScrollSpy = () => {
     const syncActive = () => {
       frame = 0;
       const marker = scrollMarker();
-      let activeIndex = 0;
+      let activeIndex = -1;
 
       for (let i = 0; i < sections.length; i++) {
         const section = sections[i];

--- a/apps/landing/src/lib/ui.ts
+++ b/apps/landing/src/lib/ui.ts
@@ -353,3 +353,8 @@ export const footerColList =
 
 export const footerMeta =
   "mt-14 flex flex-wrap justify-between gap-5 border-t border-hairline pt-6 font-mono text-[11.5px] tracking-[0.04em] text-fg-4 [&_a]:text-fg-3 [&_a:hover]:text-accent";
+
+export const backToTop =
+  "fixed bottom-5 left-1/2 z-40 inline-flex -translate-x-1/2 cursor-pointer items-center gap-1.5 rounded-pill border border-hairline-2 bg-[color-mix(in_oklch,var(--color-surface)_82%,transparent)] py-1.5 pr-3 pl-2.5 font-mono text-[11px] leading-none tracking-[0.02em] text-fg-3 shadow-card backdrop-blur-[14px] backdrop-saturate-[1.2] transition-[opacity,transform,color,border-color] duration-300 ease-[cubic-bezier(0.2,0.6,0.2,1)] hover:-translate-y-px hover:border-accent-line hover:text-fg focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent data-[visible=false]:pointer-events-none data-[visible=false]:translate-y-3 data-[visible=false]:opacity-0";
+
+export const backToTopArrow = "text-accent transition-transform";

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "docs": "pnpm --filter \"./apps/docs\" run dev",
     "landing": "pnpm --filter \"./apps/landing\" run dev",
     "og:build": "pnpm --filter \"./apps/landing\" run og:build",
+    "pages:dev": "pnpm --filter \"./apps/**\" -r --parallel run dev",
     "typecheck": "pnpm -r run typecheck",
     "test": "pnpm --filter \"./packages/**\" -r run test",
     "lint": "biome check .",


### PR DESCRIPTION
## Summary
- Fix the landing nav scrollspy: the `"why-raw"` section id was missing from the tracked list, so the first link ("Why not raw?") was never highlighted and "Packages" stayed active even at the top of the page.
- Default `activeIndex` to `-1` so nothing is highlighted while above the first section.
- Add a compact, glassy "Back to top" button (`BackToTop.tsx`) that fades in once the first section starts being highlighted (reusing ScrollSpy's marker) and smooth-scrolls to the top. Hidden state is non-focusable and `aria-hidden`.
- Add a `pages:dev` convenience script to run both apps in parallel.

## Test plan
- [ ] At the very top of the landing page, no nav link is highlighted.
- [ ] Scrolling into "Why not raw?" highlights that link and reveals the "Back to top" button.
- [ ] Subsequent sections highlight their respective nav links.
- [ ] Clicking "Back to top" smooth-scrolls to the top and the button fades out.
- [ ] `pnpm lint`, `pnpm typecheck` pass.