### PR TITLE
docs(site): drop redundant API-name parentheticals in architecture wraps table

### DIFF
--- a/apps/site/src/content/docs/architecture.mdx
+++ b/apps/site/src/content/docs/architecture.mdx
@@ -11,8 +11,8 @@ Each `@web-ai-sdk/*` package wraps a single cohesive web capability relevant to 
 
 | Package | Wraps |
 | --- | --- |
-| [`@web-ai-sdk/prompt`](/docs/guides/prompt/) | `LanguageModel` (Web Built-in Prompt API) |
-| [`@web-ai-sdk/webmcp`](/docs/guides/webmcp/) | `document.modelContext` (W3C WebMCP) |
+| [`@web-ai-sdk/prompt`](/docs/guides/prompt/) | `LanguageModel` |
+| [`@web-ai-sdk/webmcp`](/docs/guides/webmcp/) | `document.modelContext` |
 | [`@web-ai-sdk/summarizer`](/docs/guides/summarizer/) | `Summarizer` |
 | [`@web-ai-sdk/translator`](/docs/guides/translator/) | `Translator` |
 | [`@web-ai-sdk/detector`](/docs/guides/detector/) | `LanguageDetector` |


### PR DESCRIPTION
## Summary

- The architecture "Wraps" table annotated only the `prompt` and `webmcp` rows with an API-name parenthetical (`(Web Built-in Prompt API)` / `(W3C WebMCP)`), which read inconsistently next to the bare interface names on every other row.
- Drop both parentheticals so each cell lists just the wrapped interface (`LanguageModel`, `document.modelContext`, `Summarizer`, ...).
- No information is lost: the paragraph below the table already explains the API origins (official Built-in AI APIs vs. the adjacent `WebMCP` standard), and the guides/README keep the genuinely useful (`LanguageModel`) clarifier that tells devs which global to call.

## Test plan

- [ ] Docs-only content change to a single MDX table; verify the rendered Architecture page shows a consistent "Wraps" column.