### PR TITLE
feat(webmcp): read modelContext from document, fall back to navigator

### DIFF
--- a/.changeset/webmcp-document-modelcontext.md
+++ b/.changeset/webmcp-document-modelcontext.md
@@ -1,0 +1,7 @@
+---
+"@web-ai-sdk/webmcp": patch
+---
+
+Read WebMCP from `document.modelContext` (the spec entry point) instead of only `navigator.modelContext`.
+
+`document.modelContext` is the location the spec defines today; `navigator.modelContext` is the previous shape of the API. The wrapper now reads from `document.modelContext` first and falls back to `navigator.modelContext` so apps keep working against implementations that still expose the older binding. No public API change — `registerTool`, `isAvailable`, and the `useWebMCP` hook all behave identically; only the underlying global lookup is broader.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,7 +12,7 @@ For human-facing context see the root [`README.md`](./README.md) and [`CONTRIBUT
 
 | Package                 | Wraps                                                  | Status     |
 | ----------------------- | ------------------------------------------------------ | ---------- |
-| `@web-ai-sdk/webmcp`    | `navigator.modelContext` (W3C WebMCP)                  | Ported     |
+| `@web-ai-sdk/webmcp`    | `document.modelContext` (W3C WebMCP)                   | Ported     |
 | `@web-ai-sdk/translator`| `Translator` (Web Built-in AI Translator API)       | Ported     |
 | `@web-ai-sdk/summarizer`| `Summarizer` (Web Built-in AI Summarizer API)       | Ported     |
 | `@web-ai-sdk/prompt`    | `LanguageModel` (Web Built-in AI Prompt API)        | New        |
@@ -248,7 +248,7 @@ Or in one shot: `pnpm gate`.
 
 ## 9. Glossary
 
-- **Tool**; In WebMCP, a named, agent-callable function with a description, optional JSON Schema input, and an `execute` handler. Registered with `navigator.modelContext.registerTool`.
+- **Tool**; In WebMCP, a named, agent-callable function with a description, optional JSON Schema input, and an `execute` handler. Registered with `document.modelContext.registerTool`.
 - **Core package / lifecycle layer**; A package that ships logic, types, and session lifecycle but no DOM / no styles / no rendering primitives. The eight API-wrapper packages are all core packages. Future packages with a different role (UI primitives, polyfills) sit at different layers.
 - **Subpath export**; A package entry exposed under a path like `@web-ai-sdk/webmcp/react`. Configured via `package.json#exports`. Lets one install ship multiple framework adapters that tree-shake independently.
 - **Feature-detected no-op**; The pattern this monorepo uses everywhere: if the underlying browser API is absent, the wrapper returns a no-op cleanup / `undefined` / similar, so consumer code can ship without polyfills or branching.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Building blocks for the Web's Built-in AI APIs.
 
-A small, focused monorepo of framework-agnostic packages that smooth over the gnarly bits of the new `navigator.modelContext`, `Translator`, `Summarizer`, `LanguageModel`, `LanguageDetector`, `Writer`, `Rewriter`, and `Proofreader` browser APIs (feature detection, session caching, streaming, lifecycle, safe DOM rebuild) without bringing any UI along.
+A small, focused monorepo of framework-agnostic packages that smooth over the gnarly bits of the new `document.modelContext`, `Translator`, `Summarizer`, `LanguageModel`, `LanguageDetector`, `Writer`, `Rewriter`, and `Proofreader` browser APIs (feature detection, session caching, streaming, lifecycle, safe DOM rebuild) without bringing any UI along.
 
 ## What it is
 
@@ -17,7 +17,7 @@ See [`apps/docs/src/content/docs/architecture.mdx`](./apps/docs/src/content/docs
 
 | Package                                          | Wraps                                          | Highlights                                                                |
 | ------------------------------------------------ | ---------------------------------------------- | ------------------------------------------------------------------------- |
-| [`@web-ai-sdk/webmcp`](./packages/webmcp)            | `navigator.modelContext` (W3C WebMCP)          | Safe register/unregister, shorthand annotations, `useWebMCP` hook         |
+| [`@web-ai-sdk/webmcp`](./packages/webmcp)            | `document.modelContext` (W3C WebMCP)           | Safe register/unregister, shorthand annotations, `useWebMCP` hook         |
 | [`@web-ai-sdk/translator`](./packages/translator)    | Web Built-in `Translator`                   | Block serialization, casing restoration, snapshot-based restore           |
 | [`@web-ai-sdk/summarizer`](./packages/summarizer)    | Web Built-in `Summarizer`                   | Skeleton extraction, sessionStorage caching, streaming chunks             |
 | [`@web-ai-sdk/prompt`](./packages/prompt)            | Web Built-in `LanguageModel` (Prompt API)   | System prompt + sampling, session reuse, streaming, result cache          |

--- a/apps/docs/src/components/WebMCPDemo.tsx
+++ b/apps/docs/src/components/WebMCPDemo.tsx
@@ -102,7 +102,7 @@ export const WebMCPDemo = () => {
   return (
     <div className="demo-card demo-card--narrow">
       <p className="demo-muted">
-        Two tools registered against <code>navigator.modelContext</code>:{" "}
+        Two tools registered against <code>document.modelContext</code>:{" "}
         <code>list_demo_items</code> (read-only) and <code>echo_message</code>{" "}
         (with input schema).
       </p>

--- a/apps/docs/src/content/docs/architecture.mdx
+++ b/apps/docs/src/content/docs/architecture.mdx
@@ -12,7 +12,7 @@ Each `@web-ai-sdk/*` package wraps a single cohesive web capability relevant to 
 | Package | Wraps |
 | --- | --- |
 | [`@web-ai-sdk/prompt`](/docs/guides/prompt/) | `LanguageModel` (Web Built-in Prompt API) |
-| [`@web-ai-sdk/webmcp`](/docs/guides/webmcp/) | `navigator.modelContext` (W3C WebMCP) |
+| [`@web-ai-sdk/webmcp`](/docs/guides/webmcp/) | `document.modelContext` (W3C WebMCP) |
 | [`@web-ai-sdk/summarizer`](/docs/guides/summarizer/) | `Summarizer` |
 | [`@web-ai-sdk/translator`](/docs/guides/translator/) | `Translator` |
 | [`@web-ai-sdk/detector`](/docs/guides/detector/) | `LanguageDetector` |

--- a/apps/docs/src/content/docs/guides/webmcp.mdx
+++ b/apps/docs/src/content/docs/guides/webmcp.mdx
@@ -1,9 +1,9 @@
 ---
 title: WebMCP
-description: Register agent-callable tools on the W3C WebMCP surface (navigator.modelContext) with AbortSignal-based cleanup.
+description: Register agent-callable tools on the W3C WebMCP surface (document.modelContext) with AbortSignal-based cleanup.
 ---
 
-Building block for the W3C [WebMCP](https://webmachinelearning.github.io/webmcp/) API exposed at `navigator.modelContext`. Register agent-callable tools from any framework; the package is vanilla TypeScript / DOM with an optional React adapter shipped as a subpath export. See [useWebMCP](/docs/react/use-web-mcp/) for React.
+Building block for the W3C [WebMCP](https://webmachinelearning.github.io/webmcp/) API exposed at `document.modelContext`. (For backward compatibility with the previous shape of the API, this package also reads from `navigator.modelContext`.) Register agent-callable tools from any framework; the package is vanilla TypeScript / DOM with an optional React adapter shipped as a subpath export. See [useWebMCP](/docs/react/use-web-mcp/) for React.
 
 ## Usage
 
@@ -57,13 +57,13 @@ interface Tool<TInput = unknown, TOutput = unknown> {
 
 ## Returns
 
-`registerTool(tool)` returns a cleanup function: `() => void`. Calling it unregisters the tool. Calling it twice is a no-op. On browsers without `navigator.modelContext`, the cleanup is itself a no-op.
+`registerTool(tool)` returns a cleanup function: `() => void`. Calling it unregisters the tool. Calling it twice is a no-op. On browsers without `document.modelContext` (or the legacy `navigator.modelContext`), the cleanup is itself a no-op.
 
 ## How it works
 
-Chrome's `navigator.modelContext.registerTool({...}, { signal })` is the spec entry point. The wrapper sits on top with three quality-of-life additions:
+`document.modelContext.registerTool({...}, { signal })` is the spec entry point. (For backward compatibility with the previous shape of the API, this package also reads from `navigator.modelContext`.) The wrapper sits on top with three quality-of-life additions:
 
-- **Feature detection.** On browsers without `navigator.modelContext`, every entry point is a no-op so consumer code ships unchanged. `isAvailable()` returns `false`.
+- **Feature detection.** On browsers without `document.modelContext` (or the legacy `navigator.modelContext`), every entry point is a no-op so consumer code ships unchanged. `isAvailable()` returns `false`.
 - **Last-writer-wins on duplicate names.** React effect cleanup is asynchronous; a fast re-render can attempt to register `"foo"` before Chrome processed the prior `abort()`. The wrapper detects the resulting duplicate-name error, queues a microtask retry, and tracks ownership so a stale registration can't squat the name.
 - **One AbortController per call.** `registerTool` returns a cleanup function that aborts the underlying controller and unregisters the tool.
 

--- a/apps/docs/src/content/docs/react/use-web-mcp.mdx
+++ b/apps/docs/src/content/docs/react/use-web-mcp.mdx
@@ -68,7 +68,7 @@ The hook returns nothing; cleanup is automatic on unmount via `useEffect`'s retu
 
 ## Errors and unavailability
 
-On browsers without `navigator.modelContext`, the hook is a no-op. Render whatever fallback UI you want; nothing breaks.
+On browsers without `document.modelContext` (or the legacy `navigator.modelContext`), the hook is a no-op. Render whatever fallback UI you want; nothing breaks.
 
 ## Reference
 

--- a/apps/landing/scripts/build-llms.mjs
+++ b/apps/landing/scripts/build-llms.mjs
@@ -118,7 +118,7 @@ function buildLlmsIndex() {
     "- [Browser support](" + SITE_URL + "/docs/browser-support/): which Chrome/Edge versions and flags each API needs.",
     "- [Meta-package](" + SITE_URL + "/docs/guides/meta-package/): `@web-ai-sdk/all` — subpath vs namespaced import shapes.",
     "- [Prompt](" + SITE_URL + "/docs/guides/prompt/): conceptual overview — sessions, streaming, sampling, structured output, abort.",
-    "- [WebMCP](" + SITE_URL + "/docs/guides/webmcp/): registering tools with `navigator.modelContext`.",
+    "- [WebMCP](" + SITE_URL + "/docs/guides/webmcp/): registering tools with `document.modelContext`.",
     "- [Summarizer](" + SITE_URL + "/docs/guides/summarizer/): TL;DR / key-points / headline with streaming.",
     "- [Translator](" + SITE_URL + "/docs/guides/translator/): block-level DOM translation with snapshot restore.",
     "- [Detector](" + SITE_URL + "/docs/guides/detector/): on-device language detection with confidence.",

--- a/apps/landing/src/App.tsx
+++ b/apps/landing/src/App.tsx
@@ -878,9 +878,9 @@ export const App = () => (
                 Browser built-in AI
               </div>
               <div className={`${stackDetail} ${stackDetailMuted}`}>
-                document.modelContext &nbsp; Summarizer &nbsp; Translator
-                &nbsp; LanguageModel &nbsp; LanguageDetector &nbsp; Writer
-                &nbsp; Rewriter &nbsp; Proofreader
+                document.modelContext &nbsp; Summarizer &nbsp; Translator &nbsp;
+                LanguageModel &nbsp; LanguageDetector &nbsp; Writer &nbsp;
+                Rewriter &nbsp; Proofreader
               </div>
             </div>
             <span className={stackOwner}>platform</span>

--- a/apps/landing/src/App.tsx
+++ b/apps/landing/src/App.tsx
@@ -413,7 +413,7 @@ export const App = () => (
               </li>
               <li>
                 <span>
-                  <b>Spec aligned.</b> Wraps <code>navigator.modelContext</code>{" "}
+                  <b>Spec aligned.</b> Wraps <code>document.modelContext</code>{" "}
                   verbatim.
                 </span>
               </li>
@@ -878,7 +878,7 @@ export const App = () => (
                 Browser built-in AI
               </div>
               <div className={`${stackDetail} ${stackDetailMuted}`}>
-                navigator.modelContext &nbsp; Summarizer &nbsp; Translator
+                document.modelContext &nbsp; Summarizer &nbsp; Translator
                 &nbsp; LanguageModel &nbsp; LanguageDetector &nbsp; Writer
                 &nbsp; Rewriter &nbsp; Proofreader
               </div>

--- a/apps/landing/src/components/WebMCPDemo.tsx
+++ b/apps/landing/src/components/WebMCPDemo.tsx
@@ -155,8 +155,8 @@ export const WebMCPDemo = () => {
           ? async () => ({
               ok: true,
               // Only the actually-registered tools. A disabled tool is not
-              // in `navigator.modelContext` at all, so listing it here
-              // would be inaccurate.
+              // in the model context at all, so listing it here would be
+              // inaccurate.
               registered: TOOL_SPECS.filter((t) =>
                 enabledIdsRef.current.has(t.id),
               ).map((t) => ({
@@ -179,12 +179,13 @@ export const WebMCPDemo = () => {
 
   const run = async () => {
     if (running) return;
-    // Defensive bail: on browsers without `navigator.modelContext` the demo's
-    // tool execute closures are pure JS and would still "succeed" if invoked
-    // directly, which makes the trace pretend WebMCP worked. Refuse to run
-    // when the API is missing so the unavailable banner is the only thing
-    // the visitor sees. The button below is also disabled in the same
-    // condition; this guard is the second line of defence.
+    // Defensive bail: on browsers without `document.modelContext` (or the
+    // legacy `navigator.modelContext`), the demo's tool execute closures are
+    // pure JS and would still "succeed" if invoked directly, which makes the
+    // trace pretend WebMCP worked. Refuse to run when the API is missing so
+    // the unavailable banner is the only thing the visitor sees. The button
+    // below is also disabled in the same condition; this guard is the second
+    // line of defence.
     if (available === false) return;
     setRunning(true);
     setTrace([]);
@@ -201,7 +202,7 @@ export const WebMCPDemo = () => {
     await push(
       {
         kind: "step",
-        text: `navigator.modelContext.listTools() → ${enabledCount} tool${enabledCount === 1 ? "" : "s"}`,
+        text: `document.modelContext.listTools() → ${enabledCount} tool${enabledCount === 1 ? "" : "s"}`,
       },
       200,
     );

--- a/packages/webmcp/README.md
+++ b/packages/webmcp/README.md
@@ -1,6 +1,6 @@
 # @web-ai-sdk/webmcp
 
-Building block for the W3C [WebMCP](https://webmachinelearning.github.io/webmcp/) API exposed at `navigator.modelContext`.
+Building block for the W3C [WebMCP](https://webmachinelearning.github.io/webmcp/) API exposed at `document.modelContext`. (For backward compatibility with the previous shape of the API, this package also reads from `navigator.modelContext`.)
 
 An ergonomic, framework-agnostic adapter over the native browser API, with safe register/unregister cleanup and a feature-detected no-op fallback for non-supporting browsers.
 
@@ -8,7 +8,7 @@ An ergonomic, framework-agnostic adapter over the native browser API, with safe 
 
 ## Status
 
-WebMCP shipped as an early preview in Chrome 146+ behind `chrome://flags/#enable-webmcp-testing`; a public [origin trial](https://developer.chrome.com/docs/ai/webmcp) opens in Chrome 149. Edge added support in 147+ behind the matching `edge://flags/` toggle. On any browser that doesn't expose `navigator.modelContext`, this library is a no-op. Your app stays callable, and no tools get registered.
+WebMCP shipped as an early preview in Chrome 146+ behind `chrome://flags/#enable-webmcp-testing`; a public [origin trial](https://developer.chrome.com/docs/ai/webmcp) opens in Chrome 149. Edge added support in 147+ behind the matching `edge://flags/` toggle. On any browser that doesn't expose `document.modelContext` (or the legacy `navigator.modelContext`), this library is a no-op. Your app stays callable, and no tools get registered.
 
 ## Install
 
@@ -188,7 +188,7 @@ Mark mutating tools `destructive: true`. The host (browser, agent) is responsibl
 
 ## Troubleshooting
 
-- **Inspector / agent doesn't see the tools.** `navigator.modelContext` is per-Window. Tools registered inside an `<iframe>` are scoped to that frame and invisible to extensions hooked into the top page. Register from the top-level document, not from an embedded frame.
+- **Inspector / agent doesn't see the tools.** The WebMCP entry point is per-Window. Tools registered inside an `<iframe>` are scoped to that frame and invisible to extensions hooked into the top page. Register from the top-level document, not from an embedded frame.
 
 ## License
 

--- a/packages/webmcp/package.json
+++ b/packages/webmcp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@web-ai-sdk/webmcp",
   "version": "0.5.2",
-  "description": "Building block for the Web's native WebMCP API (navigator.modelContext)",
+  "description": "Building block for the Web's native WebMCP API (document.modelContext)",
   "license": "MIT",
   "author": "Beto Muniz",
   "homepage": "https://github.com/obetomuniz/web-ai-sdk/tree/main/packages/webmcp#readme",

--- a/packages/webmcp/src/index.test.ts
+++ b/packages/webmcp/src/index.test.ts
@@ -19,12 +19,23 @@ interface RegisterOptions {
   signal?: AbortSignal;
 }
 
+type Host = "document" | "navigator";
+
+const setModelContext = (host: Host, value: unknown) => {
+  Object.defineProperty(
+    host === "document" ? document : navigator,
+    "modelContext",
+    { value, configurable: true },
+  );
+};
+
 /**
- * Mirror Chrome's native `navigator.modelContext` shape: a single
- * `registerTool(def, { signal? })` method. There is no `unregisterTool`;
- * cleanup happens by aborting the signal that was passed at registration.
+ * Mirror the native WebMCP shape: a single `registerTool(def, { signal? })`
+ * method. There is no `unregisterTool`; cleanup happens by aborting the signal
+ * that was passed at registration. Installs on `navigator` by default; pass
+ * `host: "document"` to mount on `document.modelContext` instead.
  */
-const installFakeModelContext = () => {
+const installFakeModelContext = (host: Host = "navigator") => {
   const registered = new Map<string, RegisteredCall>();
   const registerTool = vi.fn(
     (def: RegisteredCall, options?: RegisterOptions) => {
@@ -41,33 +52,43 @@ const installFakeModelContext = () => {
   );
 
   const mc = { registerTool };
-  Object.defineProperty(navigator, "modelContext", {
-    value: mc,
-    configurable: true,
-  });
+  setModelContext(host, mc);
 
   return { mc, registered, registerTool };
 };
 
-const removeModelContext = () => {
-  Object.defineProperty(navigator, "modelContext", {
-    value: undefined,
-    configurable: true,
-  });
-};
-
 afterEach(() => {
-  removeModelContext();
+  setModelContext("document", undefined);
+  setModelContext("navigator", undefined);
 });
 
 describe("feature detection", () => {
-  it("isAvailable() is false when navigator.modelContext is missing", () => {
+  it("isAvailable() is false when modelContext is missing on both hosts", () => {
     expect(isAvailable()).toBe(false);
   });
 
   it("isAvailable() is true when navigator.modelContext is present", () => {
-    installFakeModelContext();
+    installFakeModelContext("navigator");
     expect(isAvailable()).toBe(true);
+  });
+
+  it("isAvailable() is true when document.modelContext is present", () => {
+    installFakeModelContext("document");
+    expect(isAvailable()).toBe(true);
+  });
+
+  it("prefers document.modelContext over navigator.modelContext when both are present", () => {
+    const onDoc = installFakeModelContext("document");
+    const onNav = installFakeModelContext("navigator");
+
+    registerTool({
+      name: "ping",
+      description: "Returns pong.",
+      execute: async () => ({ result: "pong" }),
+    });
+
+    expect(onDoc.registerTool).toHaveBeenCalledTimes(1);
+    expect(onNav.registerTool).not.toHaveBeenCalled();
   });
 });
 
@@ -81,7 +102,7 @@ describe("registerTool", () => {
     expect(() => cleanup()).not.toThrow();
   });
 
-  it("forwards name/description/execute to navigator.modelContext", async () => {
+  it("forwards name/description/execute to the host modelContext", async () => {
     const { registered, registerTool: spy } = installFakeModelContext();
 
     registerTool({

--- a/packages/webmcp/src/index.ts
+++ b/packages/webmcp/src/index.ts
@@ -1,5 +1,7 @@
 /**
- * Building block for the W3C WebMCP API exposed at `navigator.modelContext`.
+ * Building block for the W3C WebMCP API exposed at `document.modelContext`.
+ * For backward compatibility with the previous shape of the API, this
+ * package also reads from `navigator.modelContext`.
  *
  * Adapts the native browser API into a shape that's pleasant to call from
  * app code, with AbortSignal-based cleanup and a feature-detected no-op
@@ -192,13 +194,23 @@ interface ModelContext {
   registerTool: (def: RegisteredTool, options?: RegisterToolOptions) => void;
 }
 
-interface NavigatorWithModelContext {
+interface HostWithModelContext {
   modelContext?: ModelContext;
 }
 
+// Read from `document.modelContext` (the spec entry point). Fall back to
+// `navigator.modelContext` for backward compatibility with the previous
+// shape of the API.
 const getModelContext = (): ModelContext | undefined => {
-  if (typeof navigator === "undefined") return undefined;
-  return (navigator as NavigatorWithModelContext).modelContext;
+  if (typeof document !== "undefined") {
+    const fromDocument = (document as unknown as HostWithModelContext)
+      .modelContext;
+    if (fromDocument) return fromDocument;
+  }
+  if (typeof navigator !== "undefined") {
+    return (navigator as unknown as HostWithModelContext).modelContext;
+  }
+  return undefined;
 };
 
 /** Whether the current environment exposes the WebMCP API. */

--- a/packages/webmcp/src/react/index.test.tsx
+++ b/packages/webmcp/src/react/index.test.tsx
@@ -11,7 +11,17 @@ interface RegisteredCall {
   execute: (input: unknown) => unknown;
 }
 
-const installFakeModelContext = () => {
+type Host = "document" | "navigator";
+
+const setModelContext = (host: Host, value: unknown) => {
+  Object.defineProperty(
+    host === "document" ? document : navigator,
+    "modelContext",
+    { value, configurable: true },
+  );
+};
+
+const installFakeModelContext = (host: Host = "navigator") => {
   const registered = new Map<string, RegisteredCall>();
   const registerTool = vi.fn(
     (def: RegisteredCall, options?: { signal?: AbortSignal }) => {
@@ -27,19 +37,14 @@ const installFakeModelContext = () => {
     },
   );
 
-  Object.defineProperty(navigator, "modelContext", {
-    value: { registerTool },
-    configurable: true,
-  });
+  setModelContext(host, { registerTool });
 
   return { registered };
 };
 
 afterEach(() => {
-  Object.defineProperty(navigator, "modelContext", {
-    value: undefined,
-    configurable: true,
-  });
+  setModelContext("document", undefined);
+  setModelContext("navigator", undefined);
 });
 
 describe("useWebMCP", () => {
@@ -77,6 +82,18 @@ describe("useWebMCP", () => {
     rerender({ tools: v2 });
     expect(registered.has("a")).toBe(false);
     expect(registered.has("b")).toBe(true);
+  });
+
+  it("works when modelContext is exposed on document instead of navigator", () => {
+    const { registered } = installFakeModelContext("document");
+    const tools: Tool[] = [
+      { name: "a", description: "A", execute: async () => ({}) },
+    ];
+
+    const { unmount } = renderHook(() => useWebMCP(tools));
+    expect(registered.has("a")).toBe(true);
+    unmount();
+    expect(registered.has("a")).toBe(false);
   });
 
   it("is a no-op when WebMCP is unavailable", () => {

--- a/packages/webmcp/src/react/index.ts
+++ b/packages/webmcp/src/react/index.ts
@@ -6,7 +6,8 @@ import { type Tool, registerTool } from "../index.js";
  * unmount. Pass a stable `tools` reference (e.g. via `useMemo`); the effect
  * re-runs whenever the array reference changes.
  *
- * On browsers that don't expose `navigator.modelContext`, the hook is a no-op.
+ * On browsers that don't expose `document.modelContext` (or the legacy
+ * `navigator.modelContext`), the hook is a no-op.
  */
 export const useWebMCP = (tools: readonly Tool[]): void => {
   useEffect(() => {


### PR DESCRIPTION
## Summary

- `document.modelContext` is the W3C WebMCP spec entry point; `navigator.modelContext` is the previous shape of the API. The wrapper now reads from `document.modelContext` first and falls back to `navigator.modelContext` so apps keep working against implementations that still expose the older binding.
- No public API change — `registerTool`, `isAvailable`, and the `useWebMCP` hook all behave identically; only the underlying global lookup is broader.
- Docs / READMEs / demo strings reframed: `document.modelContext` as primary, `navigator.modelContext` mentioned only as a backward-compat note.

Closes #34.

## Test plan

- [x] `pnpm --filter @web-ai-sdk/webmcp test` — 27/27 pass (added cases for `document.modelContext`, precedence when both are present, and React hook on `document`)
- [x] `pnpm --filter @web-ai-sdk/webmcp typecheck` — clean
- [x] `pnpm --filter @web-ai-sdk-apps/landing typecheck` — clean
- [x] `pnpm --filter @web-ai-sdk-apps/docs typecheck` — clean
- [ ] Manual smoke: load the docs demo in a Chrome build that exposes `document.modelContext` and confirm `isAvailable()` returns true and tools register.
- [ ] Manual smoke: load it in a build that only exposes `navigator.modelContext` and confirm the fallback path still works.