### PR TITLE
chore(repo): exclude major updates from Dependabot groups

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,9 +5,16 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 10
+    # Group only minor/patch updates so a single green PR can sweep them up.
+    # Major updates are intentionally excluded from the groups: each lands as
+    # its own PR so a breaking bump can't block the rest of the batch (a single
+    # major in a group turns the whole grouped PR red).
     groups:
       dev-dependencies:
         dependency-type: "development"
+        update-types:
+          - "minor"
+          - "patch"
         patterns:
           - "*"
       production-dependencies:


### PR DESCRIPTION
## Summary

Restrict both npm Dependabot groups (dev + production) to `minor`/`patch` updates so **major** bumps each get their own PR instead of being bundled into a group.

A single breaking major in a grouped PR turns the entire grouped PR red, which is exactly what happened with the initial `dev-dependencies` group (it bundled Biome 2, TypeScript 6, Vite 8, etc., and failed wholesale). Isolating majors keeps the minor/patch sweep green and auto-mergeable, while majors get individual, reviewable PRs.

`github-actions` stays fully grouped (action majors are low-risk and nicer batched).

## Test plan

- [x] Config-only change; no code/build impact
- [ ] Confirm next weekly Dependabot run produces a green grouped minor/patch PR + separate major PRs