### PR TITLE
feat(summarizer): default `preference` to "auto" + docs sync (0.6.0)

### DIFF
--- a/.changeset/summarizer-preference-auto-default.md
+++ b/.changeset/summarizer-preference-auto-default.md
@@ -1,0 +1,10 @@
+---
+"@web-ai-sdk/summarizer": minor
+"@web-ai-sdk/proofreader": patch
+---
+
+summarizer: default `preference` to `"auto"` instead of `"speed"`, matching the platform default.
+
+`summarize()` previously forced `preference: "speed"` whenever the option was omitted, biasing every consumer toward the low-latency/lower-capability path and risking surprising unavailability for configurations a faster model can't serve (e.g. non-English languages). The default is now `"auto"`, letting the browser balance speed and capability; opt into `"speed"` or `"capability"` explicitly. The `preference` hint is also forwarded into the `availability()` probe so it stays consistent with the session `create()` actually makes.
+
+proofreader: document that the API is English-only today (`expectedInputLanguages` accepts an array, but unsupported languages reject and surface as `ProofreaderUnavailableError`).

--- a/.changeset/summarizer-preference-auto-default.md
+++ b/.changeset/summarizer-preference-auto-default.md
@@ -7,4 +7,6 @@ summarizer: default `preference` to `"auto"` instead of `"speed"`, matching the 
 
 `summarize()` previously forced `preference: "speed"` whenever the option was omitted, biasing every consumer toward the low-latency/lower-capability path and risking surprising unavailability for configurations a faster model can't serve (e.g. non-English languages). The default is now `"auto"`, letting the browser balance speed and capability; opt into `"speed"` or `"capability"` explicitly. The `preference` hint is also forwarded into the `availability()` probe so it stays consistent with the session `create()` actually makes.
 
+Also rewrites the package README, which had drifted to a pre-0.4 API shape (`article`/`text`/`summary`, `isSummarizerAvailable`, `createSessionStorageCache`, skeleton helpers), to match the current `summarize({ input, language, … }) -> { output, cached }` surface.
+
 proofreader: document that the API is English-only today (`expectedInputLanguages` accepts an array, but unsupported languages reject and surface as `ProofreaderUnavailableError`).

--- a/apps/docs/src/content/docs/guides/proofreader.mdx
+++ b/apps/docs/src/content/docs/guides/proofreader.mdx
@@ -41,7 +41,7 @@ interface ProofreadOptions {
 | Name | Type | Description |
 | --- | --- | --- |
 | `input` <sup>required</sup> | `string` | Text to proofread. Empty / whitespace resolves to `{ output: null }`. |
-| `expectedInputLanguages` | `readonly string[]` | BCP-47 languages the proofreader should expect as input. |
+| `expectedInputLanguages` | `readonly string[]` | BCP-47 languages the proofreader should expect as input. English-only today; see [Language support](#language-support). |
 | `monitor` | `(m) => void` | Observe the first-call model download. |
 | `cache` | `"session" \| "local" \| { get, set }` | Opt-in result cache (stores the serialized output). |
 | `cacheKey` | `string` | Override the default cache key. |
@@ -87,6 +87,10 @@ for (const c of output.corrections) {
 if (cursor < input.length)
   spans.push({ text: input.slice(cursor), error: false });
 ```
+
+## Language support
+
+The Proofreader API is **English-only** today. `expectedInputLanguages` accepts an array for forward compatibility, but requesting a language the browser can't proofread causes the native `create()` to reject, which this wrapper surfaces as `ProofreaderUnavailableError`. Pass `["en"]` or omit the option until more languages ship.
 
 ## No streaming
 

--- a/apps/docs/src/content/docs/guides/summarizer.mdx
+++ b/apps/docs/src/content/docs/guides/summarizer.mdx
@@ -120,7 +120,27 @@ summarize({ language: "en", input: text, preference: "speed", length: "short" })
 summarize({ language: "en", input: text, preference: "capability" });
 ```
 
-It's a hint, not a guarantee. The browser may override `"speed"` and fall back to a more capable model when a functional requirement — such as the requested language, type, or length — needs one. When a configuration can't be served at all, the wrapper surfaces it as unavailability (the availability probe receives the same `preference`, so it stays consistent with what `create()` would do). The default is `"auto"` to match the platform default; opt into `"speed"` or `"capability"` explicitly when you have a clear preference.
+The default is `"auto"` to match the platform default; `"speed"` and `"capability"` are explicit opt-ins.
+
+### `"speed"` is narrower than `"auto"`
+
+The faster model behind `"speed"` does not serve every configuration. Some combinations of `language`, `type`, `length`, and `format` are not available on the speed path, and there is no promise that the browser silently upgrades you to a more capable model when they aren't — the configuration can instead be reported as **unavailable**. When that happens, `summarize()` throws `SummarizerUnavailableError`, the same way it does for any unavailable configuration.
+
+This wrapper forwards `preference` into the `availability()` probe, so the probe and the session `create()` agree: if `availability()` reports the `"speed"` configuration as unavailable, `summarize()` fails fast instead of creating a session that can't serve the request. Because of this, treat `"speed"` as an opt-in you guard — be ready to fall back to `"auto"` on unavailability (or pre-check with `checkAvailability({ preference: "speed", … })`):
+
+```ts
+import { summarize, SummarizerUnavailableError } from "@web-ai-sdk/summarizer";
+
+const opts = { language: "en", input: text, type: "tldr", length: "short" } as const;
+
+try {
+  await summarize({ ...opts, preference: "speed" });
+} catch (err) {
+  if (err instanceof SummarizerUnavailableError) {
+    await summarize({ ...opts, preference: "auto" });
+  } else throw err;
+}
+```
 
 ## Output normalization
 

--- a/apps/docs/src/content/docs/guides/summarizer.mdx
+++ b/apps/docs/src/content/docs/guides/summarizer.mdx
@@ -53,7 +53,7 @@ interface SummarizeOptions {
 | `type` | `"tldr" \| "key-points" \| "teaser" \| "headline"` | Summary shape. Defaults to `"tldr"`. |
 | `length` | `"short" \| "medium" \| "long"` | Length preset. Defaults to `"medium"`. |
 | `format` | `"plain-text" \| "markdown"` | Output format. Defaults to `"plain-text"`. |
-| `preference` | `"auto" \| "speed" \| "capability"` | Performance preference. Defaults to `"speed"`. |
+| `preference` | `"auto" \| "speed" \| "capability"` | Performance preference hint. Defaults to `"auto"`. See [Performance preference](#performance-preference). |
 | `sharedContext` | `string` | Native `sharedContext` string (a hint about who/what the summary is for). |
 | `monitor` | `(m) => void` | Observe the first-call model download (~1.7 GB on a fresh profile). |
 | `cache` | `"session" \| "local" \| { get, set }` | Opt-in result cache. |
@@ -103,6 +103,24 @@ summarize({ language: "en", input: text, cache: "local" });
 ## Streaming
 
 When the underlying Summarizer instance exposes `summarizeStreaming()`, the library uses it and pushes cleaned chunks to `onUpdate` as they arrive (cumulative buffer, not deltas). Otherwise it falls back to one-shot `summarize()`. Either way, `result.output` is the final cleaned text.
+
+## Performance preference
+
+`preference` is a hint about the speed/quality tradeoff the browser should make when it picks the underlying model. It maps straight to the native `Summarizer.create()` option:
+
+- `"auto"` (default) — the browser balances execution speed with summarization capability, and may adjust based on the environment, system constraints, or context.
+- `"speed"` — prioritizes low latency and fast execution. This can route to a smaller, faster model, which may produce less nuanced or simpler summaries.
+- `"capability"` — prioritizes comprehensiveness and coherence, capturing subtler context at the cost of higher latency.
+
+```ts
+// Fast path for short, low-stakes summaries (e.g. list previews).
+summarize({ language: "en", input: text, preference: "speed", length: "short" });
+
+// Quality path for a single, carefully written summary.
+summarize({ language: "en", input: text, preference: "capability" });
+```
+
+It's a hint, not a guarantee. The browser may override `"speed"` and fall back to a more capable model when a functional requirement — such as the requested language, type, or length — needs one. When a configuration can't be served at all, the wrapper surfaces it as unavailability (the availability probe receives the same `preference`, so it stays consistent with what `create()` would do). The default is `"auto"` to match the platform default; opt into `"speed"` or `"capability"` explicitly when you have a clear preference.
 
 ## Output normalization
 

--- a/packages/proofreader/README.md
+++ b/packages/proofreader/README.md
@@ -8,6 +8,8 @@ Building block for the Web's Built-in [Proofreader API](https://developer.chrome
 
 The Proofreader API is in an origin trial in Chrome 141 to 145, behind `chrome://flags/#proofreader-api-for-gemini-nano` on localhost (`chrome://flags/#optimization-guide-on-device-model` must also be enabled). In Edge it's a developer preview in Canary/Dev 142+ behind "Proofreader API for Phi mini". On any other browser this library is a no-op for the React hook (it stays in `"unavailable"`). The vanilla `proofread()` throws `ProofreaderUnavailableError` so callers can branch explicitly.
 
+The API is **English-only** today. `expectedInputLanguages` accepts an array, but a request for an unsupported language causes the underlying `create()` to reject (surfaced here as `ProofreaderUnavailableError`); pass `["en"]` or omit it.
+
 ## Install
 
 ```sh

--- a/packages/summarizer/README.md
+++ b/packages/summarizer/README.md
@@ -1,6 +1,6 @@
 # @web-ai-sdk/summarizer
 
-Building block for the Web's Built-in [Summarizer API](https://developer.chrome.com/docs/ai/summarizer-api). Skeleton extraction, sentence-boundary trimming, streaming, and sessionStorage caching.
+Building block for the Web's Built-in [Summarizer API](https://developer.chrome.com/docs/ai/summarizer-api). String-mode summarization with session reuse, output cleaning, streaming, and opt-in result caching.
 
 **Docs:** <https://web-ai-sdk.dev/docs/guides/summarizer/> · **React:** [`useSummarizer`](https://web-ai-sdk.dev/docs/react/use-summarizer/)
 
@@ -17,132 +17,120 @@ pnpm add @web-ai-sdk/summarizer
 
 The React adapter ships as a subpath export, with no extra install. `react` is a peer dependency only when you import the `/react` entry.
 
-## How it works
-
-1. **Build a skeleton**: title + description + every `h1-h4` and `<strong>`/`<b>` inside the article. That's the highest-signal content; for long posts it drops the input from thousands of chars to a few hundred and produces a tighter summary. Falls back to the trimmed body when the skeleton is too thin.
-2. **Trim to a sentence boundary** so the model never sees a half-cut sentence (default cap: 3000 chars).
-3. **Cache `Summarizer.create()` sessions** by JSON-stringified options. First post pays the ~1-3s cold start; later same-config calls reuse the warm session.
-4. **Stream `summarizeStreaming()`** when the instance supports it, falling back to one-shot `summarize()`. Cleaned chunks are pushed to `onUpdate` as they arrive (cumulative buffer).
-5. **Optionally cache the final summary** when you pass a `cache` (e.g. `createSessionStorageCache()`). Off by default; opt in for revisits in the same tab to render instantly without invoking the model.
-
 ## Vanilla TypeScript / DOM
 
 ```ts
 import { summarize } from "@web-ai-sdk/summarizer";
 
 const result = await summarize({
+  input: longArticleText,
   language: "en",
-  article: document.querySelector("article")!,
-  title: "My Post",
-  description: "About interesting things",
-  onUpdate: (text) => console.log("partial", text),
+  type: "key-points",
+  length: "short",
+  onUpdate: (text) => render(text),
 });
 
-console.log(result.summary, result.cached);
+console.log(result.output, result.cached);
 ```
+
+`result.output` is the cleaned summary text, or `null` when the input is empty. `result.cached` tells you whether the response came from the cache without invoking the model.
 
 ## React
 
 ```tsx
 import { useSummarizer } from "@web-ai-sdk/summarizer/react";
-import { useMemo } from "react";
 
-export function PostSummary({ article }: { article: HTMLElement | null }) {
-  const result = useSummarizer({
+export function PostSummary({ text }: { text: string }) {
+  const { status, output, dismiss } = useSummarizer({
+    input: text,
     language: "en",
-    article: article ?? undefined,
-    title: "My Post",
-    description: "About interesting things",
+    type: "key-points",
   });
 
-  if (result.status === "unavailable") return null;
-  if (result.status === "loading") return <p>Generating summary…</p>;
-  if (!result.summary) return null;
+  if (status === "unavailable") return null;
+  if (status === "loading") return <p>Generating summary…</p>;
+  if (!output) return null;
 
   return (
     <aside>
-      <p>{result.summary}</p>
-      <button type="button" onClick={result.dismiss}>Dismiss</button>
+      <p>{output}</p>
+      <button type="button" onClick={dismiss}>Dismiss</button>
     </aside>
   );
 }
 ```
 
-State machine: `pending | loading | streaming | done | unavailable`. `summary` is the latest cleaned text (grows during streaming). `fromCache` is `true` when the result came back without invoking the model.
+State machine: `idle | loading | streaming | done | unavailable`. `output` is the latest cleaned text (grows during streaming). `fromCache` is `true` when the result came back without invoking the model.
 
 ## API
 
 ### `summarize(options): Promise<SummarizeResult>`
 
-Run a one-shot summarization.
-
 ```ts
 interface SummarizeOptions {
+  input: string;
   language: string;
-  article?: Element; // skeleton extracted from this
-  text?: string;     // or pass pre-built input directly
-  title?: string;
-  description?: string;
   supportedLanguages?: readonly string[]; // default ["en", "es", "ja"]
-  sharedContext?: Record<string, string>; // per-language steering prompt
-  createOptions?: Partial<SummarizerCreateOptions>;
-  maxInputChars?: number;     // default 3000
-  minSkeletonChars?: number;  // default 200
-  cache?: SummaryCache;
-  cacheKey?: string;
+  type?: "tldr" | "key-points" | "teaser" | "headline"; // default "tldr"
+  length?: "short" | "medium" | "long";                 // default "medium"
+  format?: "plain-text" | "markdown";                   // default "plain-text"
+  preference?: "auto" | "speed" | "capability";         // default "auto"
+  sharedContext?: string;
+  monitor?: (m: CreateMonitor) => void;
+  cache?: "session" | "local" | { get, set };
+  cacheKey?: string; // default `${pathname}:${lang}`
   onUpdate?: (text: string) => void;
   signal?: AbortSignal;
 }
 
 interface SummarizeResult {
-  summary: string | null;
+  output: string | null;
   cached: boolean;
 }
 ```
 
-### `isSummarizerAvailable(): boolean`
+### `isAvailable(): boolean`
 
 Feature-detect helper.
 
-### `checkAvailability(): Promise<SummarizerAvailability | null>`
+### `checkAvailability(options?): Promise<SummarizerAvailability | null>`
 
 Forwards to the spec's `availability()` call. Returns `null` if the global is missing or the call throws.
 
-### `createSessionStorageCache({ storage?, prefix? }): SummaryCache`
+## Performance preference
 
-Optional cache backend. Pass it to `summarize({ cache })` to enable result caching, with an optional custom `storage` (e.g. `localStorage`, an in-memory polyfill).
+`preference` is a hint about the speed/quality tradeoff the browser makes when picking the underlying model:
+
+- `"auto"` (default) balances speed and capability.
+- `"speed"` prioritizes low latency, which can route to a smaller, faster model that produces less nuanced summaries.
+- `"capability"` prioritizes comprehensiveness and coherence at the cost of latency.
+
+It's a hint, not a guarantee: the browser may override `"speed"` and fall back to a more capable model when a functional requirement (e.g. the requested language) needs one.
+
+## Result caching
+
+Off by default; every call hits the model. Pass `cache: "session"` for `sessionStorage`, `cache: "local"` for `localStorage`, or any `{ get, set }`-shaped object for a custom backend.
 
 ```ts
 // Off by default; every call hits the model.
-summarize({ language: "en", article });
+summarize({ language: "en", input: text });
 
-// Opt in for sessionStorage-backed caching.
-summarize({ language: "en", article, cache: createSessionStorageCache() });
+// Per-tab caching via sessionStorage.
+summarize({ language: "en", input: text, cache: "session" });
+
+// Persistent caching across tabs.
+summarize({ language: "en", input: text, cache: "local" });
 ```
 
-### Output normalization
+The internal session cache (warm `Summarizer` instances) is separate and always on, so same-config calls skip the ~1-3s cold start within a tab.
 
-`cleanSummary` strips wrapping quotes / whitespace and collapses internal whitespace; applied to every summary regardless of `type`. Anything beyond that — e.g. trimming terminal punctuation for headline-style chat titles — is the consumer's concern; apply your own post-process after the call returns.
+## Output normalization
 
-### Cache controls
-
-```ts
-import {
-  clearSummarizerSessions,    // drop every cached summarizer session
-  clearSummarizerSession,     // drop one cached session by create-options
-  configureSummarizerCache,   // change the LRU cap (default 8)
-} from "@web-ai-sdk/summarizer";
-```
-
-The internal session cache is LRU-bounded (default 8). Evicted sessions have their `destroy()` invoked when present.
-
-### Lower-level helpers (advanced)
-
-`buildSkeleton`, `trimToSentenceBoundary`, `cleanSummary`, `getOrCreateSummarizer`, `defaultCacheKey`, `getSummarizerApi`. Exported so you can compose your own pipeline (e.g. extract a skeleton without summarizing, or share one cached session across multiple call sites).
+The wrapper strips wrapping quotes / whitespace and collapses internal whitespace on every result regardless of `type`. Anything beyond that — e.g. trimming the trailing period from a `type: "headline"` result — is the consumer's concern; apply your own post-process after the call returns.
 
 ## Language support
 
-The Web's Built-in Summarizer (Chrome 138+ and Edge 138+) accepts `expectedInputLanguages` / `outputLanguage` only for `["en", "es", "ja"]`. For other languages this library omits those hints and steers output via `sharedContext` instead. Pass your own `supportedLanguages` if Chrome adds more.
+The Web's Built-in Summarizer (Chrome 138+ and Edge 138+) accepts `expectedInputLanguages` / `outputLanguage` only for `["en", "es", "ja"]`. For other languages this library omits those hints and you steer output via `sharedContext` instead. Pass your own `supportedLanguages` if Chrome adds more.
 
 ## License
 

--- a/packages/summarizer/src/api.ts
+++ b/packages/summarizer/src/api.ts
@@ -53,6 +53,7 @@ export interface SummarizerAvailabilityOptions {
   type?: SummarizerCreateOptions["type"];
   format?: SummarizerCreateOptions["format"];
   length?: SummarizerCreateOptions["length"];
+  preference?: SummarizerCreateOptions["preference"];
   expectedInputLanguages?: string[];
   expectedContextLanguages?: string[];
   outputLanguage?: string;

--- a/packages/summarizer/src/index.test.ts
+++ b/packages/summarizer/src/index.test.ts
@@ -242,4 +242,21 @@ describe("summarize", () => {
     expect(createOpts.format).toBe("markdown");
     expect(createOpts.preference).toBe("capability");
   });
+
+  it("defaults preference to 'auto' when omitted", async () => {
+    const api = installFakeSummarizer({ summary: "ok" });
+    await summarize({ language: "en", input: "body" });
+    const createOpts = api.create.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(createOpts.preference).toBe("auto");
+  });
+
+  it("forwards preference to the availability() probe", async () => {
+    const api = installFakeSummarizer({ summary: "ok" });
+    await summarize({ language: "en", input: "body", preference: "speed" });
+    const availabilityOpts = api.availability.mock.calls[0]?.[0] as Record<
+      string,
+      unknown
+    >;
+    expect(availabilityOpts.preference).toBe("speed");
+  });
 });

--- a/packages/summarizer/src/index.ts
+++ b/packages/summarizer/src/index.ts
@@ -52,7 +52,13 @@ export interface SummarizeOptions {
   length?: "short" | "medium" | "long";
   /** Output format. Default: `"plain-text"`. */
   format?: "plain-text" | "markdown";
-  /** Performance preference. Default: `"speed"`. */
+  /**
+   * Performance preference hint. `"speed"` biases toward a faster, lighter
+   * model; `"capability"` toward a more comprehensive one; `"auto"` lets the
+   * browser balance the two. The browser may override the hint when a
+   * functional requirement (e.g. the requested language) needs a more capable
+   * model. Default: `"auto"` (matches the platform default).
+   */
   preference?: "auto" | "speed" | "capability";
   /** Native `sharedContext` string (a hint about who/what the summary is for). */
   sharedContext?: string;
@@ -141,7 +147,7 @@ export const summarize = async (
     type: options.type ?? "tldr",
     format: options.format ?? "plain-text",
     length: options.length ?? "medium",
-    preference: options.preference ?? "speed",
+    preference: options.preference ?? "auto",
     sharedContext: options.sharedContext ?? "",
     ...langOptions,
     ...(options.monitor ? { monitor: options.monitor } : {}),
@@ -153,14 +159,19 @@ export const summarize = async (
   // We pass the same options shape to availability() as we do to create().
   // Edge requires this for accurate results and warns when fields like
   // outputLanguage are missing; Chrome is more lenient but accepts the same
-  // input. The narrower SummarizerAvailabilityOptions shape filters out
-  // create-only fields like `sharedContext` and `preference`.
+  // input. `preference` is a create-core option, so availability() accepts it
+  // too; forwarding it keeps the probe honest about the configuration we're
+  // actually about to create. The narrower SummarizerAvailabilityOptions shape
+  // still filters out create-only fields like `sharedContext`.
   const sessionPromise = getOrCreateSummarizer(api, baseCreateOptions);
   const availability = await api
     .availability({
       ...(baseCreateOptions.type ? { type: baseCreateOptions.type } : {}),
       ...(baseCreateOptions.format ? { format: baseCreateOptions.format } : {}),
       ...(baseCreateOptions.length ? { length: baseCreateOptions.length } : {}),
+      ...(baseCreateOptions.preference
+        ? { preference: baseCreateOptions.preference }
+        : {}),
       ...(baseCreateOptions.expectedInputLanguages
         ? { expectedInputLanguages: baseCreateOptions.expectedInputLanguages }
         : {}),


### PR DESCRIPTION
Batches four backlog items (plus a README cleanup) into the next release. With `fixed` versioning, the `minor` changeset here rolls the whole group (and the queued webmcp patch) to **0.6.0** via the version PR (#37).

## Summary

- **#53 (summarizer, behavior):** default `preference` is now `"auto"` instead of `"speed"`, matching the platform default. The old `"speed"` default silently biased every consumer toward the faster/lower-capability path and risked surprising unavailability for configs a faster model can't serve (e.g. non-English). `"speed"`/`"capability"` are now explicit opt-ins.
- **#54 (summarizer, correctness):** `preference` is a create-core option, so it's now forwarded into the `availability()` probe, keeping the probe consistent with the session `create()` actually makes.
- **#55 (docs):** new "Performance preference" section in the summarizer guide + updated options-table default.
- **#56 (docs):** documents that the Proofreader API is English-only today, in the guide and the package README.
- **README cleanup (summarizer):** the package README had drifted to a pre-0.4 API shape (`article`/`text`/`summary`, `isSummarizerAvailable`, `createSessionStorageCache`, skeleton helpers, none of which are exported). Rewritten to match the real `summarize({ input, language, … }) -> { output, cached }` surface.

## Versioning

- One `minor` changeset on `@web-ai-sdk/summarizer` (+ `patch` on `@web-ai-sdk/proofreader` for the README note).
- `fixed` config means all packages release together as **0.6.0**.

## Test plan

- [x] `pnpm gate` (lint, build, typecheck, test) green
- [x] New tests: default `preference` is `"auto"`; `preference` forwarded to `availability()`
- [ ] Docs render check after merge (Starlight build runs in CI)

## Notes

- The Proofreader `chrome://flags` reference was left unchanged: public Chrome docs still use `#proofreader-api-for-gemini-nano`, which our docs already match, so #56 reduced to the English-only note.

Closes #53
Closes #54
Closes #55
Closes #56