### PR TITLE
feat(prompt): add sampling mode support

### DIFF
--- a/.changeset/mean-dancers-sparkle.md
+++ b/.changeset/mean-dancers-sparkle.md
@@ -1,0 +1,8 @@
+---
+"@web-ai-sdk/prompt": minor
+"@web-ai-sdk/all": minor
+---
+
+Add `samplingMode` support for the Prompt API while keeping raw `temperature` and `topK` as deprecated legacy passthroughs.
+
+`samplingMode` is forwarded to `LanguageModel.create()` and rejected when mixed with raw sampling parameters.

--- a/apps/site/src/content/docs/architecture.mdx
+++ b/apps/site/src/content/docs/architecture.mdx
@@ -60,7 +60,7 @@ If a different framework adapter ever ships, it will follow the same shape: `@we
 The SDK is allowed to be ergonomic *within a single capability*. Examples that live inside `@web-ai-sdk/prompt`:
 
 - **Warm LRU session pool.** `ask()` reuses `LanguageModel.create()` results across same-shape callers. Cold start drops to sub-second. The pool size is fixed at a sensible default; if you need fine-grained eviction control, use `createSession()` and own the lifecycle yourself.
-- **Optional result cache.** `ask()` accepts a `cache` option that memoizes responses by `(input, systemPrompt, temperature, topK)`. Off by default; pass `"session"` / `"local"` for the matching web-storage shortcut, or supply your own `{ get, set }` backend.
+- **Optional result cache.** `ask()` accepts a `cache` option that memoizes responses by `(input, systemPrompt, samplingMode / temperature / topK)`. Off by default; pass `"session"` / `"local"` for the matching web-storage shortcut, or supply your own `{ get, set }` backend.
 - **Delta-vs-cumulative stream normalization.** Chrome emits delta chunks; some Edge backends emit cumulative buffers. The wrapper smooths this so `onUpdate` always sees the cumulative buffer and `sendStreaming()` always yields deltas.
 
 These are **ergonomic defaults**, not opinions about *how* you build an app. They each:

--- a/apps/site/src/content/docs/guides/prompt.mdx
+++ b/apps/site/src/content/docs/guides/prompt.mdx
@@ -15,7 +15,7 @@ import { ask } from "@web-ai-sdk/prompt";
 const result = await ask({
   input: "Summarize this in one sentence: WebMCP lets pages expose tools to agents.",
   systemPrompt: "You are concise. Reply with a single sentence.",
-  temperature: 0.2,
+  samplingMode: "predictable",
   onUpdate: (text) => render(text),
 });
 
@@ -32,6 +32,7 @@ Pass `onUpdate` to render partial text as it streams. `result.output` is the fin
 interface AskOptions {
   input: string;
   systemPrompt?: string;
+  samplingMode?: "most-predictable" | "predictable" | "balanced" | "creative" | "most-creative";
   temperature?: number;
   topK?: number;
   language?: string;
@@ -54,8 +55,9 @@ interface AskOptions {
 | --- | --- | --- |
 | `input` <sup>required</sup> | `string` | The user-facing prompt / question. Empty / whitespace resolves to `{ output: null }`. |
 | `systemPrompt` | `string` | Optional system prompt (folded into `initialPrompts` as a `system` role). |
-| `temperature` | `number` | Sampling temperature (0..1). Defaults to the model's default. |
-| `topK` | `number` | Sampling top-k. Defaults to the model's default. |
+| `samplingMode` | `"most-predictable" \| "predictable" \| "balanced" \| "creative" \| "most-creative"` | Semantic sampling preset. Mutually exclusive with `temperature` / `topK`. |
+| `temperature` | `number` | Legacy raw sampling temperature. Web page contexts are moving to `samplingMode`. |
+| `topK` | `number` | Legacy raw sampling top-k. Web page contexts are moving to `samplingMode`. |
 | `language` | `string` | BCP-47 language hint. Folded into `expectedInputs` / `expectedOutputs` when supported. |
 | `supportedLanguages` | `readonly string[]` | Languages the model supports for the language hint. Defaults to `["en"]`. |
 | `expectedInputs` | `LanguageModelExpectedInput[]` | Advanced: full passthrough. Overrides the `language` hint. |
@@ -64,7 +66,7 @@ interface AskOptions {
 | `monitor` | `(m) => void` | Observe the first-call model download. |
 | `responseConstraint` | `object` | JSON Schema for structured output. |
 | `cache` | `"session" \| "local" \| { get, set }` | Opt-in result cache. |
-| `cacheKey` | `string` | Override the default cache key (hash of `{ input, systemPrompt, temperature, topK }`). |
+| `cacheKey` | `string` | Override the default cache key (hash of `{ input, systemPrompt, samplingMode, temperature, topK }`). |
 | `onUpdate` | `(text: string) => void` | Streaming update callback. Cumulative buffer, not deltas. |
 | `signal` | `AbortSignal` | Abort signal. |
 
@@ -88,7 +90,7 @@ import { createSession } from "@web-ai-sdk/prompt";
 
 const session = createSession({
   systemPrompt: "You are a helpful assistant.",
-  temperature: 0.7,
+  samplingMode: "balanced",
 });
 
 // Streaming yields DELTA chunks (not cumulative buffers):
@@ -165,21 +167,20 @@ Chrome's `LanguageModel` exposes `LanguageModel.create({...})` to spin up a sess
 
 - **Feature detection.** `isAvailable()` / `checkAvailability()` return `false` / `null` on browsers without the API. The vanilla `ask()` throws `PromptUnavailableError`; the React hook surfaces `status: "unavailable"`.
 - **Session reuse for `ask()`** (ergonomic default, scoped to `ask`). A bounded LRU caches `LanguageModel.create()` by stringified create options. Cold start is roughly 1 to 3 seconds; warm calls are sub-second. `createSession()` never touches this cache.
-- **Optional result cache for `ask()` (off by default).** Every call hits the model unless you opt in. Pass `cache: "session"` for `sessionStorage`, `cache: "local"` for `localStorage`, or any `{ get, set }`-shaped object to memoize responses by `(input, systemPrompt, temperature, topK)`.
+- **Optional result cache for `ask()` (off by default).** Every call hits the model unless you opt in. Pass `cache: "session"` for `sessionStorage`, `cache: "local"` for `localStorage`, or any `{ get, set }`-shaped object to memoize responses by `(input, systemPrompt, samplingMode / temperature / topK)`.
 - **Delta-vs-cumulative chunk detection.** Chrome ships delta chunks; some Edge backends ship cumulative. The wrapper normalizes per-chunk so `onUpdate` (cumulative) and `sendStreaming()` (deltas) work the same across browsers.
 
 The two cache-shaped items above are *ergonomic defaults scoped to `ask()`*, not opinions about how to use a language model. Multi-package compositions (agent loops, conversation history, tool dispatch) are not part of this package; see [Architecture](/docs/architecture/) for the split.
 
 ## System prompt + sampling
 
-`systemPrompt` is folded into the session's `initialPrompts` as a `system` role. `temperature` and `topK` are passed through verbatim; when omitted, the model's defaults apply.
+`systemPrompt` is folded into the session's `initialPrompts` as a `system` role. Prefer `samplingMode` for output variety: the browser maps the semantic mode to model-appropriate sampling parameters. Legacy `temperature` and `topK` are still passed through where browsers expose them, but they are mutually exclusive with `samplingMode`.
 
 ```ts
 ask({
   input: "Tell me a joke about web standards.",
   systemPrompt: "You are a stand-up comedian. Be punchy.",
-  temperature: 1.0,
-  topK: 8,
+  samplingMode: "creative",
 });
 ```
 

--- a/apps/site/src/content/docs/packages/prompt.md
+++ b/apps/site/src/content/docs/packages/prompt.md
@@ -32,7 +32,7 @@ import { ask } from "@web-ai-sdk/prompt";
 const result = await ask({
   input: "Summarize this in one sentence: WebMCP lets web pages expose tools to agents.",
   systemPrompt: "You are concise. Reply with a single sentence.",
-  temperature: 0.2,
+  samplingMode: "predictable",
   onUpdate: (text) => console.log("partial", text), // cumulative buffer
 });
 
@@ -49,7 +49,7 @@ import { usePrompt } from "@web-ai-sdk/prompt/react";
 export function AskBox() {
   const { status, output, error, ask, abort } = usePrompt({
     systemPrompt: "You are a helpful assistant. Be concise.",
-    temperature: 0.7,
+    samplingMode: "balanced",
   });
 
   if (status === "unavailable") return null;
@@ -83,6 +83,7 @@ State machine: `idle | loading | streaming | done | unavailable`. `ask(input)` t
 interface AskOptions {
   input: string;
   systemPrompt?: string;
+  samplingMode?: "most-predictable" | "predictable" | "balanced" | "creative" | "most-creative";
   temperature?: number;
   topK?: number;
   language?: string;                        // BCP-47 hint, folded into expectedInputs/Outputs
@@ -121,8 +122,8 @@ Forwards to `LanguageModel.availability()`. Returns `null` if the global is miss
 
 Two layers, same as `@web-ai-sdk/summarizer`:
 
-- **Session cache** (internal, in-memory, always on): a `Map<stringifiedCreateOptions, LanguageModel>` so consecutive calls with the same shape (system prompt, temperature, topK, language hints) reuse the warm session. Cold-start ≈ 1-3s; warm calls are sub-second.
-- **Result cache** (opt-in): pass a `cache` (anything matching `{ get, set }`) to memoize final responses by `(prompt, systemPrompt, temperature, topK)`. Omit it for a fresh model call every time.
+- **Session cache** (internal, in-memory, always on): a `Map<stringifiedCreateOptions, LanguageModel>` so consecutive calls with the same shape (system prompt, sampling mode or raw sampling params, language hints) reuse the warm session. Cold-start ≈ 1-3s; warm calls are sub-second.
+- **Result cache** (opt-in): pass a `cache` (anything matching `{ get, set }`) to memoize final responses by `(prompt, systemPrompt, samplingMode / temperature / topK)`. Omit it for a fresh model call every time.
 
 ```ts
 // Off by default; every call hits the model.

--- a/apps/site/src/content/docs/react/use-prompt.mdx
+++ b/apps/site/src/content/docs/react/use-prompt.mdx
@@ -21,7 +21,7 @@ import { usePrompt } from "@web-ai-sdk/prompt/react";
 export function AskBox() {
   const { status, output, error, ask, abort } = usePrompt({
     systemPrompt: "You are a helpful assistant. Be concise.",
-    temperature: 0.7,
+    samplingMode: "balanced",
   });
 
   if (status === "unavailable") return null;
@@ -87,6 +87,7 @@ type PromptStatus = "idle" | "loading" | "streaming" | "done" | "unavailable";
 interface UsePromptOptions extends Omit<AskOptions, "input" | "onUpdate" | "signal"> {
   // Inherited from AskOptions (subset shown — see Prompt guide):
   systemPrompt?: string;
+  samplingMode?: "most-predictable" | "predictable" | "balanced" | "creative" | "most-creative";
   temperature?: number;
   topK?: number;
   language?: string;

--- a/apps/site/src/content/docs/react/use-session.mdx
+++ b/apps/site/src/content/docs/react/use-session.mdx
@@ -16,7 +16,7 @@ import { useState } from "react";
 export function Chat({ persona }: { persona: string }) {
   const { status, session } = useSession({
     systemPrompt: persona,
-    temperature: 0.7,
+    samplingMode: "balanced",
   });
 
   const [response, setResponse] = useState("");
@@ -63,10 +63,10 @@ function ChatList({ agents }: { agents: Agent[] }) {
 
 function ChatPane({ agent }: { agent: Agent }) {
   // Each ChatPane owns its own session. Streams don't queue against
-  // each other even when systemPrompt / temperature are identical.
+  // each other even when systemPrompt / samplingMode are identical.
   const { session } = useSession({
     systemPrompt: agent.systemPrompt,
-    temperature: agent.temperature,
+    samplingMode: agent.samplingMode,
   });
   // …
 }
@@ -110,7 +110,7 @@ The hook does not pre-detect creation errors that surface async. If `LanguageMod
 
 ## Recreating the session
 
-The hook recreates the underlying instance whenever a primitive option changes (`systemPrompt`, `temperature`, `topK`, `language`, `enabled`). Object options (`expectedInputs`, `expectedOutputs`, `createOptions`) participate in the dependency check by reference; memoize them or accept the recreate cost.
+The hook recreates the underlying instance whenever a primitive option changes (`systemPrompt`, `samplingMode`, `temperature`, `topK`, `language`, `enabled`). Object options (`expectedInputs`, `expectedOutputs`, `createOptions`) participate in the dependency check by reference; memoize them or accept the recreate cost.
 
 ```tsx
 const expected = useMemo<LanguageModelExpectedInput[]>(
@@ -154,6 +154,7 @@ interface UseSessionOptions extends CreateSessionOptions {
   enabled?: boolean;       // default: true; skip session creation when false
   // Inherited from CreateSessionOptions:
   systemPrompt?: string;
+  samplingMode?: "most-predictable" | "predictable" | "balanced" | "creative" | "most-creative";
   temperature?: number;
   topK?: number;
   language?: string;

--- a/apps/site/src/features/docs/components/PromptDemo.tsx
+++ b/apps/site/src/features/docs/components/PromptDemo.tsx
@@ -1,20 +1,23 @@
-import { usePrompt } from "@web-ai-sdk/prompt/react";
+import {
+  type LanguageModelSamplingMode,
+  usePrompt,
+} from "@web-ai-sdk/prompt/react";
 import { type ComponentProps, useState } from "react";
 import { UnavailableHint } from "./UnavailableHint.js";
 
 export interface PromptDemoProps {
   systemPrompt?: string;
-  temperature?: number;
+  samplingMode?: LanguageModelSamplingMode;
 }
 
 export const PromptDemo = ({
   systemPrompt = "You are a concise assistant. Reply with a single short paragraph.",
-  temperature = 0.7,
+  samplingMode = "balanced",
 }: PromptDemoProps) => {
   const [input, setInput] = useState("What is React.js, in one sentence?");
   const { status, output, error, fromCache, ask, abort, reset } = usePrompt({
     systemPrompt,
-    temperature,
+    samplingMode,
   });
 
   const onSubmit: ComponentProps<"form">["onSubmit"] = (e) => {

--- a/apps/site/src/features/home/components/PromptDemo.tsx
+++ b/apps/site/src/features/home/components/PromptDemo.tsx
@@ -42,7 +42,7 @@ export const PromptDemo = () => {
   const { progress, monitor } = useDownloadMonitor();
   const { status, output, ask, abort, reset } = usePrompt({
     systemPrompt: "You are concise. Reply briefly and avoid preamble.",
-    temperature: 0.7,
+    samplingMode: "balanced",
     monitor,
   });
 
@@ -77,7 +77,7 @@ export const PromptDemo = () => {
           <span className={streaming ? cardDotLive : cardDotOk} />
           ask() · streaming
         </span>
-        <span>session: cached · temp 0.7</span>
+        <span>session: cached · balanced</span>
       </div>
       <div className={cardBody}>
         {available === false && (

--- a/apps/site/src/features/home/components/WebMCPDemo.tsx
+++ b/apps/site/src/features/home/components/WebMCPDemo.tsx
@@ -263,7 +263,7 @@ Reply with ONLY valid JSON of the shape {"tool":"name_or_null","args":{},"reason
             "You are a tool-routing agent. Reply with valid JSON only. " +
             "Set tool to null when no registered tool fits the user intent; " +
             "don't force a call.",
-          temperature: 0.1,
+          samplingMode: "most-predictable",
           monitor,
         });
         const raw = result.output ?? "";

--- a/packages/prompt/README.md
+++ b/packages/prompt/README.md
@@ -27,7 +27,7 @@ import { ask } from "@web-ai-sdk/prompt";
 const result = await ask({
   input: "Summarize this in one sentence: WebMCP lets web pages expose tools to agents.",
   systemPrompt: "You are concise. Reply with a single sentence.",
-  temperature: 0.2,
+  samplingMode: "predictable",
   onUpdate: (text) => console.log("partial", text), // cumulative buffer
 });
 
@@ -43,7 +43,7 @@ import { createSession } from "@web-ai-sdk/prompt";
 
 const session = createSession({
   systemPrompt: "You are a helpful assistant.",
-  temperature: 0.7,
+  samplingMode: "balanced",
 });
 
 // Streaming, yields DELTA chunks (not cumulative buffers):
@@ -72,7 +72,7 @@ import { usePrompt } from "@web-ai-sdk/prompt/react";
 export function AskBox() {
   const { status, output, error, ask, abort } = usePrompt({
     systemPrompt: "You are a helpful assistant. Be concise.",
-    temperature: 0.7,
+    samplingMode: "balanced",
   });
 
   if (status === "unavailable") return null;
@@ -139,7 +139,10 @@ export function Chat({ persona }: { persona: string }) {
 interface AskOptions {
   input: string;
   systemPrompt?: string;
+  samplingMode?: "most-predictable" | "predictable" | "balanced" | "creative" | "most-creative";
+  /** @deprecated Web page contexts are moving to samplingMode. */
   temperature?: number;
+  /** @deprecated Web page contexts are moving to samplingMode. */
   topK?: number;
   language?: string;                        // BCP-47 hint, folded into expectedInputs/Outputs
   supportedLanguages?: readonly string[];   // default ["en"]
@@ -169,7 +172,10 @@ If `systemPrompt` is passed alongside `createOptions.initialPrompts`, the SDK em
 ```ts
 interface CreateSessionOptions {
   systemPrompt?: string;
+  samplingMode?: "most-predictable" | "predictable" | "balanced" | "creative" | "most-creative";
+  /** @deprecated Web page contexts are moving to samplingMode. */
   temperature?: number;
+  /** @deprecated Web page contexts are moving to samplingMode. */
   topK?: number;
   language?: string;
   supportedLanguages?: readonly string[];
@@ -295,7 +301,7 @@ interface UseSessionReturn {
 }
 ```
 
-Lifecycle-only: feature detection + create + destroy on unmount + recreate when any primitive option (`systemPrompt`, `temperature`, `topK`, `language`) changes. Object options (`expectedInputs`, `createOptions`) participate by reference; memoize them or accept the recreate cost. UI state is your concern — iterate `session.sendStreaming()` and accumulate text into your own component state.
+Lifecycle-only: feature detection + create + destroy on unmount + recreate when any primitive option (`systemPrompt`, `samplingMode`, `temperature`, `topK`, `language`) changes. Object options (`expectedInputs`, `createOptions`) participate by reference; memoize them or accept the recreate cost. UI state is your concern — iterate `session.sendStreaming()` and accumulate text into your own component state.
 
 ### `isAvailable(): boolean`
 
@@ -326,7 +332,7 @@ The internal session cache is LRU-bounded (default 8) and only memoizes sessions
 Two layers, same as `@web-ai-sdk/summarizer`:
 
 - **Session cache** (internal, in-memory, on by default for `ask()` only): a bounded LRU of `LanguageModel` instances keyed by stringified create-options. Cold-start ≈ 1-3s; warm calls are sub-second. `createSession()` bypasses this cache entirely.
-- **Result cache** (opt-in): pass a `cache` (anything matching `{ get, set }`) to memoize final responses by `(input, systemPrompt, temperature, topK)`. Omit it for a fresh model call every time.
+- **Result cache** (opt-in): pass a `cache` (anything matching `{ get, set }`) to memoize final responses by `(input, systemPrompt, samplingMode / temperature / topK)`. Omit it for a fresh model call every time.
 
 ```ts
 // Off by default; every call hits the model.

--- a/packages/prompt/src/api.ts
+++ b/packages/prompt/src/api.ts
@@ -51,9 +51,23 @@ export interface CreateMonitor {
   ): void;
 }
 
+export type LanguageModelSamplingMode =
+  | "most-predictable"
+  | "predictable"
+  | "balanced"
+  | "creative"
+  | "most-creative";
+
 export interface LanguageModelCreateOptions {
   initialPrompts?: LanguageModelMessage[];
+  /**
+   * Semantic sampling preset. Mutually exclusive with `temperature` / `topK`
+   * where browsers still expose those legacy raw parameters.
+   */
+  samplingMode?: LanguageModelSamplingMode;
+  /** @deprecated Web page contexts are moving to `samplingMode`. */
   temperature?: number;
+  /** @deprecated Web page contexts are moving to `samplingMode`. */
   topK?: number;
   expectedInputs?: LanguageModelExpectedInput[];
   expectedOutputs?: LanguageModelExpectedOutput[];
@@ -135,9 +149,13 @@ export type LanguageModelAvailability =
   | "available";
 
 export interface LanguageModelParams {
+  /** @deprecated Web page contexts are moving to `samplingMode`. */
   defaultTemperature: number;
+  /** @deprecated Web page contexts are moving to `samplingMode`. */
   maxTemperature: number;
+  /** @deprecated Web page contexts are moving to `samplingMode`. */
   defaultTopK: number;
+  /** @deprecated Web page contexts are moving to `samplingMode`. */
   maxTopK: number;
 }
 

--- a/packages/prompt/src/cache.ts
+++ b/packages/prompt/src/cache.ts
@@ -5,8 +5,9 @@
  * renders.
  *
  * Prompt cache keys hash the inputs that affect the model output
- * (prompt + systemPrompt + temperature + topK). Pass an explicit `cacheKey`
- * to `ask()` if you want a more stable key (e.g. per-feature shorthand).
+ * (prompt + systemPrompt + samplingMode / temperature / topK). Pass an
+ * explicit `cacheKey` to `ask()` if you want a more stable key (e.g.
+ * per-feature shorthand).
  */
 
 export interface ResponseCache {
@@ -78,6 +79,7 @@ export const resolveCache = (
 export interface DefaultCacheKeyInput {
   prompt: string;
   systemPrompt?: string;
+  samplingMode?: string;
   temperature?: number;
   topK?: number;
 }
@@ -87,10 +89,13 @@ export interface DefaultCacheKeyInput {
  * stringification keeps it collision-free without pulling in a hashing
  * dependency. Pass a custom `cacheKey` to `ask()` for shorter / sticky keys.
  */
-export const defaultCacheKey = (input: DefaultCacheKeyInput): string =>
-  JSON.stringify([
+export const defaultCacheKey = (input: DefaultCacheKeyInput): string => {
+  const parts: unknown[] = [
     input.prompt,
     input.systemPrompt ?? "",
     input.temperature ?? null,
     input.topK ?? null,
-  ]);
+  ];
+  if (input.samplingMode !== undefined) parts.push(input.samplingMode);
+  return JSON.stringify(parts);
+};

--- a/packages/prompt/src/cache.ts
+++ b/packages/prompt/src/cache.ts
@@ -10,6 +10,8 @@
  * per-feature shorthand).
  */
 
+import type { LanguageModelSamplingMode } from "./api.js";
+
 export interface ResponseCache {
   get(key: string): string | null;
   set(key: string, value: string): void;
@@ -79,7 +81,7 @@ export const resolveCache = (
 export interface DefaultCacheKeyInput {
   prompt: string;
   systemPrompt?: string;
-  samplingMode?: string;
+  samplingMode?: LanguageModelSamplingMode;
   temperature?: number;
   topK?: number;
 }

--- a/packages/prompt/src/index.test.ts
+++ b/packages/prompt/src/index.test.ts
@@ -213,6 +213,37 @@ describe("ask", () => {
     expect(createOpts).toMatchObject({ temperature: 0.2, topK: 5 });
   });
 
+  it("forwards samplingMode when provided", async () => {
+    const fake = installFakeLanguageModel();
+    await ask({
+      input: "ping",
+      samplingMode: "creative",
+      cache: inMemoryCache(),
+    });
+    const createOpts = fake.create.mock.calls[0]?.[0];
+    expect(createOpts).toMatchObject({ samplingMode: "creative" });
+  });
+
+  it("rejects mixed samplingMode and raw sampling parameters", async () => {
+    installFakeLanguageModel();
+    await expect(
+      ask({
+        input: "ping",
+        samplingMode: "balanced",
+        temperature: 0.2,
+        cache: inMemoryCache(),
+      }),
+    ).rejects.toThrow(TypeError);
+    await expect(
+      ask({
+        input: "ping",
+        samplingMode: "balanced",
+        topK: 5,
+        cache: inMemoryCache(),
+      }),
+    ).rejects.toThrow(TypeError);
+  });
+
   it("forwards tools to LanguageModel.create() without executing them", async () => {
     const fake = installFakeLanguageModel({ response: "ok" });
     const execute = vi.fn(async () => "tool result");
@@ -397,6 +428,42 @@ describe("createSession", () => {
     expect(createOpts).toMatchObject({ tools });
     expect(execute).not.toHaveBeenCalled();
     session.destroy();
+  });
+
+  it("forwards samplingMode to the underlying LanguageModel.create()", async () => {
+    const fake = installFakeLanguageModel({ response: "ok" });
+    const session = createSession({
+      systemPrompt: "S",
+      samplingMode: "most-predictable",
+    });
+    await session.send("warm");
+    const createOpts = fake.create.mock.calls[0]?.[0];
+    expect(createOpts).toMatchObject({
+      samplingMode: "most-predictable",
+    });
+    session.destroy();
+  });
+
+  it("rejects createSession options that mix semantic and raw sampling", () => {
+    installFakeLanguageModel({ response: "ok" });
+    expect(() =>
+      createSession({
+        samplingMode: "creative",
+        temperature: 0.8,
+      }),
+    ).toThrow(TypeError);
+    expect(() =>
+      createSession({
+        samplingMode: "creative",
+        createOptions: { topK: 8 },
+      }),
+    ).toThrow(TypeError);
+    expect(() =>
+      createSession({
+        topK: 8,
+        createOptions: { samplingMode: "creative" },
+      }),
+    ).toThrow(TypeError);
   });
 
   it("does not set a tools key when none are passed", async () => {

--- a/packages/prompt/src/index.ts
+++ b/packages/prompt/src/index.ts
@@ -23,6 +23,7 @@ import {
   type LanguageModelMessage,
   type LanguageModelParams,
   type LanguageModelPromptOptions,
+  type LanguageModelSamplingMode,
   type LanguageModelTool,
 } from "./api.js";
 import {
@@ -33,6 +34,7 @@ import {
   resolveCache,
 } from "./cache.js";
 import {
+  assertValidSamplingOptions,
   buildLangHints,
   type CreateSessionOptions,
   createSession,
@@ -58,6 +60,7 @@ export type {
   LanguageModelInstance,
   LanguageModelMessage,
   LanguageModelParams,
+  LanguageModelSamplingMode,
   LanguageModelTool,
   ResponseCache,
   Session,
@@ -77,9 +80,11 @@ export interface AskOptions {
   input: string;
   /** Optional system prompt (folded into `initialPrompts` as a `system` role). */
   systemPrompt?: string;
-  /** Sampling temperature (0..1). Defaults to the model's default. */
+  /** Semantic sampling preset. Defaults to the model's default. */
+  samplingMode?: LanguageModelSamplingMode;
+  /** @deprecated Web page contexts are moving to `samplingMode`. */
   temperature?: number;
-  /** Sampling top-k. Defaults to the model's default. */
+  /** @deprecated Web page contexts are moving to `samplingMode`. */
   topK?: number;
   /** BCP-47 language hint. Folded into `expectedInputs` / `expectedOutputs` when supported. */
   language?: string;
@@ -117,7 +122,7 @@ export interface AskOptions {
    * `{ get, set }`-shaped object for a custom backend.
    */
   cache?: CacheOption;
-  /** Cache key. Default: hash of `{ input, systemPrompt, temperature, topK }`. */
+  /** Cache key. Default: hash of `{ input, systemPrompt, samplingMode, temperature, topK }`. */
   cacheKey?: string;
   /**
    * Streaming update callback. Receives the **cumulative** buffer (full text so
@@ -158,12 +163,15 @@ export const ask = async (options: AskOptions): Promise<AskResult> => {
     return { output: null, cached: false };
   }
 
+  assertValidSamplingOptions(options);
+
   const cache = resolveCache(options.cache);
   const cacheKey =
     options.cacheKey ??
     defaultCacheKey({
       prompt: options.input,
       systemPrompt: options.systemPrompt,
+      samplingMode: options.samplingMode,
       temperature: options.temperature,
       topK: options.topK,
     });
@@ -182,6 +190,9 @@ export const ask = async (options: AskOptions): Promise<AskResult> => {
 
   const baseCreateOptions: LanguageModelCreateOptions = {
     ...(initialPrompts.length > 0 ? { initialPrompts } : {}),
+    ...(options.samplingMode !== undefined
+      ? { samplingMode: options.samplingMode }
+      : {}),
     ...(options.temperature !== undefined
       ? { temperature: options.temperature }
       : {}),

--- a/packages/prompt/src/react/index.test.tsx
+++ b/packages/prompt/src/react/index.test.tsx
@@ -195,4 +195,17 @@ describe("useSession", () => {
     rerender({ p: "B" });
     expect(api.create).toHaveBeenCalledTimes(2);
   });
+
+  it("recreates the session when samplingMode changes", () => {
+    const api = installFakeLanguageModel();
+    type SamplingModeProps = { samplingMode: "predictable" | "creative" };
+    const initialProps: SamplingModeProps = { samplingMode: "predictable" };
+    const { rerender } = renderHook(
+      ({ samplingMode }: SamplingModeProps) => useSession({ samplingMode }),
+      { initialProps },
+    );
+    expect(api.create).toHaveBeenCalledTimes(1);
+    rerender({ samplingMode: "creative" });
+    expect(api.create).toHaveBeenCalledTimes(2);
+  });
 });

--- a/packages/prompt/src/react/index.ts
+++ b/packages/prompt/src/react/index.ts
@@ -151,8 +151,8 @@ export interface UseSessionReturn {
  * underlying `LanguageModel` session with its own history, system prompt,
  * sampling, and lifecycle — `abort()` / `destroy()` on one component's
  * session never touch another's — and the session is destroyed on unmount
- * or when any primitive option (`systemPrompt`, `temperature`, `topK`,
- * `language`, `enabled`) changes.
+ * or when any primitive option (`systemPrompt`, `samplingMode`,
+ * `temperature`, `topK`, `language`, `enabled`) changes.
  *
  * Token-level interleaving across sessions is browser-defined: the
  * underlying on-device model is single-instance, so Chrome 148 / Edge 138
@@ -175,6 +175,7 @@ export const useSession = (
   const {
     enabled = true,
     systemPrompt,
+    samplingMode,
     temperature,
     topK,
     language,
@@ -205,6 +206,7 @@ export const useSession = (
     try {
       session = createSession({
         systemPrompt,
+        samplingMode,
         temperature,
         topK,
         language,
@@ -234,6 +236,7 @@ export const useSession = (
   }, [
     enabled,
     systemPrompt,
+    samplingMode,
     temperature,
     topK,
     language,
@@ -252,6 +255,7 @@ export type {
   AskResult,
   CacheOption,
   CreateSessionOptions,
+  LanguageModelSamplingMode,
   LanguageModelTool,
   ResponseCache,
   Session,

--- a/packages/prompt/src/session.ts
+++ b/packages/prompt/src/session.ts
@@ -27,6 +27,7 @@ import {
   type LanguageModelExpectedOutput,
   type LanguageModelInstance,
   type LanguageModelPromptOptions,
+  type LanguageModelSamplingMode,
   type LanguageModelTool,
 } from "./api.js";
 
@@ -133,12 +134,35 @@ export const mergeStreamChunk = (
   return { buffer: buffer + chunk, delta: chunk };
 };
 
+export const assertValidSamplingOptions = (options: {
+  samplingMode?: LanguageModelSamplingMode;
+  temperature?: number;
+  topK?: number;
+  createOptions?: Partial<LanguageModelCreateOptions>;
+}): void => {
+  const samplingMode =
+    options.samplingMode ?? options.createOptions?.samplingMode;
+  const hasTemperature =
+    options.temperature !== undefined ||
+    options.createOptions?.temperature !== undefined;
+  const hasTopK =
+    options.topK !== undefined || options.createOptions?.topK !== undefined;
+
+  if (samplingMode !== undefined && (hasTemperature || hasTopK)) {
+    throw new TypeError(
+      "`samplingMode` is mutually exclusive with `temperature` and `topK`.",
+    );
+  }
+};
+
 export interface CreateSessionOptions {
   /** Optional system prompt (folded into `initialPrompts` as a `system` role). */
   systemPrompt?: string;
-  /** Sampling temperature (0..1). Defaults to the model's default. */
+  /** Semantic sampling preset. Defaults to the model's default. */
+  samplingMode?: LanguageModelSamplingMode;
+  /** @deprecated Web page contexts are moving to `samplingMode`. */
   temperature?: number;
-  /** Sampling top-k. Defaults to the model's default. */
+  /** @deprecated Web page contexts are moving to `samplingMode`. */
   topK?: number;
   /** BCP-47 language hint. Folded into `expectedInputs` / `expectedOutputs` when supported. */
   language?: string;
@@ -240,6 +264,7 @@ export interface Session {
 const buildCreateOptions = (
   options: CreateSessionOptions,
 ): LanguageModelCreateOptions => {
+  assertValidSamplingOptions(options);
   const initialPrompts = options.systemPrompt
     ? [{ role: "system" as const, content: options.systemPrompt }]
     : [];
@@ -249,6 +274,9 @@ const buildCreateOptions = (
   );
   return {
     ...(initialPrompts.length > 0 ? { initialPrompts } : {}),
+    ...(options.samplingMode !== undefined
+      ? { samplingMode: options.samplingMode }
+      : {}),
     ...(options.temperature !== undefined
       ? { temperature: options.temperature }
       : {}),


### PR DESCRIPTION
## Summary

- Add `samplingMode` support to `@web-ai-sdk/prompt` and its React adapter types.
- Forward `samplingMode` to `LanguageModel.create()` and reject mixed `samplingMode` + raw `temperature` / `topK` usage.
- Update Prompt docs and demos to prefer semantic sampling presets while keeping raw params as deprecated legacy passthroughs.
- Add a minor changeset for `@web-ai-sdk/prompt` and `@web-ai-sdk/all`.

## Validation

- `pnpm gate`
- Chrome DevTools MCP smoke test against `localhost:4173`:
  - Prompt guide renders `samplingMode` examples.
  - `usePrompt` demo forwards `samplingMode: "balanced"` to `LanguageModel.create()`.
  - Direct SDK call omits sampling options when none are provided.
  - Mixed `samplingMode` + `temperature` throws `TypeError`.
