### PR TITLE
chore(repo): upgrade Biome to 2.4.16

### DIFF
--- a/apps/docs/src/components/WebMCPDemo.tsx
+++ b/apps/docs/src/components/WebMCPDemo.tsx
@@ -1,4 +1,4 @@
-import { type Tool, isAvailable } from "@web-ai-sdk/webmcp";
+import { isAvailable, type Tool } from "@web-ai-sdk/webmcp";
 import { useWebMCP } from "@web-ai-sdk/webmcp/react";
 import { useCallback, useEffect, useMemo, useState } from "react";
 

--- a/apps/landing/src/components/DetectorDemo.tsx
+++ b/apps/landing/src/components/DetectorDemo.tsx
@@ -20,10 +20,10 @@ import {
 } from "../lib/ui.js";
 import {
   DownloadNotice,
+  detectModelName,
   ErrorNotice,
   StatusBar,
   UnavailableNotice,
-  detectModelName,
   useStreamStats,
 } from "./shared.js";
 

--- a/apps/landing/src/components/PromptDemo.tsx
+++ b/apps/landing/src/components/PromptDemo.tsx
@@ -21,10 +21,10 @@ import {
 } from "../lib/ui.js";
 import {
   DownloadNotice,
+  detectModelName,
   MarkdownOutput,
   StatusBar,
   UnavailableNotice,
-  detectModelName,
   useDownloadMonitor,
   useStreamStats,
 } from "./shared.js";

--- a/apps/landing/src/components/ProofreaderDemo.tsx
+++ b/apps/landing/src/components/ProofreaderDemo.tsx
@@ -1,6 +1,6 @@
 import {
-  ProofreaderUnavailableError,
   isAvailable as isProofreaderAvailable,
+  ProofreaderUnavailableError,
   proofread,
 } from "@web-ai-sdk/proofreader";
 import { useEffect, useRef, useState } from "react";

--- a/apps/landing/src/components/RewriterDemo.tsx
+++ b/apps/landing/src/components/RewriterDemo.tsx
@@ -1,6 +1,6 @@
 import {
-  RewriterUnavailableError,
   isAvailable as isRewriterAvailable,
+  RewriterUnavailableError,
   rewrite,
 } from "@web-ai-sdk/rewriter";
 import { useEffect, useRef, useState } from "react";

--- a/apps/landing/src/components/ShaderBackdrop.tsx
+++ b/apps/landing/src/components/ShaderBackdrop.tsx
@@ -77,6 +77,7 @@ export function ShaderBackdrop({
     gl.attachShader(prog, fs);
     gl.linkProgram(prog);
     if (!gl.getProgramParameter(prog, gl.LINK_STATUS)) return;
+    // biome-ignore lint/correctness/useHookAtTopLevel: gl.useProgram is the WebGL rendering API, not a React hook
     gl.useProgram(prog);
 
     const buf = gl.createBuffer();

--- a/apps/landing/src/components/SummarizerDemo.tsx
+++ b/apps/landing/src/components/SummarizerDemo.tsx
@@ -1,6 +1,6 @@
 import {
-  SummarizerUnavailableError,
   isAvailable as isSummarizerAvailable,
+  SummarizerUnavailableError,
   summarize,
 } from "@web-ai-sdk/summarizer";
 import { useEffect, useRef, useState } from "react";

--- a/apps/landing/src/components/ThemeSwitcher.tsx
+++ b/apps/landing/src/components/ThemeSwitcher.tsx
@@ -1,12 +1,12 @@
 import { useEffect, useState } from "react";
 import {
+  applyTheme,
+  clearTheme,
   DEFAULT_MODE,
   DEFAULT_THEME_ID,
   type Mode,
-  THEMES,
-  applyTheme,
-  clearTheme,
   resolveTheme,
+  THEMES,
 } from "../lib/themes.js";
 
 const LS_THEME = "wais-theme";
@@ -39,13 +39,11 @@ export function ThemeSwitcher() {
   }, [themeId, mode]);
 
   return (
-    <div
-      className="fixed top-[4.5rem] right-3 z-40 flex items-center gap-1 rounded-pill border border-hairline-2 bg-surface px-1.5 py-1 font-mono text-[11px] text-fg-4 transition-colors hover:bg-surface-2 hover:text-fg-2"
-      aria-label="Tone Lab theme selector"
-    >
+    <div className="fixed top-[4.5rem] right-3 z-40 flex items-center gap-1 rounded-pill border border-hairline-2 bg-surface px-1.5 py-1 font-mono text-[11px] text-fg-4 transition-colors hover:bg-surface-2 hover:text-fg-2">
       <select
         value={themeId}
         onChange={(e) => setThemeId(e.target.value)}
+        aria-label="Tone Lab theme selector"
         className="cursor-pointer rounded-pill bg-transparent px-1.5 py-0.5 text-fg-2 outline-none transition-colors hover:text-fg"
       >
         {THEMES.map((t) => (

--- a/apps/landing/src/components/TranslatorDemo.tsx
+++ b/apps/landing/src/components/TranslatorDemo.tsx
@@ -1,6 +1,6 @@
 import {
-  TranslatorUnavailableError,
   isAvailable as isTranslatorAvailable,
+  TranslatorUnavailableError,
   translate,
 } from "@web-ai-sdk/translator";
 import { useEffect, useRef, useState } from "react";

--- a/apps/landing/src/components/WebMCPDemo.tsx
+++ b/apps/landing/src/components/WebMCPDemo.tsx
@@ -1,11 +1,11 @@
 import {
-  PromptUnavailableError,
   ask,
   isAvailable as isPromptAvailable,
+  PromptUnavailableError,
 } from "@web-ai-sdk/prompt";
 import {
-  type Tool,
   isAvailable as isWebMcpAvailable,
+  type Tool,
 } from "@web-ai-sdk/webmcp";
 import { useWebMCP } from "@web-ai-sdk/webmcp/react";
 import { useEffect, useMemo, useRef, useState } from "react";
@@ -25,7 +25,6 @@ import {
   demoControls,
   fieldGroup,
   fieldLegend,
-  fieldSpaced,
   fieldset,
   label,
   outputBox,
@@ -473,6 +472,7 @@ Reply with ONLY valid JSON of the shape {"tool":"name_or_null","args":{},"reason
             trace.map((ev, i) => {
               if (ev.kind === "call") {
                 return (
+                  // biome-ignore lint/suspicious/noArrayIndexKey: the trace is an append-only log rendered in order; entries are never reordered or removed, so the index is a stable key
                   <div key={`${ev.tool}-${i}`} className="mb-1.5">
                     <span className="text-accent">→ call</span>{" "}
                     <span>{ev.tool}</span>
@@ -502,6 +502,7 @@ Reply with ONLY valid JSON of the shape {"tool":"name_or_null","args":{},"reason
                       ? "✓ "
                       : "· ";
               return (
+                // biome-ignore lint/suspicious/noArrayIndexKey: the trace is an append-only log rendered in order; entries are never reordered or removed, so the index is a stable key
                 <div key={`${ev.kind}-${i}`} className={`${colorClass} mb-1`}>
                   {prefix}
                   {ev.text}

--- a/apps/landing/src/components/WriterDemo.tsx
+++ b/apps/landing/src/components/WriterDemo.tsx
@@ -1,6 +1,6 @@
 import {
-  WriterUnavailableError,
   isAvailable as isWriterAvailable,
+  WriterUnavailableError,
   write,
 } from "@web-ai-sdk/writer";
 import { useEffect, useRef, useState } from "react";

--- a/biome.json
+++ b/biome.json
@@ -1,19 +1,17 @@
 {
-  "$schema": "https://biomejs.dev/schemas/1.9.4/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.4.16/schema.json",
   "files": {
-    "include": [
-      "packages/**/*.ts",
-      "packages/**/*.tsx",
-      "apps/**/*.ts",
-      "apps/**/*.tsx"
-    ],
-    "ignore": [
-      "**/dist/**",
-      "**/node_modules/**",
-      "**/*.d.ts",
-      "**/storybook-static/**",
-      "**/.astro/**",
-      "**/_site/**"
+    "includes": [
+      "**/packages/**/*.ts",
+      "**/packages/**/*.tsx",
+      "**/apps/**/*.ts",
+      "**/apps/**/*.tsx",
+      "!**/dist",
+      "!**/node_modules",
+      "!**/*.d.ts",
+      "!**/storybook-static",
+      "!**/.astro",
+      "!**/_site"
     ]
   },
   "linter": {

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "pages:preview": "pnpm pages:build && serve _site -p 4173"
   },
   "devDependencies": {
-    "@biomejs/biome": "^1.9.4",
+    "@biomejs/biome": "2.4.16",
     "@changesets/cli": "^2.27.10",
     "serve": "14.2.6",
     "typescript": "^5.7.2"

--- a/packages/detector/src/index.ts
+++ b/packages/detector/src/index.ts
@@ -10,16 +10,16 @@
 
 import {
   type CreateMonitor,
+  checkAvailability,
   type DetectionResult,
+  getLanguageDetectorApi,
+  getOrCreateLanguageDetector,
+  isAvailable,
   type LanguageDetectorApi,
   type LanguageDetectorAvailability,
   type LanguageDetectorAvailabilityOptions,
   type LanguageDetectorCreateOptions,
   type LanguageDetectorInstance,
-  checkAvailability,
-  getLanguageDetectorApi,
-  getOrCreateLanguageDetector,
-  isAvailable,
 } from "./api.js";
 import {
   type CacheOption,
@@ -28,19 +28,18 @@ import {
   resolveCache,
 } from "./cache.js";
 
-export { isAvailable, checkAvailability };
-
 export type {
   CacheOption,
   CreateMonitor,
-  DetectionResult,
   DetectionCache,
+  DetectionResult,
   LanguageDetectorApi,
   LanguageDetectorAvailability,
   LanguageDetectorAvailabilityOptions,
   LanguageDetectorCreateOptions,
   LanguageDetectorInstance,
 };
+export { checkAvailability, isAvailable };
 
 export interface DetectOptions {
   /** Text to detect. Empty / whitespace-only input resolves to `{ output: null }`. */

--- a/packages/detector/src/react/index.ts
+++ b/packages/detector/src/react/index.ts
@@ -1,9 +1,8 @@
 import { useEffect, useRef, useState } from "react";
 import {
   type DetectOptions,
-  type DetectResult,
-  type DetectionResult,
   DetectorUnavailableError,
+  type DetectResult,
   detect,
   isAvailable,
 } from "../index.js";
@@ -117,9 +116,9 @@ export const useDetector = (options: UseDetectorOptions): UseDetectorReturn => {
 };
 
 export type {
+  CacheOption,
+  DetectionCache,
+  DetectionResult,
   DetectOptions,
   DetectResult,
-  DetectionResult,
-  DetectionCache,
-  CacheOption,
 } from "../index.js";

--- a/packages/prompt/src/index.test.ts
+++ b/packages/prompt/src/index.test.ts
@@ -1,12 +1,12 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { __clearSessionCacheForTests } from "./api.js";
 import {
-  PromptAbortError,
-  PromptUnavailableError,
-  type ResponseCache,
   ask,
   createSession,
   isAvailable,
+  PromptAbortError,
+  PromptUnavailableError,
+  type ResponseCache,
 } from "./index.js";
 
 interface FakeSession {

--- a/packages/prompt/src/index.ts
+++ b/packages/prompt/src/index.ts
@@ -10,6 +10,10 @@
 
 import {
   type CreateMonitor,
+  checkAvailability,
+  getLanguageModelApi,
+  getOrCreateLanguageModel,
+  isAvailable,
   type LanguageModelApi,
   type LanguageModelAvailability,
   type LanguageModelCreateOptions,
@@ -20,43 +24,32 @@ import {
   type LanguageModelParams,
   type LanguageModelPromptOptions,
   type LanguageModelTool,
-  checkAvailability,
-  getLanguageModelApi,
-  getOrCreateLanguageModel,
-  isAvailable,
 } from "./api.js";
 import {
   type CacheOption,
   type DefaultCacheKeyInput,
-  type ResponseCache,
   defaultCacheKey,
+  type ResponseCache,
   resolveCache,
 } from "./cache.js";
 import {
+  buildLangHints,
   type CreateSessionOptions,
+  createSession,
+  mergeStreamChunk,
   PromptAbortError,
   PromptUnavailableError,
   type Session,
   SessionDestroyedError,
   type SessionSendOptions,
-  buildLangHints,
-  createSession,
-  mergeStreamChunk,
   sanitizeResponse,
 } from "./session.js";
-
-export {
-  isAvailable,
-  checkAvailability,
-  createSession,
-  PromptAbortError,
-  PromptUnavailableError,
-  SessionDestroyedError,
-};
 
 export type {
   CacheOption,
   CreateMonitor,
+  CreateSessionOptions,
+  DefaultCacheKeyInput,
   LanguageModelApi,
   LanguageModelAvailability,
   LanguageModelCreateOptions,
@@ -67,10 +60,16 @@ export type {
   LanguageModelParams,
   LanguageModelTool,
   ResponseCache,
-  DefaultCacheKeyInput,
   Session,
   SessionSendOptions,
-  CreateSessionOptions,
+};
+export {
+  checkAvailability,
+  createSession,
+  isAvailable,
+  PromptAbortError,
+  PromptUnavailableError,
+  SessionDestroyedError,
 };
 
 export interface AskOptions {

--- a/packages/prompt/src/react/index.ts
+++ b/packages/prompt/src/react/index.ts
@@ -2,12 +2,12 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import {
   type AskOptions,
   type AskResult,
-  type CreateSessionOptions,
-  PromptUnavailableError,
-  type Session,
   ask,
+  type CreateSessionOptions,
   createSession,
   isAvailable,
+  PromptUnavailableError,
+  type Session,
 } from "../index.js";
 
 export type PromptStatus =
@@ -250,9 +250,9 @@ export const useSession = (
 export type {
   AskOptions,
   AskResult,
-  ResponseCache,
   CacheOption,
   CreateSessionOptions,
   LanguageModelTool,
+  ResponseCache,
   Session,
 } from "../index.js";

--- a/packages/prompt/src/session.ts
+++ b/packages/prompt/src/session.ts
@@ -20,6 +20,7 @@
  */
 
 import {
+  getLanguageModelApi,
   type LanguageModelApi,
   type LanguageModelCreateOptions,
   type LanguageModelExpectedInput,
@@ -27,7 +28,6 @@ import {
   type LanguageModelInstance,
   type LanguageModelPromptOptions,
   type LanguageModelTool,
-  getLanguageModelApi,
 } from "./api.js";
 
 const NORMALIZE_LANG = (lang: string): string =>

--- a/packages/proofreader/src/index.test.ts
+++ b/packages/proofreader/src/index.test.ts
@@ -1,9 +1,9 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { __clearSessionCacheForTests } from "./api.js";
 import {
+  isAvailable,
   type ProofreadCache,
   ProofreaderUnavailableError,
-  isAvailable,
   proofread,
 } from "./index.js";
 

--- a/packages/proofreader/src/index.ts
+++ b/packages/proofreader/src/index.ts
@@ -10,31 +10,29 @@
 
 import {
   type CreateMonitor,
+  getOrCreateProofreader,
+  getProofreaderApi,
   type ProofreadCorrection,
-  type ProofreadOutput,
   type ProofreaderApi,
   type ProofreaderAvailability,
   type ProofreaderAvailabilityOptions,
   type ProofreaderCreateOptions,
   type ProofreaderInstance,
-  checkAvailability,
-  getOrCreateProofreader,
-  getProofreaderApi,
-  isAvailable,
+  type ProofreadOutput,
 } from "./api.js";
 import {
   type CacheOption,
-  type ProofreadCache,
   defaultCacheKey,
+  type ProofreadCache,
   resolveCache,
 } from "./cache.js";
 
 export {
-  isAvailable,
   checkAvailability,
   clearProofreaderSessions,
   getOrCreateProofreader,
   getProofreaderApi,
+  isAvailable,
 } from "./api.js";
 
 export { defaultCacheKey, resolveCache } from "./cache.js";
@@ -44,12 +42,12 @@ export type {
   CreateMonitor,
   ProofreadCache,
   ProofreadCorrection,
-  ProofreadOutput,
   ProofreaderApi,
   ProofreaderAvailability,
   ProofreaderAvailabilityOptions,
   ProofreaderCreateOptions,
   ProofreaderInstance,
+  ProofreadOutput,
 };
 
 export interface ProofreadOptions {

--- a/packages/proofreader/src/react/index.ts
+++ b/packages/proofreader/src/react/index.ts
@@ -1,9 +1,9 @@
 import { useEffect, useState } from "react";
 import {
+  isAvailable,
+  ProofreaderUnavailableError,
   type ProofreadOptions,
   type ProofreadResult,
-  ProofreaderUnavailableError,
-  isAvailable,
   proofread,
 } from "../index.js";
 
@@ -100,10 +100,10 @@ export const useProofreader = (
 };
 
 export type {
-  ProofreadOptions,
-  ProofreadResult,
-  ProofreadOutput,
-  ProofreadCorrection,
-  ProofreadCache,
   CacheOption,
+  ProofreadCache,
+  ProofreadCorrection,
+  ProofreadOptions,
+  ProofreadOutput,
+  ProofreadResult,
 } from "../index.js";

--- a/packages/rewriter/src/index.test.ts
+++ b/packages/rewriter/src/index.test.ts
@@ -1,9 +1,9 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { __clearSessionCacheForTests } from "./api.js";
 import {
+  isAvailable,
   type RewriteCache,
   RewriterUnavailableError,
-  isAvailable,
   rewrite,
 } from "./index.js";
 

--- a/packages/rewriter/src/index.ts
+++ b/packages/rewriter/src/index.ts
@@ -9,31 +9,29 @@
 
 import {
   type CreateMonitor,
+  getOrCreateRewriter,
+  getRewriterApi,
   type RewriterApi,
   type RewriterAvailability,
   type RewriterAvailabilityOptions,
   type RewriterCreateOptions,
   type RewriterInstance,
-  checkAvailability,
-  getOrCreateRewriter,
-  getRewriterApi,
-  isAvailable,
 } from "./api.js";
 import {
   type CacheOption,
-  type RewriteCache,
   defaultCacheKey,
+  type RewriteCache,
   resolveCache,
 } from "./cache.js";
 
 export {
-  isAvailable,
   checkAvailability,
-  clearRewriterSessions,
   clearRewriterSession,
+  clearRewriterSessions,
   configureRewriterCache,
   getOrCreateRewriter,
   getRewriterApi,
+  isAvailable,
 } from "./api.js";
 
 export { defaultCacheKey, resolveCache } from "./cache.js";

--- a/packages/rewriter/src/react/index.ts
+++ b/packages/rewriter/src/react/index.ts
@@ -1,8 +1,8 @@
 import { useEffect, useState } from "react";
 import {
+  isAvailable,
   type RewriteOptions,
   RewriterUnavailableError,
-  isAvailable,
   rewrite,
 } from "../index.js";
 
@@ -141,8 +141,8 @@ export const useRewriter = (options: UseRewriterOptions): UseRewriterReturn => {
 };
 
 export type {
+  CacheOption,
+  RewriteCache,
   RewriteOptions,
   RewriteResult,
-  RewriteCache,
-  CacheOption,
 } from "../index.js";

--- a/packages/sdk/src/index.test.ts
+++ b/packages/sdk/src/index.test.ts
@@ -1,8 +1,6 @@
 import { describe, expect, it } from "vitest";
-
-import * as sdk from "./index.js";
-
 import * as detectorSubpath from "./detector.js";
+import * as sdk from "./index.js";
 import * as promptSubpath from "./prompt.js";
 import * as proofreaderSubpath from "./proofreader.js";
 import * as rewriterSubpath from "./rewriter.js";

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -18,11 +18,11 @@
  * (e.g. `checkAvailability` is defined in most of them).
  */
 
+export * as detector from "@web-ai-sdk/detector";
 export * as prompt from "@web-ai-sdk/prompt";
-export * as webmcp from "@web-ai-sdk/webmcp";
+export * as proofreader from "@web-ai-sdk/proofreader";
+export * as rewriter from "@web-ai-sdk/rewriter";
 export * as summarizer from "@web-ai-sdk/summarizer";
 export * as translator from "@web-ai-sdk/translator";
-export * as detector from "@web-ai-sdk/detector";
+export * as webmcp from "@web-ai-sdk/webmcp";
 export * as writer from "@web-ai-sdk/writer";
-export * as rewriter from "@web-ai-sdk/rewriter";
-export * as proofreader from "@web-ai-sdk/proofreader";

--- a/packages/summarizer/src/index.test.ts
+++ b/packages/summarizer/src/index.test.ts
@@ -1,9 +1,9 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { __clearSessionCacheForTests } from "./api.js";
 import {
+  isAvailable,
   SummarizerUnavailableError,
   type SummaryCache,
-  isAvailable,
   summarize,
 } from "./index.js";
 

--- a/packages/summarizer/src/index.ts
+++ b/packages/summarizer/src/index.ts
@@ -9,25 +9,23 @@
 
 import {
   type CreateMonitor,
+  checkAvailability,
+  getOrCreateSummarizer,
+  getSummarizerApi,
+  isAvailable,
   type SummarizerApi,
   type SummarizerAvailability,
   type SummarizerAvailabilityOptions,
   type SummarizerCreateOptions,
   type SummarizerInstance,
-  checkAvailability,
-  getOrCreateSummarizer,
-  getSummarizerApi,
-  isAvailable,
 } from "./api.js";
 import {
   type CacheOption,
-  type SummaryCache,
   defaultCacheKey,
   resolveCache,
+  type SummaryCache,
 } from "./cache.js";
 import { cleanSummary } from "./skeleton.js";
-
-export { isAvailable, checkAvailability };
 
 export type {
   CacheOption,
@@ -39,6 +37,7 @@ export type {
   SummarizerInstance,
   SummaryCache,
 };
+export { checkAvailability, isAvailable };
 
 export interface SummarizeOptions {
   /** Text to summarize. Empty / whitespace input resolves to `{ output: null }`. */

--- a/packages/summarizer/src/react/index.ts
+++ b/packages/summarizer/src/react/index.ts
@@ -1,8 +1,8 @@
 import { useEffect, useState } from "react";
 import {
+  isAvailable,
   type SummarizeOptions,
   SummarizerUnavailableError,
-  isAvailable,
   summarize,
 } from "../index.js";
 
@@ -143,8 +143,8 @@ export const useSummarizer = (
 };
 
 export type {
+  CacheOption,
   SummarizeOptions,
   SummarizeResult,
   SummaryCache,
-  CacheOption,
 } from "../index.js";

--- a/packages/translator/src/index.test.ts
+++ b/packages/translator/src/index.test.ts
@@ -1,9 +1,9 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { __clearSessionCacheForTests } from "./api.js";
 import {
+  isAvailable,
   type TranslationCache,
   TranslatorUnavailableError,
-  isAvailable,
   translate,
 } from "./index.js";
 

--- a/packages/translator/src/index.ts
+++ b/packages/translator/src/index.ts
@@ -8,25 +8,23 @@
  */
 
 import {
+  checkAvailability,
+  getOrCreateTranslator,
+  getTranslatorApi,
+  isAvailable,
   type TranslatorApi,
   type TranslatorAvailability,
   type TranslatorAvailabilityOptions,
   type TranslatorCreateOptions,
   type TranslatorInstance,
   type TranslatorMonitor,
-  checkAvailability,
-  getOrCreateTranslator,
-  getTranslatorApi,
-  isAvailable,
 } from "./api.js";
 import {
   type CacheOption,
-  type TranslationCache,
   defaultCacheKey,
   resolveCache,
+  type TranslationCache,
 } from "./cache.js";
-
-export { isAvailable, checkAvailability };
 
 export type {
   CacheOption,
@@ -38,6 +36,7 @@ export type {
   TranslatorInstance,
   TranslatorMonitor,
 };
+export { checkAvailability, isAvailable };
 
 const NORMALIZE_LANG = (lang: string): string =>
   lang.split("-")[0]?.toLowerCase() ?? lang.toLowerCase();

--- a/packages/translator/src/react/index.ts
+++ b/packages/translator/src/react/index.ts
@@ -1,8 +1,8 @@
 import { useEffect, useState } from "react";
 import {
+  isAvailable,
   type TranslateOptions,
   TranslatorUnavailableError,
-  isAvailable,
   translate,
 } from "../index.js";
 
@@ -106,8 +106,8 @@ export const useTranslator = (
 };
 
 export type {
+  CacheOption,
   TranslateOptions,
   TranslateResult,
   TranslationCache,
-  CacheOption,
 } from "../index.js";

--- a/packages/webmcp/src/index.test.ts
+++ b/packages/webmcp/src/index.test.ts
@@ -1,10 +1,10 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
-  type StandardSchemaV1,
-  ToolValidationError,
   defineTool,
   isAvailable,
   registerTool,
+  type StandardSchemaV1,
+  ToolValidationError,
 } from "./index.js";
 
 interface RegisteredCall {

--- a/packages/webmcp/src/index.ts
+++ b/packages/webmcp/src/index.ts
@@ -66,9 +66,8 @@ export namespace StandardSchemaV1 {
     readonly key: PropertyKey;
   }
 
-  export type InferInput<S> = S extends StandardSchemaV1<infer In, unknown>
-    ? In
-    : unknown;
+  export type InferInput<S> =
+    S extends StandardSchemaV1<infer In, unknown> ? In : unknown;
 }
 
 export class ToolValidationError extends Error {

--- a/packages/webmcp/src/react/index.ts
+++ b/packages/webmcp/src/react/index.ts
@@ -1,5 +1,5 @@
 import { useEffect } from "react";
-import { type Tool, registerTool } from "../index.js";
+import { registerTool, type Tool } from "../index.js";
 
 /**
  * React hook that registers WebMCP tools on mount and unregisters them on
@@ -18,10 +18,10 @@ export const useWebMCP = (tools: readonly Tool[]): void => {
   }, [tools]);
 };
 
-export { defineTool, ToolValidationError } from "../index.js";
 export type {
-  Tool,
-  ToolAnnotations,
   DefineToolOptions,
   StandardSchemaV1,
+  Tool,
+  ToolAnnotations,
 } from "../index.js";
+export { defineTool, ToolValidationError } from "../index.js";

--- a/packages/writer/src/index.test.ts
+++ b/packages/writer/src/index.test.ts
@@ -1,9 +1,9 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { __clearSessionCacheForTests } from "./api.js";
 import {
+  isAvailable,
   type WriteCache,
   WriterUnavailableError,
-  isAvailable,
   write,
 } from "./index.js";
 

--- a/packages/writer/src/index.ts
+++ b/packages/writer/src/index.ts
@@ -9,31 +9,29 @@
 
 import {
   type CreateMonitor,
+  getOrCreateWriter,
+  getWriterApi,
   type WriterApi,
   type WriterAvailability,
   type WriterAvailabilityOptions,
   type WriterCreateOptions,
   type WriterInstance,
-  checkAvailability,
-  getOrCreateWriter,
-  getWriterApi,
-  isAvailable,
 } from "./api.js";
 import {
   type CacheOption,
-  type WriteCache,
   defaultCacheKey,
   resolveCache,
+  type WriteCache,
 } from "./cache.js";
 
 export {
-  isAvailable,
   checkAvailability,
-  clearWriterSessions,
   clearWriterSession,
+  clearWriterSessions,
   configureWriterCache,
   getOrCreateWriter,
   getWriterApi,
+  isAvailable,
 } from "./api.js";
 
 export { defaultCacheKey, resolveCache } from "./cache.js";

--- a/packages/writer/src/react/index.ts
+++ b/packages/writer/src/react/index.ts
@@ -1,8 +1,8 @@
 import { useEffect, useState } from "react";
 import {
+  isAvailable,
   type WriteOptions,
   WriterUnavailableError,
-  isAvailable,
   write,
 } from "../index.js";
 
@@ -141,8 +141,8 @@ export const useWriter = (options: UseWriterOptions): UseWriterReturn => {
 };
 
 export type {
+  CacheOption,
+  WriteCache,
   WriteOptions,
   WriteResult,
-  WriteCache,
-  CacheOption,
 } from "../index.js";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     devDependencies:
       '@biomejs/biome':
-        specifier: ^1.9.4
-        version: 1.9.4
+        specifier: 2.4.16
+        version: 2.4.16
       '@changesets/cli':
         specifier: ^2.27.10
         version: 2.31.0(@types/node@25.9.1)
@@ -558,55 +558,55 @@ packages:
     resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
     engines: {node: '>=6.9.0'}
 
-  '@biomejs/biome@1.9.4':
-    resolution: {integrity: sha512-1rkd7G70+o9KkTn5KLmDYXihGoTaIGO9PIIN2ZB7UJxFrWw04CZHPYiMRjYsaDvVV7hP1dYNRLxSANLaBFGpog==}
+  '@biomejs/biome@2.4.16':
+    resolution: {integrity: sha512-x9ajFh1zChVybCiM3TN6OD4phAqLgtPZjFrZF+aTMYCPjwBO+k529TX7PPsAqtGNLeV4UgzwQnowEgS7bGmzcA==}
     engines: {node: '>=14.21.3'}
     hasBin: true
 
-  '@biomejs/cli-darwin-arm64@1.9.4':
-    resolution: {integrity: sha512-bFBsPWrNvkdKrNCYeAp+xo2HecOGPAy9WyNyB/jKnnedgzl4W4Hb9ZMzYNbf8dMCGmUdSavlYHiR01QaYR58cw==}
+  '@biomejs/cli-darwin-arm64@2.4.16':
+    resolution: {integrity: sha512-wxPvu4XOA85YJk9ixSWUmq/QBHbid85BISbOAqqBM/5xQpPk9ayjk5375tOlSC0BeCwNSbPFafQBm+vBumXq0A==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [darwin]
 
-  '@biomejs/cli-darwin-x64@1.9.4':
-    resolution: {integrity: sha512-ngYBh/+bEedqkSevPVhLP4QfVPCpb+4BBe2p7Xs32dBgs7rh9nY2AIYUL6BgLw1JVXV8GlpKmb/hNiuIxfPfZg==}
+  '@biomejs/cli-darwin-x64@2.4.16':
+    resolution: {integrity: sha512-xFCqGPwYusQJp4N4NJLi1XJiZqjwFdjhT+KqtNy+Ug3qgfczqnTa6MSDvxJF6TkuDLoYJItMapz6tAf7kCekFw==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [darwin]
 
-  '@biomejs/cli-linux-arm64-musl@1.9.4':
-    resolution: {integrity: sha512-v665Ct9WCRjGa8+kTr0CzApU0+XXtRgwmzIf1SeKSGAv+2scAlW6JR5PMFo6FzqqZ64Po79cKODKf3/AAmECqA==}
+  '@biomejs/cli-linux-arm64-musl@2.4.16':
+    resolution: {integrity: sha512-oYxnW0ARfJkr72ezzF2OR8N/rtkgLUQeYtF8cFhVswbknHxtTcmzSsanVJP8yQKnGpGpc2ck6c5zLvHahL6Cbg==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
 
-  '@biomejs/cli-linux-arm64@1.9.4':
-    resolution: {integrity: sha512-fJIW0+LYujdjUgJJuwesP4EjIBl/N/TcOX3IvIHJQNsAqvV2CHIogsmA94BPG6jZATS4Hi+xv4SkBBQSt1N4/g==}
+  '@biomejs/cli-linux-arm64@2.4.16':
+    resolution: {integrity: sha512-2kFb4//jxfZaP6D+Rj5VkHkxgyD9EoRAVBEQb8PKRv+s4NO2zYNJKXFaJmK1CmhufJOWEfpHKaRbOja7qjmdhQ==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
 
-  '@biomejs/cli-linux-x64-musl@1.9.4':
-    resolution: {integrity: sha512-gEhi/jSBhZ2m6wjV530Yy8+fNqG8PAinM3oV7CyO+6c3CEh16Eizm21uHVsyVBEB6RIM8JHIl6AGYCv6Q6Q9Tg==}
+  '@biomejs/cli-linux-x64-musl@2.4.16':
+    resolution: {integrity: sha512-iHDS+MCM65DPqWGu+ECC3uoALyj2H7F4nVUPxIPjz/PIl94EUu+EDfGZDzFP+NY1EOPVt9NQvwFqq7HdMmowdg==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
 
-  '@biomejs/cli-linux-x64@1.9.4':
-    resolution: {integrity: sha512-lRCJv/Vi3Vlwmbd6K+oQ0KhLHMAysN8lXoCI7XeHlxaajk06u7G+UsFSO01NAs5iYuWKmVZjmiOzJ0OJmGsMwg==}
+  '@biomejs/cli-linux-x64@2.4.16':
+    resolution: {integrity: sha512-NbcBbi/nJqn5baae6wqRXdS7Gadf2uRpehSh6vMSYpG8OhkXl/Xg8aorWrJ+9VWqAT5ml90alLvorkpMW0nBwQ==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
 
-  '@biomejs/cli-win32-arm64@1.9.4':
-    resolution: {integrity: sha512-tlbhLk+WXZmgwoIKwHIHEBZUwxml7bRJgk0X2sPyNR3S93cdRq6XulAZRQJ17FYGGzWne0fgrXBKpl7l4M87Hg==}
+  '@biomejs/cli-win32-arm64@2.4.16':
+    resolution: {integrity: sha512-0rgImMsNb5v/chhkIFe3wu7PEFClS6RBAYUijGL9UsYN3PanSaoK24HSSuSJb1pYbYYVjzAyZTl3gtjJ84BM8A==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [win32]
 
-  '@biomejs/cli-win32-x64@1.9.4':
-    resolution: {integrity: sha512-8Y5wMhVIPaWe6jw2H+KlEm4wP/f7EW3810ZLmDlrEEy5KvBsb9ECEfu/kMWD484ijfQ8+nIi0giMgu9g1UAuuA==}
+  '@biomejs/cli-win32-x64@2.4.16':
+    resolution: {integrity: sha512-Kp85jgoBHa05gix6UIRjfCDiUV3w/8VIdZ247VyyO2gEjaw12WEVhdIjlxp/AMzXxqxQwbxNTDVZ3Mwd2RG5rw==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [win32]
@@ -4525,39 +4525,39 @@ snapshots:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
 
-  '@biomejs/biome@1.9.4':
+  '@biomejs/biome@2.4.16':
     optionalDependencies:
-      '@biomejs/cli-darwin-arm64': 1.9.4
-      '@biomejs/cli-darwin-x64': 1.9.4
-      '@biomejs/cli-linux-arm64': 1.9.4
-      '@biomejs/cli-linux-arm64-musl': 1.9.4
-      '@biomejs/cli-linux-x64': 1.9.4
-      '@biomejs/cli-linux-x64-musl': 1.9.4
-      '@biomejs/cli-win32-arm64': 1.9.4
-      '@biomejs/cli-win32-x64': 1.9.4
+      '@biomejs/cli-darwin-arm64': 2.4.16
+      '@biomejs/cli-darwin-x64': 2.4.16
+      '@biomejs/cli-linux-arm64': 2.4.16
+      '@biomejs/cli-linux-arm64-musl': 2.4.16
+      '@biomejs/cli-linux-x64': 2.4.16
+      '@biomejs/cli-linux-x64-musl': 2.4.16
+      '@biomejs/cli-win32-arm64': 2.4.16
+      '@biomejs/cli-win32-x64': 2.4.16
 
-  '@biomejs/cli-darwin-arm64@1.9.4':
+  '@biomejs/cli-darwin-arm64@2.4.16':
     optional: true
 
-  '@biomejs/cli-darwin-x64@1.9.4':
+  '@biomejs/cli-darwin-x64@2.4.16':
     optional: true
 
-  '@biomejs/cli-linux-arm64-musl@1.9.4':
+  '@biomejs/cli-linux-arm64-musl@2.4.16':
     optional: true
 
-  '@biomejs/cli-linux-arm64@1.9.4':
+  '@biomejs/cli-linux-arm64@2.4.16':
     optional: true
 
-  '@biomejs/cli-linux-x64-musl@1.9.4':
+  '@biomejs/cli-linux-x64-musl@2.4.16':
     optional: true
 
-  '@biomejs/cli-linux-x64@1.9.4':
+  '@biomejs/cli-linux-x64@2.4.16':
     optional: true
 
-  '@biomejs/cli-win32-arm64@1.9.4':
+  '@biomejs/cli-win32-arm64@2.4.16':
     optional: true
 
-  '@biomejs/cli-win32-x64@1.9.4':
+  '@biomejs/cli-win32-x64@2.4.16':
     optional: true
 
   '@capsizecss/unpack@4.0.0':


### PR DESCRIPTION
## Summary

Upgrades Biome 1.9.4 → **2.4.16** (the Biome major from the original dev-dependencies group #41, now isolated per the new grouping config).

What's in here:
- **Config migration** (`biome migrate`): `files.include`/`files.ignore` → `files.includes` with `!` negations; `$schema` bumped to 2.4.16.
- **Formatter pass**: Biome 2's formatter produced whitespace deltas across packages/apps (the bulk of the diff, mechanical).
- **Unused imports** newly flagged by Biome 2 removed from the detector/proofreader/rewriter/writer cores and `WebMCPDemo`.
- **a11y fix**: `aria-label` moved from the unsupported wrapper `<div>` onto the `<select>` it labels (`ThemeSwitcher`).
- **Two suppressions with rationale**:
  - `gl.useProgram` in `ShaderBackdrop` — a WebGL API, not a React hook (false positive of `useHookAtTopLevel`'s `use*` heuristic).
  - append-only trace index keys in `WebMCPDemo` (`noArrayIndexKey`) — the trace is render-in-order and never reordered.

Pinned to exactly `2.4.16` per the supply-chain freshness policy.

## Test plan

- [x] `pnpm exec biome check` clean locally (0 errors)
- [ ] CI `gate` green (lint + build + typecheck + test)