### PR TITLE
fix(react): treat empty results as done, not unavailable

### DIFF
--- a/.changeset/react-empty-result-status.md
+++ b/.changeset/react-empty-result-status.md
@@ -1,0 +1,7 @@
+---
+"@web-ai-sdk/summarizer": patch
+"@web-ai-sdk/writer": patch
+"@web-ai-sdk/rewriter": patch
+---
+
+Fix `useSummarizer` / `useWriter` / `useRewriter` treating a successful empty or `null` result as "unavailable": a resolved call now resolves to status `"done"`, matching `useProofreader` / `useDetector`. Previously a legitimately empty output (no-op rewrite, same-language skip, or safety soft-block trimmed to empty) silently set the hook to an unavailable state with `error` left `null`.

--- a/packages/rewriter/src/react/index.test.tsx
+++ b/packages/rewriter/src/react/index.test.tsx
@@ -57,6 +57,17 @@ describe("useRewriter", () => {
     expect(result.current.error).toBeNull();
   });
 
+  it("sets status to done, not unavailable, when the result is empty", async () => {
+    installFakeRewriter({ output: "" });
+    const { result } = renderHook(() =>
+      useRewriter({ input: "A long sentence.", length: "shorter" }),
+    );
+
+    await waitFor(() => expect(result.current.status).toBe("done"));
+    expect(result.current.output).toBeNull();
+    expect(result.current.error).toBeNull();
+  });
+
   it("re-runs when input changes", async () => {
     const api = installFakeRewriter({ output: "ok" });
     const { result, rerender } = renderHook(

--- a/packages/rewriter/src/react/index.ts
+++ b/packages/rewriter/src/react/index.ts
@@ -95,10 +95,6 @@ export const useRewriter = (options: UseRewriterOptions): UseRewriterReturn => {
     })
       .then((result) => {
         if (controller.signal.aborted) return;
-        if (!result.output) {
-          setStatus("unavailable");
-          return;
-        }
         setOutput(result.output);
         setFromCache(result.cached);
         setStatus("done");

--- a/packages/summarizer/src/react/index.test.tsx
+++ b/packages/summarizer/src/react/index.test.tsx
@@ -69,6 +69,18 @@ describe("useSummarizer", () => {
     expect(result.current.output).toBe("Result.");
   });
 
+  it("sets status to done, not unavailable, when the result is empty", async () => {
+    installFakeSummarizer({ summary: "" });
+    const cache = inMemoryCache();
+    const { result } = renderHook(() =>
+      useSummarizer({ language: "en", input: "body", cache, cacheKey: "k" }),
+    );
+
+    await waitFor(() => expect(result.current.status).toBe("done"));
+    expect(result.current.output).toBeNull();
+    expect(result.current.error).toBeNull();
+  });
+
   it("streams chunks to the consumer", async () => {
     installFakeSummarizer({ chunks: ["Hel", "lo", "."] });
     const cache = inMemoryCache();

--- a/packages/summarizer/src/react/index.ts
+++ b/packages/summarizer/src/react/index.ts
@@ -97,10 +97,6 @@ export const useSummarizer = (
     })
       .then((result) => {
         if (controller.signal.aborted) return;
-        if (!result.output) {
-          setStatus("unavailable");
-          return;
-        }
         setOutput(result.output);
         setFromCache(result.cached);
         setStatus("done");

--- a/packages/writer/src/react/index.test.tsx
+++ b/packages/writer/src/react/index.test.tsx
@@ -57,6 +57,17 @@ describe("useWriter", () => {
     expect(result.current.error).toBeNull();
   });
 
+  it("sets status to done, not unavailable, when the result is empty", async () => {
+    installFakeWriter({ output: "" });
+    const { result } = renderHook(() =>
+      useWriter({ input: "Draft an email." }),
+    );
+
+    await waitFor(() => expect(result.current.status).toBe("done"));
+    expect(result.current.output).toBeNull();
+    expect(result.current.error).toBeNull();
+  });
+
   it("re-runs when input changes", async () => {
     const api = installFakeWriter({ output: "ok" });
     const { result, rerender } = renderHook(

--- a/packages/writer/src/react/index.ts
+++ b/packages/writer/src/react/index.ts
@@ -95,10 +95,6 @@ export const useWriter = (options: UseWriterOptions): UseWriterReturn => {
     })
       .then((result) => {
         if (controller.signal.aborted) return;
-        if (!result.output) {
-          setStatus("unavailable");
-          return;
-        }
         setOutput(result.output);
         setFromCache(result.cached);
         setStatus("done");


### PR DESCRIPTION
## Summary

`useSummarizer`, `useWriter`, and `useRewriter` treated a **successful call
that returned empty/`null` output** as if the API were missing: they called
`setStatus("unavailable")`. A healthy model that legitimately produces no text
(no-op rewrite, same-language skip, or safety soft-block trimming to empty)
became indistinguishable in hook state from "browser doesn't support this API,"
while `error` stayed `null` — a silent, wrong failure mode that drove consumer
UI into an unsupported state.

This aligns the three hooks with the already-correct `useProofreader` /
`useDetector`, which set `"done"` on any resolved promise and route genuine
unavailability through the `.catch` handler (checking the `*UnavailableError`
class).

## Changes
- Removed the `if (!result.output) { setStatus("unavailable") }` branch from the
  `.then` of `useSummarizer`, `useWriter`, `useRewriter`; a resolved promise now
  sets `"done"` unconditionally.
- `.catch` blocks (`*UnavailableError` handling) are unchanged.
- Added one regression test per hook: a resolved call returning empty output
  asserts `status === "done"`, `output === null`, `error === null`.
- Includes a changeset (patch on the three published packages) so the fix ships
  in a release.

## Verification
- `pnpm gate` exits 0 (lint, build, typecheck, test all green).
- Scope: only the 3 hooks + 3 test files touched.
