### PR TITLE
fix(docs): align package API examples

### DIFF
--- a/.agents/agents.md
+++ b/.agents/agents.md
@@ -168,6 +168,14 @@ These rules apply to the API-wrapper packages (`@web-ai-sdk/prompt`, `webmcp`, `
 - **READMEs are user-facing.** Show install, the smallest possible vanilla example, the smallest possible React example, then the API surface.
 - Don't write design docs unless the user asks. Conventions live here; package-specific decisions live in the package README.
 
+### Docs reliability
+
+- Treat docs examples as part of the public API. When editing or reviewing docs, verify option names, result shapes, hook return values, and helper export names against the actual exported TypeScript interfaces and runtime tests.
+- After API renames, audit stale docs terms across READMEs and docs pages. Common drift patterns in this repo include `prompt()` vs `ask()`, `prompt` vs `input`, `onChunk` vs `onUpdate`, `response` / `summary` vs `output`, top-level detector `language` vs `output.language`, `is*Available()` aliases vs `isAvailable()`, and removed cache factories vs `cache: "session" | "local"`.
+- Package READMEs are the source for generated package docs under `apps/site/src/content/docs/packages/*.md`, but those pages are checked in. If you fix a README drift, update the matching checked-in package docs page in the same change or regenerate it.
+- Changelog migration snippets are historical; don't "fix" old before/after examples unless they are inaccurate for the release they describe.
+- After docs changes, run `pnpm --filter @web-ai-sdk-apps/site typecheck`. Biome may intentionally ignore Markdown docs, so don't treat "no files processed" as validation.
+
 ### Home page styling (`apps/site`)
 
 The marketing site uses **Tailwind CSS v4**. Full guardrails: [`apps/site/README.md`](../apps/site/README.md).

--- a/apps/site/src/content/docs/packages/all.md
+++ b/apps/site/src/content/docs/packages/all.md
@@ -7,7 +7,7 @@ editUrl: https://github.com/obetomuniz/web-ai-sdk/edit/main/packages/sdk/README.
 :::note
 This page is generated from [`packages/sdk/README.md`](https://github.com/obetomuniz/web-ai-sdk/blob/main/packages/sdk/README.md) on every build. Edits should go to the README.
 :::
-One-install meta-package for every `@web-ai-sdk/*` building block: `prompt`, `summarizer`, `translator`, `detector`, and `webmcp`. Pulls each scoped package in as a regular dependency so consumers don't have to track them individually.
+One-install meta-package for every `@web-ai-sdk/*` building block: `prompt`, `summarizer`, `translator`, `detector`, `writer`, `rewriter`, `proofreader`, and `webmcp`. Pulls each scoped package in as a regular dependency so consumers don't have to track them individually.
 
 ## Status
 
@@ -17,6 +17,9 @@ Each underlying scoped package is independently supported in Chrome / Edge with 
 - [`@web-ai-sdk/summarizer`](https://github.com/obetomuniz/web-ai-sdk/tree/main/packages/summarizer)
 - [`@web-ai-sdk/translator`](https://github.com/obetomuniz/web-ai-sdk/tree/main/packages/translator)
 - [`@web-ai-sdk/detector`](https://github.com/obetomuniz/web-ai-sdk/tree/main/packages/detector)
+- [`@web-ai-sdk/writer`](https://github.com/obetomuniz/web-ai-sdk/tree/main/packages/writer)
+- [`@web-ai-sdk/rewriter`](https://github.com/obetomuniz/web-ai-sdk/tree/main/packages/rewriter)
+- [`@web-ai-sdk/proofreader`](https://github.com/obetomuniz/web-ai-sdk/tree/main/packages/proofreader)
 - [`@web-ai-sdk/webmcp`](https://github.com/obetomuniz/web-ai-sdk/tree/main/packages/webmcp)
 
 ## Install
@@ -35,36 +38,39 @@ pnpm add @web-ai-sdk/all
 Tree-shakes cleanly; the bundler only pulls in the building blocks you actually use.
 
 ```ts
-import { prompt } from "@web-ai-sdk/all/prompt";
+import { ask, createSession } from "@web-ai-sdk/all/prompt";
 import { summarize } from "@web-ai-sdk/all/summarizer";
 import { translate } from "@web-ai-sdk/all/translator";
 import { detect } from "@web-ai-sdk/all/detector";
-import { registerTool } from "@web-ai-sdk/all/webmcp";
+import { write } from "@web-ai-sdk/all/writer";
+import { rewrite } from "@web-ai-sdk/all/rewriter";
+import { proofread } from "@web-ai-sdk/all/proofreader";
+import { registerTool, defineTool } from "@web-ai-sdk/all/webmcp";
 ```
 
 ```tsx
-import { usePrompt } from "@web-ai-sdk/all/prompt/react";
+import { usePrompt, useSession } from "@web-ai-sdk/all/prompt/react";
 import { useSummarizer } from "@web-ai-sdk/all/summarizer/react";
 ```
 
 ### Namespaced root (handy for prototyping)
 
 ```ts
-import { prompt, summarizer, translator, detector, webmcp } from "@web-ai-sdk/all";
+import { prompt, summarizer, translator, detector, writer, rewriter, proofreader, webmcp } from "@web-ai-sdk/all";
 
-await prompt.prompt({ prompt: "Hello" });
-await summarizer.summarize({ language: "en", article: document.body });
+await prompt.ask({ input: "Hello" });
+await summarizer.summarize({ language: "en", input: document.body.innerText });
 ```
 
-The root entry namespaces each scoped package because several exports (e.g. `checkAvailability`, `defaultCacheKey`, `createSessionStorageCache`) appear in more than one package and would collide on a flat re-export.
+The root entry namespaces each scoped package because several exports (e.g. `checkAvailability`, `isAvailable`, `defaultCacheKey`) appear in more than one package and would collide on a flat re-export.
 
 ## Why a meta-package?
 
-The scoped packages are deliberately small lifecycle wrappers; a meta-package just spares consumers from tracking five separate installs and version pins. The aggregator is a thin re-export shell with no behaviour of its own; all logic, tests, and version history live in the scoped packages.
+The scoped packages are deliberately small lifecycle wrappers; a meta-package just spares consumers from tracking eight separate installs and version pins. The aggregator is a thin re-export shell with no behaviour of its own; all logic, tests, and version history live in the scoped packages.
 
 ## Versioning
 
-The aggregator and the five scoped packages release together via a Changesets `fixed` group: every release ships all six at the same version. Pin a single number, get the whole suite.
+The aggregator and the eight scoped packages release together via a Changesets `fixed` group: every release ships all nine at the same version. Pin a single number, get the whole suite.
 
 ## License
 

--- a/apps/site/src/content/docs/packages/detector.md
+++ b/apps/site/src/content/docs/packages/detector.md
@@ -11,7 +11,7 @@ Building block for [the Web's Built-in Language Detector API](https://developer.
 
 ## Status
 
-Language Detector ships in Chrome 138+ and Edge 138+. On any other browser this library is a no-op for the React hook (it stays in `"unavailable"`). The vanilla `detect()` throws `DetectorUnavailableError` so callers can branch explicitly.
+Language Detector ships stable in Chrome 138+ on desktop. On Edge it is a developer preview starting at Canary/Dev 147+ behind `edge://flags/#edge-language-detection-api` (per the [Edge Language Detector API docs](https://learn.microsoft.com/en-us/microsoft-edge/web-platform/languagedetector-api)) — not yet in Edge stable. On any other browser this library is a no-op for the React hook (it stays in `"unavailable"`). The vanilla `detect()` throws `DetectorUnavailableError` so callers can branch explicitly.
 
 ## Install
 
@@ -27,10 +27,10 @@ The React adapter ships as a subpath export, with no extra install. `react` is a
 ```ts
 import { detect } from "@web-ai-sdk/detector";
 
-const result = await detect({ text: "Olá, mundo" });
-console.log(result.language);   // → "pt"
-console.log(result.confidence); // → 0.98
-console.log(result.all);        // → full sorted list of candidates
+const result = await detect({ input: "Olá, mundo" });
+console.log(result.output?.language);   // → "pt"
+console.log(result.output?.confidence); // → 0.98
+console.log(result.output?.all);        // → full sorted list of candidates
 ```
 
 ## React
@@ -39,18 +39,18 @@ console.log(result.all);        // → full sorted list of candidates
 import { useDetector } from "@web-ai-sdk/detector/react";
 
 export function LangBadge({ text }: { text: string }) {
-  const { status, language, confidence } = useDetector({ text });
+  const { status, output } = useDetector({ input: text });
 
-  if (status !== "done" || !language) return null;
+  if (status !== "done" || !output) return null;
   return (
     <span>
-      {language} · {Math.round(confidence * 100)}%
+      {output.language} · {Math.round(output.confidence * 100)}%
     </span>
   );
 }
 ```
 
-State machine: `pending | loading | done | unavailable`. The hook auto-runs on mount and re-runs whenever `text` changes. Stays in `"pending"` while the input is empty or whitespace-only.
+State machine: `idle | loading | done | unavailable`. The hook auto-runs on mount and re-runs whenever `input` changes. Stays in `"idle"` while the input is empty or whitespace-only.
 
 ## API
 
@@ -58,34 +58,32 @@ State machine: `pending | loading | done | unavailable`. The hook auto-runs on m
 
 ```ts
 interface DetectOptions {
-  text: string;
+  input: string;
   expectedInputLanguages?: readonly string[];  // bias hint
   minConfidence?: number;                      // default 0
-  createOptions?: Partial<LanguageDetectorCreateOptions>;
-  cache?: DetectionCache;
+  monitor?: (m: CreateMonitor) => void;
+  cache?: "session" | "local" | { get, set };
   cacheKey?: string;
   signal?: AbortSignal;
 }
 
 interface DetectResult {
-  language: string | null;          // top BCP-47 code, or null below minConfidence
-  confidence: number;               // 0..1 for the top result
-  all: DetectionResult[];           // [{ detectedLanguage, confidence }, ...]
+  output: {
+    language: string;
+    confidence: number;
+    all: DetectionResult[];
+  } | null;
   cached: boolean;
 }
 ```
 
-### `isDetectorAvailable(): boolean`
+### `isAvailable(): boolean`
 
 Feature-detect helper.
 
 ### `checkAvailability(opts?): Promise<LanguageDetectorAvailability | null>`
 
 Forwards to `LanguageDetector.availability()`. Returns `null` if the global is missing or the call throws.
-
-### `createSessionStorageCache({ storage?, prefix? }): DetectionCache`
-
-Optional cache backend. Pass it to `detect({ cache })` to enable result caching, with an optional custom `storage` (e.g. `localStorage`, an in-memory polyfill).
 
 ### Lower-level helpers (advanced)
 
@@ -100,10 +98,10 @@ Two layers, same as the other packages:
 
 ```ts
 // Off by default; every call hits the model.
-detect({ text: "hello" });
+detect({ input: "hello" });
 
 // Opt in for sessionStorage-backed caching.
-detect({ text: "hello", cache: createSessionStorageCache() });
+detect({ input: "hello", cache: "session" });
 ```
 
 ## Composing with the other packages
@@ -114,8 +112,8 @@ Pair detector with summarizer / translator / prompt to skip the manual `language
 import { detect } from "@web-ai-sdk/detector";
 import { summarize } from "@web-ai-sdk/summarizer";
 
-const { language } = await detect({ text: articleText });
-await summarize({ language: language ?? "en", text: articleText });
+const { output } = await detect({ input: articleText });
+await summarize({ language: output?.language ?? "en", input: articleText });
 ```
 
 A first-class `language: "auto"` shortcut may land in a future release.

--- a/apps/site/src/content/docs/packages/prompt.md
+++ b/apps/site/src/content/docs/packages/prompt.md
@@ -11,7 +11,7 @@ Building block for the Web's Built-in [Prompt API](https://developer.chrome.com/
 
 ## Status
 
-Prompt API ships in Chrome 138+ (behind `chrome://flags/#prompt-api-for-gemini-nano`) and Edge 138+ (behind `edge://flags/#prompt-api-for-phi-mini`). On any other browser this library is a no-op for the React hook (it stays in `"unavailable"`). The vanilla `prompt()` throws `PromptUnavailableError` so callers can branch explicitly.
+Prompt API ships stable in Chrome 148+ — no flag required. Chrome 138–147 still works with `chrome://flags/#prompt-api-for-gemini-nano` enabled. On Edge it remains a developer preview in Canary/Dev 138+ behind `edge://flags/#prompt-api-for-phi-mini`, with Phi-4-mini's stricter safety pipeline often refusing output (see [Browser support](https://web-ai-sdk.dev/browser-support)). On any other browser this library is a no-op for the React hook (it stays in `"unavailable"`). The vanilla `ask()` throws `PromptUnavailableError` so callers can branch explicitly.
 
 ## Install
 
@@ -24,18 +24,22 @@ The React adapter ships as a subpath export, with no extra install. `react` is a
 
 ## Vanilla TypeScript / DOM
 
-```ts
-import { prompt } from "@web-ai-sdk/prompt";
+### One-shot — `ask()`
 
-const result = await prompt({
-  prompt: "Summarize this in one sentence: WebMCP lets web pages expose tools to agents.",
+```ts
+import { ask } from "@web-ai-sdk/prompt";
+
+const result = await ask({
+  input: "Summarize this in one sentence: WebMCP lets web pages expose tools to agents.",
   systemPrompt: "You are concise. Reply with a single sentence.",
   temperature: 0.2,
-  onChunk: (text) => console.log("partial", text),
+  onUpdate: (text) => console.log("partial", text), // cumulative buffer
 });
 
-console.log(result.response, result.cached);
+console.log(result.output, result.cached);
 ```
+
+`ask()` shares a warm `LanguageModel` instance across same-shape callers so the cold start is paid once per persona. That's right for embeds, widgets, ask-and-display flows. It's the wrong shape for chat: two callers with the same mode would share one instance, so conversation history cross-bleeds and `abort()` on one caller kills the other.
 
 ## React
 
@@ -43,7 +47,7 @@ console.log(result.response, result.cached);
 import { usePrompt } from "@web-ai-sdk/prompt/react";
 
 export function AskBox() {
-  const { status, response, error, ask, abort } = usePrompt({
+  const { status, output, error, ask, abort } = usePrompt({
     systemPrompt: "You are a helpful assistant. Be concise.",
     temperature: 0.7,
   });
@@ -62,22 +66,22 @@ export function AskBox() {
       <button type="submit" disabled={status === "loading" || status === "streaming"}>
         {status === "streaming" ? "Streaming…" : "Ask"}
       </button>
-      {response && <p>{response}</p>}
+      {output && <p>{output}</p>}
       {error && <small>{error.message}</small>}
     </form>
   );
 }
 ```
 
-State machine: `idle | loading | streaming | done | unavailable`. `ask(input)` triggers a request, cancels any in-flight one, and updates `response` as chunks stream. `abort()` cancels the current request; `reset()` clears state.
+State machine: `idle | loading | streaming | done | unavailable`. `ask(input)` triggers a request, cancels any in-flight one, and updates `output` as chunks stream. `abort()` cancels the current request; `reset()` clears state.
 
 ## API
 
-### `prompt(options): Promise<PromptResult>`
+### `ask(options): Promise<AskResult>`
 
 ```ts
-interface PromptOptions {
-  prompt: string;
+interface AskOptions {
+  input: string;
   systemPrompt?: string;
   temperature?: number;
   topK?: number;
@@ -85,31 +89,29 @@ interface PromptOptions {
   supportedLanguages?: readonly string[];   // default ["en"]
   expectedInputs?: LanguageModelExpectedInput[];   // advanced passthrough
   expectedOutputs?: LanguageModelExpectedOutput[]; // advanced passthrough
-  createOptions?: Partial<LanguageModelCreateOptions>;
+  tools?: LanguageModelTool[];              // experimental: native function-calling passthrough
+  monitor?: (m: CreateMonitor) => void;
   responseConstraint?: object;              // JSON Schema for structured output
+  omitResponseConstraintInput?: boolean;
   cache?: ResponseCache;
   cacheKey?: string;
-  onChunk?: (text: string) => void;
+  onUpdate?: (text: string) => void;        // CUMULATIVE buffer
   signal?: AbortSignal;
 }
 
-interface PromptResult {
-  response: string | null;
+interface AskResult {
+  output: string | null;
   cached: boolean;
 }
 ```
 
-### `isPromptAvailable(): boolean`
+### `isAvailable(): boolean`
 
 Feature-detect helper.
 
 ### `checkAvailability(opts?): Promise<LanguageModelAvailability | null>`
 
 Forwards to `LanguageModel.availability()`. Returns `null` if the global is missing or the call throws.
-
-### `createSessionStorageCache({ storage?, prefix? }): ResponseCache`
-
-Optional cache backend. Pass it to `prompt({ cache })` to enable response caching, with an optional custom `storage` (e.g. `localStorage`, an in-memory polyfill).
 
 ### Lower-level helpers (advanced)
 
@@ -124,18 +126,21 @@ Two layers, same as `@web-ai-sdk/summarizer`:
 
 ```ts
 // Off by default; every call hits the model.
-prompt({ prompt: "hi" });
+ask({ input: "hi" });
 
 // Opt in for sessionStorage-backed caching.
-prompt({ prompt: "hi", cache: createSessionStorageCache() });
+ask({ input: "hi", cache: "session" });
+
+// Or persistent localStorage-backed caching.
+ask({ input: "hi", cache: "local" });
 
 // Or roll your own.
-prompt({ prompt: "hi", cache: myMap, cacheKey: "greeting" });
+ask({ input: "hi", cache: myMap, cacheKey: "greeting" });
 ```
 
 ## Errors and unavailability
 
-The vanilla `prompt()` throws `PromptUnavailableError` when the API is missing or reports `availability: "unavailable"`. The React hook absorbs this and returns `status: "unavailable"` instead.
+The vanilla `ask()` throws `PromptUnavailableError` when the API is missing or reports `availability: "unavailable"`. The React hook absorbs this and returns `status: "unavailable"` instead.
 
 `AbortSignal` is supported on both surfaces. Aborting mid-stream resolves cleanly; the result cache is not written for aborted runs.
 

--- a/apps/site/src/content/docs/packages/summarizer.md
+++ b/apps/site/src/content/docs/packages/summarizer.md
@@ -7,11 +7,11 @@ editUrl: https://github.com/obetomuniz/web-ai-sdk/edit/main/packages/summarizer/
 :::note
 This page is generated from [`packages/summarizer/README.md`](https://github.com/obetomuniz/web-ai-sdk/blob/main/packages/summarizer/README.md) on every build. Edits should go to the README.
 :::
-Building block for the Web's Built-in [Summarizer API](https://developer.chrome.com/docs/ai/summarizer-api). Skeleton extraction, sentence-boundary trimming, streaming, and sessionStorage caching.
+Building block for the Web's Built-in [Summarizer API](https://developer.chrome.com/docs/ai/summarizer-api). String-mode summarization with session reuse, output cleaning, streaming, and opt-in result caching.
 
 ## Status
 
-Summarizer API is in Chrome 138+ and Edge 138+ stable on desktop. On any other browser this library is a no-op for the React hook (it stays in `"unavailable"`). The vanilla `summarize()` throws `SummarizerUnavailableError` so callers can branch explicitly.
+Summarizer API is stable in Chrome 138+ and Edge 138+ on desktop (enabled by default since Edge 138, per the [Edge Writing Assistance APIs docs](https://learn.microsoft.com/en-us/microsoft-edge/web-platform/writing-assistance-apis)). On Edge the Phi-4-mini safety pipeline frequently returns "low quality output blocked"; the library wraps that as a typed error. On any other browser this library is a no-op for the React hook (it stays in `"unavailable"`). The vanilla `summarize()` throws `SummarizerUnavailableError` so callers can branch explicitly.
 
 ## Install
 
@@ -22,58 +22,50 @@ pnpm add @web-ai-sdk/summarizer
 
 The React adapter ships as a subpath export, with no extra install. `react` is a peer dependency only when you import the `/react` entry.
 
-## How it works
-
-1. **Build a skeleton**: title + description + every `h1-h4` and `<strong>`/`<b>` inside the article. That's the highest-signal content; for long posts it drops the input from thousands of chars to a few hundred and produces a tighter summary. Falls back to the trimmed body when the skeleton is too thin.
-2. **Trim to a sentence boundary** so the model never sees a half-cut sentence (default cap: 3000 chars).
-3. **Cache `Summarizer.create()` sessions** by JSON-stringified options. First post pays the ~1-3s cold start; later same-config calls reuse the warm session.
-4. **Stream `summarizeStreaming()`** when the instance supports it, falling back to one-shot `summarize()`. Cleaned chunks are pushed to `onChunk` as they arrive.
-5. **Optionally cache the final summary** when you pass a `cache` (e.g. `createSessionStorageCache()`). Off by default; opt in for revisits in the same tab to render instantly without invoking the model.
-
 ## Vanilla TypeScript / DOM
 
 ```ts
 import { summarize } from "@web-ai-sdk/summarizer";
 
 const result = await summarize({
+  input: longArticleText,
   language: "en",
-  article: document.querySelector("article")!,
-  title: "My Post",
-  description: "About interesting things",
-  onChunk: (text) => console.log("partial", text),
+  type: "key-points",
+  length: "short",
+  onUpdate: (text) => render(text),
 });
 
-console.log(result.summary, result.cached);
+console.log(result.output, result.cached);
 ```
+
+`result.output` is the cleaned summary text, or `null` when the input is empty. `result.cached` tells you whether the response came from the cache without invoking the model.
 
 ## React
 
 ```tsx
 import { useSummarizer } from "@web-ai-sdk/summarizer/react";
-import { useMemo } from "react";
 
-export function PostSummary({ article }: { article: HTMLElement | null }) {
-  const result = useSummarizer({
+export function PostSummary({ text }: { text: string }) {
+  const { status, output, dismiss } = useSummarizer({
+    input: text,
     language: "en",
-    article: article ?? undefined,
-    title: "My Post",
-    description: "About interesting things",
+    type: "key-points",
   });
 
-  if (result.status === "unavailable") return null;
-  if (result.status === "loading") return <p>Generating summary…</p>;
-  if (!result.summary) return null;
+  if (status === "unavailable") return null;
+  if (status === "loading") return <p>Generating summary…</p>;
+  if (!output) return null;
 
   return (
     <aside>
-      <p>{result.summary}</p>
-      <button type="button" onClick={result.dismiss}>Dismiss</button>
+      <p>{output}</p>
+      <button type="button" onClick={dismiss}>Dismiss</button>
     </aside>
   );
 }
 ```
 
-State machine: `pending | loading | streaming | done | unavailable`. `summary` is the latest cleaned text (grows during streaming). `fromCache` is `true` when the result came back without invoking the model.
+State machine: `idle | loading | streaming | done | unavailable`. `output` is the latest cleaned text (grows during streaming). `fromCache` is `true` when the result came back without invoking the model.
 
 ## API
 
@@ -83,55 +75,65 @@ Run a one-shot summarization.
 
 ```ts
 interface SummarizeOptions {
+  input: string;
   language: string;
-  article?: Element; // skeleton extracted from this
-  text?: string;     // or pass pre-built input directly
-  title?: string;
-  description?: string;
   supportedLanguages?: readonly string[]; // default ["en", "es", "ja"]
-  sharedContext?: Record<string, string>; // per-language steering prompt
-  createOptions?: Partial<SummarizerCreateOptions>;
-  maxInputChars?: number;     // default 3000
-  minSkeletonChars?: number;  // default 200
-  cache?: SummaryCache;
-  cacheKey?: string;
-  onChunk?: (text: string) => void;
+  type?: "tldr" | "key-points" | "teaser" | "headline"; // default "tldr"
+  length?: "short" | "medium" | "long";                 // default "medium"
+  format?: "plain-text" | "markdown";                   // default "plain-text"
+  preference?: "auto" | "speed" | "capability";         // default "auto"
+  sharedContext?: string;
+  monitor?: (m: CreateMonitor) => void;
+  cache?: "session" | "local" | { get, set };
+  cacheKey?: string; // default `${pathname}:${lang}`
+  onUpdate?: (text: string) => void;
   signal?: AbortSignal;
 }
 
 interface SummarizeResult {
-  summary: string | null;
+  output: string | null;
   cached: boolean;
 }
 ```
 
-### `isSummarizerAvailable(): boolean`
+### `isAvailable(): boolean`
 
 Feature-detect helper.
 
-### `checkAvailability(): Promise<SummarizerAvailability | null>`
+### `checkAvailability(options?): Promise<SummarizerAvailability | null>`
 
 Forwards to the spec's `availability()` call. Returns `null` if the global is missing or the call throws.
 
-### `createSessionStorageCache({ storage?, prefix? }): SummaryCache`
+## Performance preference
 
-Optional cache backend. Pass it to `summarize({ cache })` to enable result caching, with an optional custom `storage` (e.g. `localStorage`, an in-memory polyfill).
+`preference` is a hint about the speed/quality tradeoff the browser makes when picking the underlying model:
+
+- `"auto"` (default) balances speed and capability.
+- `"speed"` prioritizes low latency, which can route to a smaller, faster model that produces less nuanced summaries.
+- `"capability"` prioritizes comprehensiveness and coherence at the cost of latency.
+
+It's a hint, not a guarantee: the browser may override `"speed"` and fall back to a more capable model when a functional requirement (e.g. the requested language) needs one.
+
+## Result caching
+
+Off by default; every call hits the model. Pass `cache: "session"` for `sessionStorage`, `cache: "local"` for `localStorage`, or any `{ get, set }`-shaped object for a custom backend.
 
 ```ts
 // Off by default; every call hits the model.
-summarize({ language: "en", article });
+summarize({ language: "en", input: text });
 
-// Opt in for sessionStorage-backed caching.
-summarize({ language: "en", article, cache: createSessionStorageCache() });
+// Per-tab caching via sessionStorage.
+summarize({ language: "en", input: text, cache: "session" });
+
+// Persistent caching across tabs.
+summarize({ language: "en", input: text, cache: "local" });
 ```
 
-### Lower-level helpers (advanced)
+The internal session cache (warm `Summarizer` instances) is separate and always on, so same-config calls skip the ~1-3s cold start within a tab.
 
-`buildSkeleton`, `trimToSentenceBoundary`, `cleanSummary`, `getOrCreateSummarizer`, `defaultCacheKey`, `getSummarizerApi`. Exported so you can compose your own pipeline (e.g. extract a skeleton without summarizing, or share one cached session across multiple call sites).
+## Output normalization
 
-## Language support
-
-The Web's Built-in Summarizer (Chrome 138+ and Edge 138+) accepts `expectedInputLanguages` / `outputLanguage` only for `["en", "es", "ja"]`. For other languages this library omits those hints and steers output via `sharedContext` instead. Pass your own `supportedLanguages` if Chrome adds more.
+The wrapper strips wrapping quotes / whitespace and collapses internal whitespace on every result regardless of `type`. Anything beyond that — e.g. trimming the trailing period from a `type: "headline"` result — is the consumer's concern; apply your own post-process after the call returns.
 
 ## License
 

--- a/apps/site/src/content/docs/packages/translator.md
+++ b/apps/site/src/content/docs/packages/translator.md
@@ -103,7 +103,7 @@ interface TranslateController {
 }
 ```
 
-### `isTranslatorAvailable(): boolean`
+### `isAvailable(): boolean`
 
 Feature-detect helper.
 

--- a/apps/site/src/content/docs/packages/webmcp.md
+++ b/apps/site/src/content/docs/packages/webmcp.md
@@ -111,7 +111,7 @@ Register a single tool. Returns a cleanup function. No-op on unsupported browser
 
 Register many tools at once. Returns a single cleanup that unregisters all of them.
 
-### `isWebMCPAvailable(): boolean`
+### `isAvailable(): boolean`
 
 Feature-detect helper.
 

--- a/packages/detector/README.md
+++ b/packages/detector/README.md
@@ -22,10 +22,10 @@ The React adapter ships as a subpath export, with no extra install. `react` is a
 ```ts
 import { detect } from "@web-ai-sdk/detector";
 
-const result = await detect({ text: "Olá, mundo" });
-console.log(result.language);   // → "pt"
-console.log(result.confidence); // → 0.98
-console.log(result.all);        // → full sorted list of candidates
+const result = await detect({ input: "Olá, mundo" });
+console.log(result.output?.language);   // → "pt"
+console.log(result.output?.confidence); // → 0.98
+console.log(result.output?.all);        // → full sorted list of candidates
 ```
 
 ## React
@@ -34,18 +34,18 @@ console.log(result.all);        // → full sorted list of candidates
 import { useDetector } from "@web-ai-sdk/detector/react";
 
 export function LangBadge({ text }: { text: string }) {
-  const { status, language, confidence } = useDetector({ text });
+  const { status, output } = useDetector({ input: text });
 
-  if (status !== "done" || !language) return null;
+  if (status !== "done" || !output) return null;
   return (
     <span>
-      {language} · {Math.round(confidence * 100)}%
+      {output.language} · {Math.round(output.confidence * 100)}%
     </span>
   );
 }
 ```
 
-State machine: `pending | loading | done | unavailable`. The hook auto-runs on mount and re-runs whenever `text` changes. Stays in `"pending"` while the input is empty or whitespace-only.
+State machine: `idle | loading | done | unavailable`. The hook auto-runs on mount and re-runs whenever `input` changes. Stays in `"idle"` while the input is empty or whitespace-only.
 
 ## API
 
@@ -53,34 +53,32 @@ State machine: `pending | loading | done | unavailable`. The hook auto-runs on m
 
 ```ts
 interface DetectOptions {
-  text: string;
+  input: string;
   expectedInputLanguages?: readonly string[];  // bias hint
   minConfidence?: number;                      // default 0
-  createOptions?: Partial<LanguageDetectorCreateOptions>;
-  cache?: DetectionCache;
+  monitor?: (m: CreateMonitor) => void;
+  cache?: "session" | "local" | { get, set };
   cacheKey?: string;
   signal?: AbortSignal;
 }
 
 interface DetectResult {
-  language: string | null;          // top BCP-47 code, or null below minConfidence
-  confidence: number;               // 0..1 for the top result
-  all: DetectionResult[];           // [{ detectedLanguage, confidence }, ...]
+  output: {
+    language: string;
+    confidence: number;
+    all: DetectionResult[];
+  } | null;
   cached: boolean;
 }
 ```
 
-### `isDetectorAvailable(): boolean`
+### `isAvailable(): boolean`
 
 Feature-detect helper.
 
 ### `checkAvailability(opts?): Promise<LanguageDetectorAvailability | null>`
 
 Forwards to `LanguageDetector.availability()`. Returns `null` if the global is missing or the call throws.
-
-### `createSessionStorageCache({ storage?, prefix? }): DetectionCache`
-
-Optional cache backend. Pass it to `detect({ cache })` to enable result caching, with an optional custom `storage` (e.g. `localStorage`, an in-memory polyfill).
 
 ### Lower-level helpers (advanced)
 
@@ -95,10 +93,10 @@ Two layers, same as the other packages:
 
 ```ts
 // Off by default; every call hits the model.
-detect({ text: "hello" });
+detect({ input: "hello" });
 
 // Opt in for sessionStorage-backed caching.
-detect({ text: "hello", cache: createSessionStorageCache() });
+detect({ input: "hello", cache: "session" });
 ```
 
 ## Composing with the other packages
@@ -109,8 +107,8 @@ Pair detector with summarizer / translator / prompt to skip the manual `language
 import { detect } from "@web-ai-sdk/detector";
 import { summarize } from "@web-ai-sdk/summarizer";
 
-const { language } = await detect({ text: articleText });
-await summarize({ language: language ?? "en", text: articleText });
+const { output } = await detect({ input: articleText });
+await summarize({ language: output?.language ?? "en", input: articleText });
 ```
 
 A first-class `language: "auto"` shortcut may land in a future release.

--- a/packages/prompt/README.md
+++ b/packages/prompt/README.md
@@ -31,7 +31,7 @@ const result = await ask({
   onUpdate: (text) => console.log("partial", text), // cumulative buffer
 });
 
-console.log(result.response, result.cached);
+console.log(result.output, result.cached);
 ```
 
 `ask()` shares a warm `LanguageModel` instance across same-shape callers so the cold start is paid once per persona. That's right for embeds, widgets, ask-and-display flows. It's the wrong shape for chat: two callers with the same mode would share one instance, so conversation history cross-bleeds and `abort()` on one caller kills the other.
@@ -70,7 +70,7 @@ Every `createSession()` call returns an independent `LanguageModelInstance` with
 import { usePrompt } from "@web-ai-sdk/prompt/react";
 
 export function AskBox() {
-  const { status, response, error, ask, abort } = usePrompt({
+  const { status, output, error, ask, abort } = usePrompt({
     systemPrompt: "You are a helpful assistant. Be concise.",
     temperature: 0.7,
   });
@@ -89,14 +89,14 @@ export function AskBox() {
       <button type="submit" disabled={status === "loading" || status === "streaming"}>
         {status === "streaming" ? "Streaming…" : "Ask"}
       </button>
-      {response && <p>{response}</p>}
+      {output && <p>{output}</p>}
       {error && <small>{error.message}</small>}
     </form>
   );
 }
 ```
 
-State machine: `idle | loading | streaming | done | unavailable`. `ask(input)` triggers a request, cancels any in-flight one, and updates `response` as chunks stream.
+State machine: `idle | loading | streaming | done | unavailable`. `ask(input)` triggers a request, cancels any in-flight one, and updates `output` as chunks stream.
 
 ### Chat — `useSession`
 
@@ -146,8 +146,8 @@ interface AskOptions {
   expectedInputs?: LanguageModelExpectedInput[];   // advanced passthrough
   expectedOutputs?: LanguageModelExpectedOutput[]; // advanced passthrough
   tools?: LanguageModelTool[];              // experimental: native function-calling passthrough
-  createOptions?: Partial<LanguageModelCreateOptions>;
   responseConstraint?: object;              // JSON Schema for structured output
+  omitResponseConstraintInput?: boolean;
   cache?: ResponseCache;
   cacheKey?: string;
   onUpdate?: (text: string) => void;        // CUMULATIVE buffer
@@ -155,7 +155,7 @@ interface AskOptions {
 }
 
 interface AskResult {
-  response: string | null;
+  output: string | null;
   cached: boolean;
 }
 ```
@@ -297,17 +297,13 @@ interface UseSessionReturn {
 
 Lifecycle-only: feature detection + create + destroy on unmount + recreate when any primitive option (`systemPrompt`, `temperature`, `topK`, `language`) changes. Object options (`expectedInputs`, `createOptions`) participate by reference; memoize them or accept the recreate cost. UI state is your concern — iterate `session.sendStreaming()` and accumulate text into your own component state.
 
-### `isPromptAvailable(): boolean`
+### `isAvailable(): boolean`
 
 Feature-detect helper.
 
 ### `checkAvailability(opts?): Promise<LanguageModelAvailability | null>`
 
 Forwards to `LanguageModel.availability()`. Returns `null` if the global is missing or the call throws.
-
-### `createSessionStorageCache({ storage?, prefix? }): ResponseCache`
-
-Optional cache backend. Pass it to `ask({ cache })` to enable response caching, with an optional custom `storage` (e.g. `localStorage`, an in-memory polyfill).
 
 ### Cache controls
 
@@ -337,7 +333,10 @@ Two layers, same as `@web-ai-sdk/summarizer`:
 ask({ input: "hi" });
 
 // Opt in for sessionStorage-backed caching.
-ask({ input: "hi", cache: createSessionStorageCache() });
+ask({ input: "hi", cache: "session" });
+
+// Or persistent localStorage-backed caching.
+ask({ input: "hi", cache: "local" });
 
 // Or roll your own.
 ask({ input: "hi", cache: myMap, cacheKey: "greeting" });

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -57,7 +57,7 @@ await prompt.ask({ input: "Hello" });
 await summarizer.summarize({ language: "en", article: document.body });
 ```
 
-The root entry namespaces each scoped package because several exports (e.g. `checkAvailability`, `defaultCacheKey`, `createSessionStorageCache`) appear in more than one package and would collide on a flat re-export.
+The root entry namespaces each scoped package because several exports (e.g. `checkAvailability`, `isAvailable`, `defaultCacheKey`) appear in more than one package and would collide on a flat re-export.
 
 ## Why a meta-package?
 

--- a/packages/translator/README.md
+++ b/packages/translator/README.md
@@ -98,7 +98,7 @@ interface TranslateController {
 }
 ```
 
-### `isTranslatorAvailable(): boolean`
+### `isAvailable(): boolean`
 
 Feature-detect helper.
 


### PR DESCRIPTION
## Summary
- Align prompt, detector, summarizer, and meta-package docs with current exported API shapes.
- Update checked-in generated package docs alongside source READMEs.
- Add docs reliability guidance to agent instructions to reduce future API drift.

## Test plan
- pnpm --filter @web-ai-sdk-apps/site typecheck
- Targeted ripgrep audit for stale docs API shapes