### PR TITLE
feat(site): expand WebMCP guide and agent-ready positioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,10 @@ Each package ships:
 - **Vanilla** entry (`@web-ai-sdk/<pkg>`): TypeScript / DOM only, zero framework deps.
 - **React** entry (`@web-ai-sdk/<pkg>/react`): small hook adapter wrapping the vanilla core. `react` is an optional peer dep.
 
+## Build for the agentic web
+
+The browser is becoming both an AI runtime and an agent surface. The Built-in AI wrappers (Prompt, Summarizer, Translator, and friends) cover the runtime half: local model capabilities behind one typed interface. [`@web-ai-sdk/webmcp`](./packages/webmcp) covers the agent half: structured, agent-callable tools your page exposes to visiting agents. Feature detection and no-op fallbacks keep the same code shipping everywhere, so neither half is a hard requirement — see [Browser support](./apps/site/src/content/docs/browser-support.mdx) for what's available where.
+
 ## Why composable
 
 Browsers are shipping built-in AI APIs behind flags. The shape changes; the lifecycle is similar across them: feature-detect, lazily create a session, stream chunks, cache results, clean up. Those concerns are framework-agnostic and worth sharing.

--- a/apps/site/src/content/docs/guides/webmcp.mdx
+++ b/apps/site/src/content/docs/guides/webmcp.mdx
@@ -5,6 +5,12 @@ description: web-ai-sdk wrapper to register agent-callable tools on the W3C WebM
 
 Building block for the W3C [WebMCP](https://webmachinelearning.github.io/webmcp/) API exposed at `document.modelContext`. (For backward compatibility with the previous shape of the API, this package also reads from `navigator.modelContext`.) Register agent-callable tools from any framework; the package is vanilla TypeScript / DOM with an optional React adapter shipped as a subpath export. See [useWebMCP](/docs/react/use-web-mcp/) for React.
 
+Where the Built-in AI APIs make the browser an AI runtime, WebMCP makes your page an agent surface: instead of a visiting agent guessing what your interface elements do, the page declares structured tools the agent can discover and call.
+
+:::caution[Experimental]
+WebMCP is a proposed standard in early preview: behind flags and an origin trial in Chromium browsers, absent everywhere else. Treat it as progressive enhancement — keep the human UI path, and let the wrapper no-op where the API is missing. Current versions and flag names live in [Browser support](/docs/browser-support/).
+:::
+
 ## Usage
 
 ```ts
@@ -86,6 +92,17 @@ registerTool({
 
 Shorthand flags map to the spec hints (`readOnlyHint`, `destructiveHint`); pass `annotations` directly when you need `idempotentHint` or `openWorldHint`.
 
+## Tool design
+
+A tool is a semantic interface, not just a function: the agent selects tools by reading names, descriptions, schemas, and annotations. A few rules of thumb:
+
+- **Action-oriented names.** `add_to_cart`, `select_shipping_address`, `run_diagnostics` — not `doAction`, `submit`, or `handleClick`.
+- **Descriptions that say when to use the tool**, not just what it does. Besides the schema, the description is the agent's only routing signal.
+- **Precise `inputSchema`.** Mark `required` fields, describe every property, and use enums for closed sets so hosts can validate before dispatch.
+- **Small, structured outputs.** Return compact objects the agent can act on, and surface failures as structured error objects rather than thrown strings.
+- **Honest annotations.** `readOnly` for inspection tools, `destructive` for anything irreversible or user-impacting — and still confirm destructive actions with the user; an annotation is not authorization, and neither is a tool. Never expose a tool that bypasses your normal authorization checks.
+- **Lifecycle-scoped registration.** Register a tool only while the UI state it acts on exists, and call the cleanup when that state goes away.
+
 ## Errors and unavailability
 
 The wrapper never throws on missing API; it's a no-op. The vanilla functions return a no-op cleanup, so consumer code stays declarative:
@@ -100,3 +117,55 @@ if (!isAvailable()) {
 
 registerTool({ ... });
 ```
+
+## Origin trial
+
+Chrome opened a public [origin trial](https://developer.chrome.com/blog/ai-webmcp-origin-trial) for WebMCP (Chrome 149), so you can test agent-callable tools with real traffic before the API stabilizes. Sign up on the [Chrome origin trials](https://developer.chrome.com/origintrials) page; for local development a flag works without a token — see [Browser support](/docs/browser-support/) for the current flag names.
+
+Keep WebMCP optional either way. The wrapper already no-ops when the API is missing, so the same registration code ships to every browser — with or without the trial:
+
+```ts
+import { registerTool } from "@web-ai-sdk/webmcp";
+
+registerTool({
+  name: "add_to_cart",
+  description: "Add a product SKU to the user's cart",
+  inputSchema: {
+    type: "object",
+    properties: {
+      sku: { type: "string", description: "The product SKU to add" },
+    },
+    required: ["sku"],
+  },
+  execute: async ({ sku }) => addToCart(sku),
+});
+```
+
+## Debugging in DevTools
+
+Chromium DevTools includes experimental WebMCP debugging in the **Application** panel (introduced in Chrome's [DevTools 149](https://developer.chrome.com/blog/new-in-devtools-149); Edge ships it too): inspect registered tools and their schemas, run a tool manually with custom parameters, track active and pending invocations, and inspect execution status and return payloads. Tools registered through `registerTool` show up there like any other `document.modelContext` registration.
+
+The panel is off by default; enable both flags (under `chrome://flags` / `edge://flags`) and restart the browser:
+
+- `#devtools-webmcp-support`
+- `#enable-webmcp-testing`
+
+## Testing and evals
+
+Test WebMCP tools at two levels:
+
+1. **Deterministic tests** for `execute` itself — plain unit tests, nothing WebMCP-specific.
+2. **Agent evals** for tool selection — does an agent pick the right tool, with the right arguments, in the right order, from a natural-language prompt?
+
+Chrome's [WebMCP evals](https://developer.chrome.com/docs/ai/webmcp/evals) tooling expresses the second kind as the call expected from a user prompt:
+
+```json
+{
+  "messages": [{ "role": "user", "content": "Add this product to my cart." }],
+  "expectedCall": [
+    { "functionName": "add_to_cart", "arguments": { "sku": "abc-123" } }
+  ]
+}
+```
+
+Multi-step journeys wrap call chains in `ordered` (must run sequentially) or `unordered` (any order). When an eval fails, the fix is usually in the tool's name, description, or `inputSchema` — that is the interface the agent actually reads; see [Tool design](#tool-design).

--- a/apps/site/src/features/home/components/WebMCPDemo.tsx
+++ b/apps/site/src/features/home/components/WebMCPDemo.tsx
@@ -47,6 +47,9 @@ interface ToolSpec {
   desc: string;
   on: boolean;
   match: RegExp;
+  readOnly?: boolean;
+  destructive?: boolean;
+  inputSchema?: object;
   execute: (input: unknown) => Promise<unknown>;
 }
 
@@ -57,6 +60,14 @@ const TOOL_SPECS: readonly ToolSpec[] = [
     desc: "Add a SKU to the user's cart",
     on: true,
     match: /\bcart\b|\badd\b|MX-\d+/i,
+    inputSchema: {
+      type: "object",
+      properties: {
+        sku: { type: "string", description: "The product SKU to add" },
+        qty: { type: "integer", minimum: 1, description: "Units to add" },
+      },
+      required: ["sku"],
+    },
     execute: async (input) => ({ ok: true, ...(input as object) }),
   },
   {
@@ -65,6 +76,7 @@ const TOOL_SPECS: readonly ToolSpec[] = [
     desc: "Search past orders by date or item",
     on: true,
     match: /\border|\btuesday|\bpurchase/i,
+    readOnly: true,
     execute: async () => ({ ok: true, results: 3 }),
   },
   {
@@ -73,6 +85,7 @@ const TOOL_SPECS: readonly ToolSpec[] = [
     desc: "List the agent's registered tools and their state",
     on: false,
     match: /\bsetting|\bnotification|\bpreference|\btool|\bregister/i,
+    readOnly: true,
     // Placeholder; overridden inside the component so it can read the
     // current registration state from React.
     execute: async () => ({ ok: true }),
@@ -83,6 +96,7 @@ const TOOL_SPECS: readonly ToolSpec[] = [
     desc: "Issue a refund (requires confirmation)",
     on: false,
     match: /\brefund|\breturn\b/i,
+    destructive: true,
     execute: async () => ({ ok: true, refundId: "rf_demo" }),
   },
 ];
@@ -149,6 +163,9 @@ export const WebMCPDemo = () => {
     return TOOL_SPECS.filter((t) => enabledIds.has(t.id)).map((spec) => ({
       name: spec.name,
       description: spec.desc,
+      ...(spec.inputSchema ? { inputSchema: spec.inputSchema } : {}),
+      ...(spec.readOnly ? { readOnly: true } : {}),
+      ...(spec.destructive ? { destructive: true } : {}),
       execute:
         spec.id === "open_settings"
           ? async () => ({

--- a/apps/site/src/features/home/components/WebMCPDemo.tsx
+++ b/apps/site/src/features/home/components/WebMCPDemo.tsx
@@ -68,7 +68,12 @@ const TOOL_SPECS: readonly ToolSpec[] = [
       },
       required: ["sku"],
     },
-    execute: async (input) => ({ ok: true, ...(input as object) }),
+    execute: async (input) => ({
+      ok: true,
+      // Manual invocations (DevTools, testing surface) can pass primitives;
+      // only spread real objects so the payload stays well-formed.
+      ...(typeof input === "object" && input !== null ? input : {}),
+    }),
   },
   {
     id: "search_orders",

--- a/apps/site/src/pages/index.astro
+++ b/apps/site/src/pages/index.astro
@@ -468,7 +468,7 @@ const supportVersionTone = (value: string) => {
         <div class={`${ui.container} ${ui.heroGrid}`}>
           <div class={ui.heroEyebrow}>
             <span class={ui.heroEyebrowDot}></span>
-            <span class={ui.gradientText}>Built-in AI, the right way</span>
+            <span class={ui.gradientText}>Web AI + agents, the right way</span>
           </div>
           <h1 class={`${ui.heroTitle} ${heroTextShadow}`}>
             web-ai-sdk


### PR DESCRIPTION
## Summary

Acts on the WebMCP handoff notes (`.ideas/web-ai-sdk-webmcp-handoff.md`): Chrome's origin trial, DevTools debugging, and evals guidance make `@web-ai-sdk/webmcp` a stronger part of the project story, so the guide and positioning catch up.

### WebMCP guide (`docs/guides/webmcp`)
- Agent-surface framing intro (Built-in AI = AI runtime, WebMCP = agent surface) and an explicit experimental caution that defers version/flag specifics to Browser support
- **Tool design** — naming, descriptions, schema precision, structured outputs, honest annotations, lifecycle-scoped registration
- **Origin trial** — sign-up pointer and the progressive-enhancement registration pattern
- **Debugging in DevTools** — Application-panel workflow (Chrome + Edge) and the two flags
- **Testing and evals** — deterministic tests vs. agent evals, with the `expectedCall` / `ordered` / `unordered` shapes

### Positioning
- Hero eyebrow: "Built-in AI, the right way" → "Web AI + agents, the right way"
- README: new "Build for the agentic web" section connecting the Built-in AI wrappers and `@web-ai-sdk/webmcp`

### Demo alignment
- Homepage WebMCP demo registrations now model the documented best practices: `inputSchema` on `add_to_cart`, `readOnly` on `search_orders`/`open_settings`, `destructive` on `refund`. No visual change; the metadata flows into `document.modelContext` where agents and the DevTools panel see it.

Copy deliberately avoids transient-status phrasing ("now in origin trial") so it won't need rewording as rollout states change; version facts stay centralized in Browser support.

Sources: [WebMCP origin trial](https://developer.chrome.com/blog/ai-webmcp-origin-trial) · [DevTools 149](https://developer.chrome.com/blog/new-in-devtools-149) · [WebMCP evals](https://developer.chrome.com/docs/ai/webmcp/evals)

## Test plan
- `pnpm gate` green (lint, build, typecheck, test)
- Hero + guide reviewed on the local dev server