### PR TITLE
fix(repo): drop unsupported semver-major-days from github-actions cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -36,9 +36,10 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    # The github-actions ecosystem only supports `default-days` for cooldown
+    # (no semver-*-days tiers).
     cooldown:
       default-days: 3
-      semver-major-days: 7
     groups:
       github-actions:
         patterns:


### PR DESCRIPTION
## Summary

Fixes the `.github/dependabot.yml` config-validation failure introduced by #64. Dependabot rejects `semver-major-days` for the **github-actions** ecosystem (it only supports `default-days`):

```
The property '#/updates/1/cooldown/semver-major-days' is not supported for the package ecosystem 'github-actions'.
```

The `gate` CI doesn't validate `dependabot.yml` against Dependabot's schema, so it slipped through; GitHub's native Dependabot config check caught it and was showing red on every open PR (e.g. #37). This drops the semver tier from the github-actions block (keeping it on npm, where it's supported) so cooldown there is just `default-days: 3`.

## Test plan

- [x] github-actions cooldown reduced to `default-days` only (npm keeps the semver tier)
- [ ] `.github/dependabot.yml` config check passes