### PR TITLE
feat(site): add Summarizer preference demo with chip-styled controls

### DIFF
--- a/apps/site/src/content/docs/guides/summarizer.mdx
+++ b/apps/site/src/content/docs/guides/summarizer.mdx
@@ -122,6 +122,8 @@ summarize({ language: "en", input: text, preference: "capability" });
 
 The default is `"auto"` to match the platform default; `"speed"` and `"capability"` are explicit opt-ins.
 
+Model tiering for `"speed"` and `"capability"` is experimental: enable the Summarizer API performance preference flag, restart your browser, and reload — otherwise the browser may accept the hint without switching models.
+
 ### `"speed"` is narrower than `"auto"`
 
 The faster model behind `"speed"` does not serve every configuration. Some combinations of `language`, `type`, `length`, and `format` are not available on the speed path, and there is no promise that the browser silently upgrades you to a more capable model when they aren't — the configuration can instead be reported as **unavailable**. When that happens, `summarize()` throws `SummarizerUnavailableError`, the same way it does for any unavailable configuration.

--- a/apps/site/src/features/docs/styles/tailwind.css
+++ b/apps/site/src/features/docs/styles/tailwind.css
@@ -29,6 +29,7 @@
   --color-accent-soft: rgba(255, 255, 255, 0.1);
   --color-accent-line: rgba(255, 255, 255, 0.3);
   --color-ok: #57d9a3;
+  --color-info: #6eb5ff;
   --color-warn: #ffc861;
   --color-err: #ff6b7a;
   --color-brand-dark: #0a0a0a;

--- a/apps/site/src/features/home/components/SummarizerDemo.tsx
+++ b/apps/site/src/features/home/components/SummarizerDemo.tsx
@@ -12,10 +12,11 @@ import {
   cardDotOk,
   cardHead,
   cardHeadTitle,
-  chip,
-  chipActive,
-  chipRow,
   chipRowEnd,
+  chipRowInline,
+  chipSelect,
+  chipSelectCaret,
+  chipSelectWrap,
   chipSep,
   demoControls,
   fieldSpaced,
@@ -25,6 +26,8 @@ import {
 import {
   DownloadNotice,
   ErrorNotice,
+  InfoNotice,
+  isDesktopChromium,
   MarkdownOutput,
   StatusBar,
   UnavailableNotice,
@@ -36,11 +39,48 @@ const SAMPLE_ARTICLE = `The Summarizer API ships as part of the browser's built-
 
 type SummaryType = "key-points" | "tldr" | "headline";
 type SummaryLength = "short" | "medium" | "long";
+type SummaryPreference = "auto" | "speed" | "capability";
+
+const preferenceInfo = (preference: SummaryPreference): string | null => {
+  if (!isDesktopChromium()) return null;
+  return `preference: ${preference} is experimental. Enable the Summarizer API performance preference flag, restart your browser, and reload for model tiering.`;
+};
+
+const ChipSelect = <T extends string>({
+  label,
+  value,
+  options,
+  onChange,
+}: {
+  label: string;
+  value: T;
+  options: readonly T[];
+  onChange: (value: T) => void;
+}) => (
+  <span className={chipSelectWrap}>
+    <select
+      className={chipSelect}
+      value={value}
+      aria-label={label}
+      onChange={(e) => onChange(e.target.value as T)}
+    >
+      {options.map((option) => (
+        <option key={option} value={option}>
+          {option}
+        </option>
+      ))}
+    </select>
+    <span className={chipSelectCaret} aria-hidden="true">
+      ▾
+    </span>
+  </span>
+);
 
 export const SummarizerDemo = () => {
   const [text, setText] = useState(SAMPLE_ARTICLE);
   const [type, setType] = useState<SummaryType>("key-points");
   const [length, setLength] = useState<SummaryLength>("short");
+  const [preference, setPreference] = useState<SummaryPreference>("auto");
   const [output, setOutput] = useState("");
   const [streaming, setStreaming] = useState(false);
   const [available, setAvailable] = useState<boolean | null>(null);
@@ -52,6 +92,8 @@ export const SummarizerDemo = () => {
   useEffect(() => {
     setAvailable(isSummarizerAvailable());
   }, []);
+
+  const info = preference !== "auto" ? preferenceInfo(preference) : null;
 
   const run = async () => {
     if (streaming) return;
@@ -67,6 +109,7 @@ export const SummarizerDemo = () => {
         input: text,
         type,
         length,
+        preference,
         monitor,
         signal: ac.signal,
         onUpdate: (chunk) => {
@@ -109,6 +152,7 @@ export const SummarizerDemo = () => {
       </div>
       <div className={cardBody}>
         {available === false && <UnavailableNotice api="Summarizer API" />}
+        <InfoNotice message={info} />
         <DownloadNotice progress={progress} />
         <ErrorNotice error={error} />
         <div className={fieldSpaced}>
@@ -132,28 +176,27 @@ export const SummarizerDemo = () => {
           >
             <span>{streaming ? "…" : "▶"}</span> Summarize
           </button>
-          <div className={`${chipRow} ${chipRowEnd}`}>
-            {(["key-points", "tldr", "headline"] as const).map((t) => (
-              <button
-                key={t}
-                type="button"
-                className={type === t ? chipActive : chip}
-                onClick={() => setType(t)}
-              >
-                {t}
-              </button>
-            ))}
+          <div className={`${chipRowInline} ${chipRowEnd}`}>
+            <ChipSelect
+              label="Summary type"
+              value={type}
+              options={["key-points", "tldr", "headline"]}
+              onChange={setType}
+            />
             <span className={chipSep} aria-hidden="true" />
-            {(["short", "medium", "long"] as const).map((l) => (
-              <button
-                key={l}
-                type="button"
-                className={length === l ? chipActive : chip}
-                onClick={() => setLength(l)}
-              >
-                {l}
-              </button>
-            ))}
+            <ChipSelect
+              label="Summary length"
+              value={length}
+              options={["short", "medium", "long"]}
+              onChange={setLength}
+            />
+            <span className={chipSep} aria-hidden="true" />
+            <ChipSelect
+              label="Performance preference"
+              value={preference}
+              options={["auto", "speed", "capability"]}
+              onChange={setPreference}
+            />
           </div>
         </div>
         <MarkdownOutput
@@ -165,7 +208,10 @@ export const SummarizerDemo = () => {
               : "Run to summarize the article above."
           }
         />
-        <StatusBar stats={stats} label={`type: ${type}`} />
+        <StatusBar
+          stats={stats}
+          label={`type: ${type} · preference: ${preference}`}
+        />
       </div>
     </div>
   );

--- a/apps/site/src/features/home/components/shared.tsx
+++ b/apps/site/src/features/home/components/shared.tsx
@@ -62,6 +62,24 @@ export const ErrorNotice = ({ error }: { error: string | null }) => {
   );
 };
 
+export const InfoNotice = ({ message }: { message: string | null }) => {
+  if (!message) return null;
+  return (
+    <div className="block rounded-sm border border-[color-mix(in_oklch,var(--color-info)_40%,var(--color-hairline))] bg-surface px-3 py-[9px] font-mono text-[11.5px] text-info">
+      <span className="text-[11px]">{message}</span>
+    </div>
+  );
+};
+
+export const WarnNotice = ({ message }: { message: string | null }) => {
+  if (!message) return null;
+  return (
+    <div className="block rounded-sm border border-[color-mix(in_oklch,var(--color-warn)_40%,var(--color-hairline))] bg-surface px-3 py-[9px] font-mono text-[11.5px] text-warn">
+      <span className="text-[11px]">{message}</span>
+    </div>
+  );
+};
+
 export const DownloadNotice = ({ progress }: { progress: number | null }) => {
   if (progress === null) return null;
   const pct = Math.round(progress * 100);
@@ -236,6 +254,13 @@ export const detectBrowser = (): "chrome" | "edge" | "other" => {
   if (/\bEdg\//.test(ua)) return "edge";
   if (/\bChrome\//.test(ua)) return "chrome";
   return "other";
+};
+
+/** Desktop Chrome or Edge — excludes mobile Chromium UAs that still match `detectBrowser()`. */
+export const isDesktopChromium = (): boolean => {
+  if (detectBrowser() === "other") return false;
+  if (typeof navigator === "undefined") return false;
+  return !/Android|iPhone|iPad|iPod|Mobile|Tablet/i.test(navigator.userAgent);
 };
 
 export const detectModelName = (): string => {

--- a/apps/site/src/features/home/components/shared.tsx
+++ b/apps/site/src/features/home/components/shared.tsx
@@ -248,6 +248,10 @@ export const MarkdownOutput = ({
   );
 };
 
+type NavigatorWithUserAgentData = Navigator & {
+  userAgentData?: { brands?: Array<{ brand: string; version: string }> };
+};
+
 export const detectBrowser = (): "chrome" | "edge" | "other" => {
   if (typeof navigator === "undefined") return "other";
   const ua = navigator.userAgent;
@@ -256,11 +260,22 @@ export const detectBrowser = (): "chrome" | "edge" | "other" => {
   return "other";
 };
 
-/** Desktop Chrome or Edge — excludes mobile Chromium UAs that still match `detectBrowser()`. */
+/** Desktop Chrome or Edge — excludes mobile UAs and other Chromium forks. */
 export const isDesktopChromium = (): boolean => {
-  if (detectBrowser() === "other") return false;
   if (typeof navigator === "undefined") return false;
-  return !/Android|iPhone|iPad|iPod|Mobile|Tablet/i.test(navigator.userAgent);
+  const ua = navigator.userAgent;
+  if (/Android|iPhone|iPad|iPod|Mobile|Tablet/i.test(ua)) return false;
+
+  const brands = (navigator as NavigatorWithUserAgentData).userAgentData
+    ?.brands;
+  if (brands) {
+    return brands.some(
+      (b) => b.brand === "Google Chrome" || b.brand === "Microsoft Edge",
+    );
+  }
+
+  const browser = detectBrowser();
+  return browser === "edge" || browser === "chrome";
 };
 
 export const detectModelName = (): string => {

--- a/apps/site/src/shared/themes.ts
+++ b/apps/site/src/shared/themes.ts
@@ -150,6 +150,7 @@ const MANAGED_TOKENS = [
   "--color-accent-line",
   "--color-brand-dark",
   "--color-ok",
+  "--color-info",
   "--color-warn",
   "--color-err",
 ] as const;
@@ -224,6 +225,7 @@ export function applyTheme(theme: Theme, mode: Mode): void {
 
   // Status lights stay semantic; only success may be retinted per theme.
   set("--color-ok", theme.ok ?? (light ? "#1f9d6b" : "#57d9a3"));
+  set("--color-info", light ? "#0066b8" : "#6eb5ff");
   set("--color-warn", light ? "#9a6b00" : "#ffc861");
   set("--color-err", light ? "#c2354a" : "#ff6b7a");
 

--- a/apps/site/src/shared/ui.ts
+++ b/apps/site/src/shared/ui.ts
@@ -67,7 +67,7 @@ const selectChevron =
 export const select = `h-[38px] w-full cursor-pointer appearance-none rounded-sm border border-hairline bg-bg px-3 pr-9 font-mono text-[13px] leading-[38px] text-fg transition-[border-color,background] focus:border-accent-line focus:bg-surface-2 focus:outline-none ${selectChevron}`;
 
 /** Pill select — matches selected `chipActive` styling (current value always shown). */
-export const chipSelect = `${chipActive} appearance-none pr-7 max-[640px]:pr-8 focus:outline-none`;
+export const chipSelect = `${chipActive} appearance-none pr-7 max-[640px]:pr-8 focus:outline-none focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent`;
 
 export const chipSelectWrap = "relative inline-flex shrink-0 items-center";
 

--- a/apps/site/src/shared/ui.ts
+++ b/apps/site/src/shared/ui.ts
@@ -28,6 +28,9 @@ export const demoControls =
 
 export const chipRow = "flex flex-wrap items-center gap-1.5";
 
+export const chipRowInline =
+  "flex shrink-0 flex-nowrap items-center gap-1.5 max-[640px]:flex-wrap";
+
 export const chipRowEnd = "ml-auto max-[640px]:ml-0 max-[640px]:w-full";
 
 const chipBase =
@@ -62,6 +65,14 @@ const selectChevron =
   "bg-[url('data:image/svg+xml;charset=utf-8,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2212%22%20height%3D%228%22%20viewBox%3D%220%200%2012%208%22%20fill%3D%22none%22%3E%3Cpath%20d%3D%22M1%201.5L6%206.5L11%201.5%22%20stroke%3D%22%238a8175%22%20stroke-width%3D%221.5%22%20stroke-linecap%3D%22round%22%20stroke-linejoin%3D%22round%22%2F%3E%3C%2Fsvg%3E')] bg-[length:12px_8px] bg-[position:right_12px_center] bg-no-repeat";
 
 export const select = `h-[38px] w-full cursor-pointer appearance-none rounded-sm border border-hairline bg-bg px-3 pr-9 font-mono text-[13px] leading-[38px] text-fg transition-[border-color,background] focus:border-accent-line focus:bg-surface-2 focus:outline-none ${selectChevron}`;
+
+/** Pill select — matches selected `chipActive` styling (current value always shown). */
+export const chipSelect = `${chipActive} appearance-none pr-7 max-[640px]:pr-8 focus:outline-none`;
+
+export const chipSelectWrap = "relative inline-flex shrink-0 items-center";
+
+export const chipSelectCaret =
+  "pointer-events-none absolute top-1/2 right-2.5 -translate-y-1/2 font-mono text-[9px] leading-none text-accent-bright";
 
 export const caret =
   "inline-block h-[0.08em] w-[0.5em] shrink-0 animate-blink rounded-[1px] bg-accent align-baseline ml-[0.06em]";

--- a/apps/site/src/styles/home.css
+++ b/apps/site/src/styles/home.css
@@ -21,6 +21,7 @@
   --color-accent-line: rgba(255, 255, 255, 0.3);
   /* Status lights: fixed semantic meaning; a theme may retint --color-ok. */
   --color-ok: #57d9a3;
+  --color-info: #6eb5ff;
   --color-warn: #ffc861;
   --color-err: #ff6b7a;
   --color-brand-dark: #0a0a0a;
@@ -129,6 +130,7 @@
     --accent-soft: var(--color-accent-soft);
     --accent-line: var(--color-accent-line);
     --ok: var(--color-ok);
+    --info: var(--color-info);
     --warn: var(--color-warn);
     --err: var(--color-err);
     --sans: var(--font-sans);


### PR DESCRIPTION
## Summary
- Re-lands the Summarizer preference work from #87 (reverted in #88) on a clean branch with no `Co-authored-by` trailers.
- Adds `auto` / `speed` / `capability` pill selects on the home Summarizer demo and forwards `preference` into `summarize()`.
- Shows an experimental tiering info notice on desktop Chromium when a non-`auto` preference is selected.
- Adds `--color-info`, `InfoNotice`/`WarnNotice`, and a docs note under performance preference in the Summarizer guide.

## Test plan
- [x] `pnpm gate`
- [ ] Confirm type / length / preference selects sit on one row beside Summarize
- [ ] Select `speed` or `capability` and confirm the info notice on desktop Chrome/Edge
- [ ] Review `/docs/guides/summarizer/` experimental tiering note