### PR TITLE
style(site): simplify section eyebrows

### DIFF
--- a/apps/site/src/pages/index.astro
+++ b/apps/site/src/pages/index.astro
@@ -483,7 +483,7 @@ const supportVersionTone = (value: string) => {
         <div class={ui.container}>
           <div class={`${ui.sectionHead} ${ui.sectionAnchor}`} id="why-raw">
             <div>
-              <div class={ui.sectionEyebrow}>00 · the question</div>
+              <div class={ui.sectionEyebrow}>the question</div>
               <h2 class="mt-2">Why not just use the APIs directly?</h2>
             </div>
             <a class={ui.permalink} href="#why-raw"><span aria-hidden="true">§</span><span class={ui.srOnly}>Link to the why-not-the-raw-APIs section</span></a>
@@ -506,7 +506,7 @@ const supportVersionTone = (value: string) => {
         <div class={ui.container}>
           <div class={`${ui.sectionHead} ${ui.sectionAnchor}`} id="packages">
             <div>
-              <div class={ui.sectionEyebrow}>01 · packages</div>
+              <div class={ui.sectionEyebrow}>packages</div>
               <h2 class="mt-2">Composable wrappers. One philosophy.</h2>
             </div>
             <a class={ui.permalink} href="#packages"><span aria-hidden="true">§</span><span class={ui.srOnly}>Link to Packages section</span></a>
@@ -553,7 +553,7 @@ const supportVersionTone = (value: string) => {
         <div class={ui.container}>
           <div class={`${ui.sectionHead} ${ui.sectionAnchor}`} id="philosophy">
             <div>
-              <div class={ui.sectionEyebrow}>02 · philosophy</div>
+              <div class={ui.sectionEyebrow}>philosophy</div>
               <h2 class="mt-2">Why composable.</h2>
             </div>
             <a class={ui.permalink} href="#philosophy"><span aria-hidden="true">§</span><span class={ui.srOnly}>Link to Philosophy section</span></a>
@@ -628,7 +628,7 @@ const supportVersionTone = (value: string) => {
         <div class={ui.container}>
           <div class={`${ui.sectionHead} ${ui.sectionAnchor}`} id="how">
             <div>
-              <div class={ui.sectionEyebrow}>03 · how it works</div>
+              <div class={ui.sectionEyebrow}>how it works</div>
               <h2 class="mt-2">Same task. Three levels of abstraction.</h2>
               <p class="mt-3.5">All three tabs do the same thing: detect an article's language and summarize it into key-points. Same result, less to wire up.</p>
             </div>
@@ -644,7 +644,7 @@ const supportVersionTone = (value: string) => {
         <div class={ui.container}>
           <div class={`${ui.sectionHead} ${ui.sectionAnchor}`} id="support">
             <div>
-              <div class={ui.sectionEyebrow}>04 · support</div>
+              <div class={ui.sectionEyebrow}>support</div>
               <h2 class="mt-2">Browser support.</h2>
               <p class="mt-3.5">Built-in AI lands engine by engine. Where it is not there yet, you get a feature-detected no-op so your code does not crash.</p>
             </div>
@@ -697,7 +697,7 @@ const supportVersionTone = (value: string) => {
       <section class={`${ui.section} pb-[calc(var(--section-py)*2)]`} data-section="start">
         <div class={ui.container}>
           <div class={`${ui.ctaBlock} ${ui.sectionAnchor} ${ui.reveal}`} data-reveal id="start">
-            <div class={`${ui.sectionEyebrow} mb-5 justify-center`}>05 · ship it</div>
+            <div class={`${ui.sectionEyebrow} mb-5 justify-center`}>ship it</div>
             <h2 class={`${ui.ctaBlockTitle} ${ui.gradientText}`}>Try it in your project.</h2>
             <p class={ui.ctaBlockText}>
               One install, all eight blocks. Or pick the individual <code>@web-ai-sdk/*</code> packages. Ships ESM, CJS, and types. Tree-shakable.

--- a/apps/site/src/shared/ui.ts
+++ b/apps/site/src/shared/ui.ts
@@ -148,7 +148,7 @@ export const sectionHead =
   "mb-8 grid grid-cols-[1fr_auto] items-baseline gap-6 max-[880px]:mb-6";
 
 export const sectionEyebrow =
-  "inline-flex items-center gap-2.5 font-mono text-[11px] uppercase tracking-[0.14em] text-fg-4 before:h-px before:w-[18px] before:bg-fg-4 before:content-['']";
+  "inline-flex items-center gap-2.5 font-mono text-[11px] uppercase tracking-[0.14em] text-fg-4";
 
 export const permalink =
   "inline-flex size-7 items-center justify-center rounded-sm border border-hairline font-mono text-[13px] leading-none text-fg-4 no-underline transition-[color,border-color] hover:border-[color-mix(in_oklch,var(--color-accent)_40%,var(--color-hairline))] hover:text-accent max-[880px]:size-auto max-[880px]:rounded-none max-[880px]:border-0 max-[880px]:p-1.5 max-[880px]:hover:border-transparent [&>span[aria-hidden=true]]:translate-y-[-0.9px] [&>span[aria-hidden=true]]:opacity-75";


### PR DESCRIPTION
## Summary
- Remove the leading dash decoration (the `before:` pseudo-element) from `sectionEyebrow` in `apps/site/src/shared/ui.ts`.
- Drop the `NN ·` number/dot prefix from all six landing-page section eyebrows, leaving just the label text (`the question`, `packages`, `philosophy`, `how it works`, `support`, `ship it`).

## Test plan
- [ ] Run `pnpm dev` and confirm the landing-page section headers show only the label, with no dash and no numeric counter.