### PR TITLE
chore(repo): add Dependabot config and CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+# Default owner for everything in the repo. Auto-requests review on PRs.
+# Review is requested, not required (no "require code owner reviews" rule),
+# so this never blocks external contributors.
+* @obetomuniz

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,27 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    groups:
+      dev-dependencies:
+        dependency-type: "development"
+        patterns:
+          - "*"
+      production-dependencies:
+        dependency-type: "production"
+        update-types:
+          - "minor"
+          - "patch"
+        patterns:
+          - "*"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      github-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
## Summary

Part of hardening the repo now that it takes external contributions. Adds two small config files:

- **`.github/dependabot.yml`** — weekly grouped update PRs for `npm` (dev deps grouped; prod deps limited to minor/patch) and `github-actions`. Keeps dependencies current with low PR noise.
- **`.github/CODEOWNERS`** — auto-requests maintainer review on PRs. Review is *requested, not required* (no "require code owner reviews" rule on the branch protection), so it never blocks external contributors.

The rest of the hardening was applied directly via repo settings (branch protection on `main`, read-only `GITHUB_TOKEN`, secret scanning + push protection, Dependabot alerts/security updates).

## Test plan

- [x] No code/build impact (config files only)
- [ ] After merge: confirm Dependabot raises its first PRs on schedule