### PR TITLE
chore(repo): add Dependabot cooldown for dependency freshness

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,14 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 10
+    # Wait before proposing a freshly-published version, giving the ecosystem
+    # time to flag a malicious or broken release (supply-chain hygiene). Mirrors
+    # the repo's >=72h freshness guidance. Security/advisory updates are exempt
+    # by Dependabot, so urgent fixes still land immediately. Note: cooldown
+    # applies to direct deps only, not transitives.
+    cooldown:
+      default-days: 3
+      semver-major-days: 7
     # Group only minor/patch updates so a single green PR can sweep them up.
     # Major updates are intentionally excluded from the groups: each lands as
     # its own PR so a breaking bump can't block the rest of the batch (a single
@@ -28,6 +36,9 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 3
+      semver-major-days: 7
     groups:
       github-actions:
         patterns:


### PR DESCRIPTION
## Summary

Adds a Dependabot `cooldown` to both the `npm` and `github-actions` ecosystems so version-update PRs wait before adopting a freshly-published release, giving the ecosystem time to flag a malicious or broken version.

- `default-days: 3`, `semver-major-days: 7` (mirrors the repo's >=72h supply-chain freshness guidance).
- **Security/advisory updates are exempt** by Dependabot, so urgent fixes still open immediately.

### Notes / scope
- Cooldown is a **soft delay on PR creation**, not a CI gate, so it never blocks merges or perpetually reds-out PRs; routine updates just appear a few days later.
- It applies to **direct dependencies only** (a documented Dependabot limitation; transitives aren't covered). The repo's >=72h agent rule still backs up transitives and manual installs.
- Hard, resolution-level enforcement that also covers transitives (pnpm `minimumReleaseAge` / Renovate) was evaluated and deferred; it requires the pnpm 11 upgrade and adds CI friction.

## Test plan

- [x] Config-only change; no code/build impact
- [ ] Confirm the next Dependabot run honors the cooldown window