### PR TITLE
fix(site): clarify Built-in AI is desktop-only in unsupported messaging

### DIFF
--- a/apps/site/src/content/docs/browser-support.mdx
+++ b/apps/site/src/content/docs/browser-support.mdx
@@ -3,7 +3,7 @@ title: Browser support
 description: Where each web-ai-sdk package runs today, including Chrome and Edge specifics.
 ---
 
-Built-in AI lands engine by engine. Where it isn't there yet, every package is a feature-detected no-op so your code doesn't crash; render whatever fallback UI you want.
+Built-in AI lands engine by engine, and it is desktop-only for now: mobile browsers, including Chrome and Edge on iOS and Android, don't expose these APIs yet. Where it isn't there yet, every package is a feature-detected no-op so your code doesn't crash; render whatever fallback UI you want.
 
 | Package | Chrome | Edge | Safari | Firefox |
 | --- | --- | --- | --- | --- |

--- a/apps/site/src/features/docs/components/UnavailableHint.tsx
+++ b/apps/site/src/features/docs/components/UnavailableHint.tsx
@@ -11,11 +11,12 @@ const detectBrowser = (): "chrome" | "edge" | "other" => {
 /**
  * Hint shown when a demo's underlying Built-in AI API is unavailable.
  *
- * Chrome and Edge implement these APIs but enable them differently (different
- * flags, channels, and versions), so each gets its own instructions. Every
- * other engine (Safari, Firefox, ...) lacks the APIs entirely, so flag steps
- * would mislead; there we say plainly that only Chrome and Edge support them
- * today.
+ * Desktop Chrome and Edge implement these APIs but enable them differently
+ * (different flags, channels, and versions), so each gets its own instructions.
+ * Everything else (Safari, Firefox, and mobile browsers, including Chrome and
+ * Edge on iOS/Android, which report as "other") lacks the APIs entirely, so
+ * flag steps would mislead; there we say plainly that only desktop Chrome and
+ * Edge support them today.
  */
 export const UnavailableHint = ({
   api,
@@ -31,8 +32,9 @@ export const UnavailableHint = ({
     return (
       <p className="demo-hint demo-hint--warn">
         {api} isn't supported in this browser yet. The Web's Built-in AI APIs
-        currently ship only in Chrome and Edge. Open this page in one of them to
-        try the demo.
+        currently run only on desktop Chrome and Edge (mobile browsers,
+        including Chrome and Edge on iOS and Android, aren't supported yet).
+        Open this page on desktop Chrome or Edge to try the demo.
       </p>
     );
   }

--- a/apps/site/src/features/home/components/shared.tsx
+++ b/apps/site/src/features/home/components/shared.tsx
@@ -259,16 +259,18 @@ export const UnavailableNotice = ({
 }) => {
   const browser = detectBrowser();
 
-  // Safari, Firefox, and every other engine don't implement the Web's Built-in
-  // AI APIs at all, so Chrome/Edge flag instructions would be misleading. Say
-  // plainly that only Chrome and Edge support these APIs today.
+  // Safari, Firefox, and mobile browsers (including Chrome and Edge on
+  // iOS/Android, which report as "other") don't implement the Web's Built-in AI
+  // APIs, so Chrome/Edge flag instructions would mislead. These APIs are
+  // desktop-only today; say so plainly.
   if (browser === "other") {
     return (
       <div className="block rounded-sm border border-[color-mix(in_oklch,var(--color-warn)_40%,var(--color-hairline))] bg-surface px-3 py-[9px] font-mono text-[11.5px] text-warn">
         <span>
           {api} isn't supported in this browser yet. The Web's Built-in AI APIs
-          currently ship only in Chrome and Edge. Open this page in one of them
-          to try the demo.
+          currently run only on desktop Chrome and Edge (mobile browsers,
+          including Chrome and Edge on iOS and Android, aren't supported yet).
+          Open this page on desktop Chrome or Edge to try the demo.
         </span>
       </div>
     );

--- a/apps/site/src/pages/index.astro
+++ b/apps/site/src/pages/index.astro
@@ -665,7 +665,7 @@ const supportVersionTone = (value: string) => {
             <div>
               <div class={ui.sectionEyebrow}>support</div>
               <h2 class="mt-2">Browser support.</h2>
-              <p class="mt-3.5">Built-in AI lands engine by engine. Where it is not there yet, you get a feature-detected no-op so your code does not crash.</p>
+              <p class="mt-3.5">Built-in AI lands engine by engine, and it is desktop-only for now: mobile browsers, including Chrome and Edge on iOS and Android, are not supported yet. Where it is not there yet, you get a feature-detected no-op so your code does not crash.</p>
             </div>
             <a class={ui.permalink} href="#support"><span aria-hidden="true">§</span><span class={ui.srOnly}>Link to Browser support section</span></a>
           </div>


### PR DESCRIPTION
## Summary

Hotfix follow-up to #83. On Chrome and Edge for iOS/Android, the browser reports as `"other"` (iOS Chrome is WebKit and its UA contains `CriOS`, not `Chrome/`), so the demos' unsupported message told users already in Chrome to "use Chrome / Edge", which is confusing. The Web's Built-in AI APIs are desktop-only today, so the messaging now says that explicitly.

- Demos (home `UnavailableNotice` + docs `UnavailableHint`): the unsupported message now reads "currently run only on desktop Chrome and Edge (mobile browsers, including Chrome and Edge on iOS and Android, aren't supported yet)".
- Home browser-support intro and docs `browser-support.mdx` intro: added the same desktop-only clarification so the limitation is stated at the source, not just in the demo fallback.

## Test plan
- [x] `pnpm lint`
- [x] `pnpm build`
- [x] `pnpm --filter @web-ai-sdk-apps/site typecheck`
- [ ] Open a demo on Chrome/Edge for iOS or Android and confirm the message says desktop-only
- [ ] Verify the home and docs browser-support sections show the desktop-only note