### PR TITLE
chore(site): add agent readiness metadata

### DIFF
--- a/apps/site/public/.well-known/agent-skills/index.json
+++ b/apps/site/public/.well-known/agent-skills/index.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://raw.githubusercontent.com/cloudflare/agent-skills-discovery-rfc/main/schema/index.schema.json",
+  "version": "0.2.0",
+  "skills": [
+    {
+      "name": "web-ai-sdk-docs",
+      "type": "skill-md",
+      "description": "Use web-ai-sdk documentation and package references to build with the Web's built-in AI APIs.",
+      "url": "https://web-ai-sdk.dev/.well-known/agent-skills/web-ai-sdk-docs/SKILL.md",
+      "digest": "sha256:4ff5c2fc09d4cc2fee24b8f3899abcc002cb618b44069818878e3de51e319e18"
+    }
+  ]
+}

--- a/apps/site/public/.well-known/agent-skills/web-ai-sdk-docs/SKILL.md
+++ b/apps/site/public/.well-known/agent-skills/web-ai-sdk-docs/SKILL.md
@@ -1,0 +1,35 @@
+---
+name: web-ai-sdk-docs
+description: Use web-ai-sdk documentation and package references to build with the Web's built-in AI APIs.
+---
+
+# web-ai-sdk Docs
+
+Use this skill when helping someone build with `@web-ai-sdk/*`, compare wrapper packages, or find examples for the Web's built-in AI APIs.
+
+## Canonical Sources
+
+Start with the LLM-friendly index:
+
+- `https://web-ai-sdk.dev/llms.txt`
+- `https://web-ai-sdk.dev/llms-full.txt`
+- `https://web-ai-sdk.dev/docs/`
+
+Then use the package READMEs as the API source of truth:
+
+- `https://github.com/obetomuniz/web-ai-sdk/tree/main/packages/sdk#readme`
+- `https://github.com/obetomuniz/web-ai-sdk/tree/main/packages/prompt#readme`
+- `https://github.com/obetomuniz/web-ai-sdk/tree/main/packages/webmcp#readme`
+- `https://github.com/obetomuniz/web-ai-sdk/tree/main/packages/summarizer#readme`
+- `https://github.com/obetomuniz/web-ai-sdk/tree/main/packages/translator#readme`
+- `https://github.com/obetomuniz/web-ai-sdk/tree/main/packages/detector#readme`
+- `https://github.com/obetomuniz/web-ai-sdk/tree/main/packages/writer#readme`
+- `https://github.com/obetomuniz/web-ai-sdk/tree/main/packages/rewriter#readme`
+- `https://github.com/obetomuniz/web-ai-sdk/tree/main/packages/proofreader#readme`
+
+## Rules
+
+- Prefer vanilla package APIs unless the user is already using React.
+- Treat browser support as feature-detected. Do not assume a Built-in AI API exists in every browser.
+- Keep examples dependency-light and avoid UI components unless the user asks for a UI.
+- For WebMCP, register tools from the top-level document and make cleanup idempotent.

--- a/apps/site/public/.well-known/webmcp.json
+++ b/apps/site/public/.well-known/webmcp.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "https://webmcp.org/manifest.schema.json",
+  "name": "web-ai-sdk",
+  "description": "Documentation and package metadata for web-ai-sdk, a TypeScript SDK for the Web's built-in AI APIs.",
+  "url": "https://web-ai-sdk.dev/",
+  "tools": [
+    {
+      "name": "get_web_ai_sdk_resources",
+      "description": "List canonical web-ai-sdk packages, documentation, and agent-friendly resources.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {},
+        "additionalProperties": false
+      },
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": false
+      }
+    }
+  ]
+}

--- a/apps/site/public/robots.txt
+++ b/apps/site/public/robots.txt
@@ -1,4 +1,6 @@
 User-agent: *
 Allow: /
 
+Content-Signal: ai-train=yes, search=yes, ai-input=yes
+
 Sitemap: https://web-ai-sdk.dev/sitemap.xml

--- a/apps/site/scripts/build-llms.mjs
+++ b/apps/site/scripts/build-llms.mjs
@@ -40,6 +40,9 @@ const PACKAGES = [
   { dir: "summarizer", npm: "@web-ai-sdk/summarizer" },
   { dir: "translator", npm: "@web-ai-sdk/translator" },
   { dir: "detector", npm: "@web-ai-sdk/detector" },
+  { dir: "writer", npm: "@web-ai-sdk/writer" },
+  { dir: "rewriter", npm: "@web-ai-sdk/rewriter" },
+  { dir: "proofreader", npm: "@web-ai-sdk/proofreader" },
 ];
 
 const readmeUrl = (dir) => `${REPO_URL}/tree/main/packages/${dir}#readme`;
@@ -109,7 +112,7 @@ function buildLlmsIndex() {
     "",
     "> Building blocks for the Web's built-in AI APIs. Composable. No runtime deps. Just lifecycle, streaming, AbortSignals. Vanilla TypeScript by default, with optional React hooks.",
     "",
-    "Each package wraps one Built-in AI surface (Prompt, Summarizer, Translator, Detector, WebMCP) plus an optional `/react` adapter. The per-package READMEs (linked below) are the source of truth for the API surface; the docs site hosts hand-curated conceptual guides. Full README content is also available concatenated at [llms-full.txt](" + SITE_URL + "/llms-full.txt).",
+    "Each package wraps one Built-in AI surface (Prompt, Summarizer, Translator, Detector, Writer, Rewriter, Proofreader, WebMCP) plus an optional `/react` adapter. The per-package READMEs (linked below) are the source of truth for the API surface; the docs site hosts hand-curated conceptual guides. Full README content is also available concatenated at [llms-full.txt](" + SITE_URL + "/llms-full.txt).",
     "",
     "## Packages",
     "",
@@ -124,6 +127,9 @@ function buildLlmsIndex() {
     "- [Summarizer](" + SITE_URL + "/docs/guides/summarizer/): TL;DR / key-points / headline with streaming.",
     "- [Translator](" + SITE_URL + "/docs/guides/translator/): block-level DOM translation with snapshot restore.",
     "- [Detector](" + SITE_URL + "/docs/guides/detector/): on-device language detection with confidence.",
+    "- [Writer](" + SITE_URL + "/docs/guides/writer/): draft new content with configurable tone, format, and length.",
+    "- [Rewriter](" + SITE_URL + "/docs/guides/rewriter/): reshape existing text by tone or length.",
+    "- [Proofreader](" + SITE_URL + "/docs/guides/proofreader/): grammar and punctuation corrections with issue offsets.",
     "",
     "## React adapters",
     "",
@@ -133,6 +139,9 @@ function buildLlmsIndex() {
     "- [useSummarizer](" + SITE_URL + "/docs/react/use-summarizer/)",
     "- [useTranslator](" + SITE_URL + "/docs/react/use-translator/)",
     "- [useDetector](" + SITE_URL + "/docs/react/use-detector/)",
+    "- [useWriter](" + SITE_URL + "/docs/react/use-writer/)",
+    "- [useRewriter](" + SITE_URL + "/docs/react/use-rewriter/)",
+    "- [useProofreader](" + SITE_URL + "/docs/react/use-proofreader/)",
     "",
     "## Optional",
     "",

--- a/apps/site/src/pages/index.astro
+++ b/apps/site/src/pages/index.astro
@@ -76,6 +76,62 @@ const structuredData = {
       },
       mainEntityOfPage: { "@id": "https://web-ai-sdk.dev/#website" },
     },
+    {
+      "@type": "SoftwareApplication",
+      "@id": "https://web-ai-sdk.dev/#software",
+      name: "web-ai-sdk",
+      applicationCategory: "DeveloperApplication",
+      operatingSystem: "Web",
+      softwareVersion: SDK_VERSION,
+      description:
+        "A TypeScript SDK for the Web's built-in AI APIs, including Prompt, Summarizer, Translator, Language Detector, Writer, Rewriter, Proofreader, and WebMCP wrappers.",
+      url: CANONICAL_URL,
+      codeRepository: repoUrl,
+      programmingLanguage: ["TypeScript", "JavaScript"],
+      license: "https://opensource.org/licenses/MIT",
+      author: {
+        "@type": "Person",
+        name: "Beto Muniz",
+        url: "https://github.com/obetomuniz",
+      },
+      offers: {
+        "@type": "Offer",
+        price: "0",
+        priceCurrency: "USD",
+      },
+      mainEntityOfPage: { "@id": "https://web-ai-sdk.dev/#website" },
+    },
+    {
+      "@type": "FAQPage",
+      "@id": "https://web-ai-sdk.dev/#faq",
+      mainEntity: [
+        {
+          "@type": "Question",
+          name: "What does web-ai-sdk wrap?",
+          acceptedAnswer: {
+            "@type": "Answer",
+            text: "web-ai-sdk wraps the Web's built-in AI APIs: Prompt, Summarizer, Translator, Language Detector, Writer, Rewriter, Proofreader, and WebMCP.",
+          },
+        },
+        {
+          "@type": "Question",
+          name: "Does web-ai-sdk require React?",
+          acceptedAnswer: {
+            "@type": "Answer",
+            text: "No. Each package ships a vanilla TypeScript core by default and an optional React hook adapter under its /react subpath.",
+          },
+        },
+        {
+          "@type": "Question",
+          name: "What happens when a browser does not support a built-in AI API?",
+          acceptedAnswer: {
+            "@type": "Answer",
+            text: "The wrappers feature-detect the browser APIs and fall back to no-op cleanup functions, undefined availability, or typed unavailable errors so apps can ship without browser-specific branches.",
+          },
+        },
+      ],
+      mainEntityOfPage: { "@id": "https://web-ai-sdk.dev/#website" },
+    },
   ],
 };
 
@@ -191,6 +247,47 @@ const supportRows = [
     <link rel="alternate" type="text/plain" title="LLM-friendly docs (full text)" href={pathFromBase("llms-full.txt")} />
     <script is:inline defer src="https://cloud.umami.is/script.js" data-website-id="9e24f5c3-6b64-48fc-8679-610907092f1c"></script>
     <script is:inline type="application/ld+json" set:html={JSON.stringify(structuredData)} />
+    <script>
+      import { registerTool } from "@web-ai-sdk/webmcp";
+
+      registerTool({
+        name: "get_web_ai_sdk_resources",
+        description:
+          "List canonical web-ai-sdk packages, documentation, and agent-friendly resources.",
+        inputSchema: {
+          type: "object",
+          properties: {},
+          additionalProperties: false,
+        },
+        annotations: {
+          readOnlyHint: true,
+          destructiveHint: false,
+          idempotentHint: true,
+          openWorldHint: false,
+        },
+        execute: () => ({
+          packages: [
+            "@web-ai-sdk/all",
+            "@web-ai-sdk/prompt",
+            "@web-ai-sdk/webmcp",
+            "@web-ai-sdk/summarizer",
+            "@web-ai-sdk/translator",
+            "@web-ai-sdk/detector",
+            "@web-ai-sdk/writer",
+            "@web-ai-sdk/rewriter",
+            "@web-ai-sdk/proofreader",
+          ],
+          docs: [
+            "https://web-ai-sdk.dev/docs/",
+            "https://web-ai-sdk.dev/docs/browser-support/",
+            "https://web-ai-sdk.dev/docs/architecture/",
+            "https://web-ai-sdk.dev/llms.txt",
+            "https://web-ai-sdk.dev/llms-full.txt",
+          ],
+          source: "https://github.com/obetomuniz/web-ai-sdk",
+        }),
+      });
+    </script>
     <meta property="og:type" content="website" />
     <meta property="og:url" content={CANONICAL_URL} />
     <meta property="og:site_name" content="web-ai-sdk" />


### PR DESCRIPTION
## Summary
- Add repo-side agent readiness metadata: Content-Signal robots directive, Agent Skills discovery, and a WebMCP manifest.
- Dogfood `@web-ai-sdk/webmcp` on the homepage by registering a read-only resource discovery tool.
- Expand homepage JSON-LD and `llms.txt` generation so agents can discover the newer SDK packages.

## Test plan
- `pnpm lint`
- `pnpm --filter @web-ai-sdk-apps/site run typecheck`
- `pnpm build:site`