### PR TITLE
docs(webmcp): say per-document instead of per-Window in troubleshooting

### DIFF
--- a/packages/webmcp/README.md
+++ b/packages/webmcp/README.md
@@ -188,7 +188,7 @@ Mark mutating tools `destructive: true`. The host (browser, agent) is responsibl
 
 ## Troubleshooting
 
-- **Inspector / agent doesn't see the tools.** The WebMCP entry point is per-Window. Tools registered inside an `<iframe>` are scoped to that frame and invisible to extensions hooked into the top page. Register from the top-level document, not from an embedded frame.
+- **Inspector / agent doesn't see the tools.** The WebMCP entry point is per-document; each frame, including iframes, has its own `document.modelContext`. Tools registered inside an `<iframe>` are scoped to that frame and invisible to extensions hooked into the top page. Register from the top-level document, not from an embedded frame.
 
 ## License
 


### PR DESCRIPTION
## Summary

- Follow-up to #36. Now that the WebMCP binding lives on `Document` (`document.modelContext`), the README troubleshooting note describing iframe scoping should say "per-document" rather than "per-Window".
- Also notes that each frame (including iframes) has its own `document.modelContext`, which is the cleaner way to make the iframe-scoping point.

Docs-only wording change. No code or API impact, so no changeset.

## Test plan

- [x] `pnpm lint` clean (Biome does not lint Markdown; change is a single line in `packages/webmcp/README.md`)
- [ ] Visual skim of the rendered README troubleshooting section