### PR TITLE
feat: add Umami analytics

### DIFF
--- a/apps/docs/astro.config.mjs
+++ b/apps/docs/astro.config.mjs
@@ -35,6 +35,7 @@ export default defineConfig({
       // apps/landing/scripts/build-og-image.mjs). Absolute URL because
       // most scrapers won't resolve relative og:image paths.
       head: [
+        { tag: "script", attrs: { defer: true, src: "https://cloud.umami.is/script.js", "data-website-id": "9e24f5c3-6b64-48fc-8679-610907092f1c" } },
         // Brand fonts: Space Grotesk (display), Geist (body), IBM Plex Mono (code).
         { tag: "link", attrs: { rel: "preconnect", href: "https://fonts.googleapis.com" } },
         { tag: "link", attrs: { rel: "preconnect", href: "https://fonts.gstatic.com", crossorigin: true } },

--- a/apps/landing/index.html
+++ b/apps/landing/index.html
@@ -25,6 +25,8 @@
     <link rel="alternate" type="text/plain" title="LLM-friendly docs (llms.txt)" href="/llms.txt" />
     <link rel="alternate" type="text/plain" title="LLM-friendly docs (full text)" href="/llms-full.txt" />
 
+    <script defer src="https://cloud.umami.is/script.js" data-website-id="9e24f5c3-6b64-48fc-8679-610907092f1c"></script>
+
     <!-- Structured data: WebSite + SoftwareSourceCode. Google's AI Optimization
          Guide says JSON-LD isn't required for AI search but recommends it as
          part of overall SEO. The npm coordinates make this discoverable as a


### PR DESCRIPTION
## Summary
- Add the hosted Umami script to the landing HTML shell.
- Add the same Umami website ID to the docs Starlight head config so docs pages are tracked too.

## Test plan
- [x] pnpm build:apps