### PR TITLE
docs(agents): allow in-tree worktrees for parallel work

### DIFF
--- a/.agents/agents.md
+++ b/.agents/agents.md
@@ -279,14 +279,22 @@ Or in one shot: `pnpm gate`.
 - Always confirm PR title and description before opening a PR; show them to me for approval first.
 - Never run `git commit --amend` without explicit approval.
 
-## 11. Work in-tree
+## 11. Work in-tree, isolate in-tree
 
-All edits and commits must happen **in this working tree**, never in an out-of-tree git worktree. The repo is bound to this directory by editors and git GUIs (e.g. openChamber); a worktree under `$TMPDIR` is invisible to them, so work done there disappears from view.
+The goal: every change stays visible to the tools bound to this repo — editors, git GUIs, and the coding agent itself. **Isolation is fine; invisibility is not.**
 
-This applies to **any** agent, skill, GUI, or automation touching this repo — regardless of whether it defaults to worktree isolation. When a tool's default is to isolate via a worktree, that default is overridden here.
+This applies to **any** agent, skill, GUI, or automation touching this repo — regardless of its default isolation behaviour.
 
-- Do **not** create or dispatch into a separate worktree. Do **not** run `git worktree add`.
-- Start from a clean working tree. If uncommitted changes are present, stop and ask me to commit or stash before beginning work.
-- Before editing, create and check out a dedicated branch from HEAD (e.g. `<type>/<scope>-<slug>`). All edits and commits land on that branch.
-- Never merge, push, or commit to `main` directly — leave the branch for me to review and merge.
-- Review the branch in-tree (`git diff --stat main..<branch>`, re-run any acceptance criteria).
+- **Default to the main working tree.** Most tasks edit the checked-out tree on a dedicated branch. That's the baseline.
+- **Worktrees are allowed for parallel work** — they're how you work on multiple branches at once — but they must stay *in-tree*:
+  - Create them **inside the repo path** under `.worktrees/<branch>/` (gitignored), **never** under `$TMPDIR` or any out-of-repo scratch location. Note: `.git/worktrees/` is git's internal metadata store, not a working-tree location — never put code there.
+  - Use `git worktree add -b <branch> .worktrees/<branch>`; remove with `git worktree remove .worktrees/<branch>` (clean trees only; `--force` otherwise). Never `rm -rf` a worktree — if you do, run `git worktree prune`. Move with `git worktree move`, not manual `mv`.
+  - Each worktree is an independent checkout needing its own `pnpm install`.
+  - Prefer the coding agent's built-in isolation/worktree tooling when it has one; only fall back to raw `git worktree add` with an in-repo path. If a skill's default is to isolate under a temp dir, override it to `.worktrees/`. If the host can only isolate out-of-tree and can't be redirected, hand the plan back for manual in-tree execution rather than work invisibly.
+  - When searching (`glob`/`grep`), scope to `packages/` and `apps/` — don't recurse into `.worktrees/` or results will be duplicated.
+- **Start from a clean working tree.** If uncommitted changes are present, stop and ask me to commit or stash before beginning work.
+- **Before editing, create and check out a dedicated branch** from HEAD (e.g. `<type>/<scope>-<slug>`). All edits and commits land on that branch — whether in the main tree or a worktree.
+- **Never merge, push, or commit to `main` directly** — leave the branch for me to review and merge.
+- **Review branches in-tree** (`git diff --stat main..<branch>`, re-run any acceptance criteria). Remove a worktree only after its branch merges — never to abandon uncommitted work.
+
+The test this section enforces: if the editor/workspace bound to this directory can't see the files (because they're under `$TMPDIR` or a random scratch path), that's the failure mode. Keep work where the tools already are.

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,8 @@ coverage/
 storybook-static/
 _site/
 .astro/
+# In-tree git worktrees for parallel branch work (see .agents/agents.md §11).
+.worktrees/
 
 *.log
 .DS_Store

--- a/biome.json
+++ b/biome.json
@@ -11,7 +11,8 @@
       "!**/*.d.ts",
       "!**/storybook-static",
       "!**/.astro",
-      "!**/_site"
+      "!**/_site",
+      "!**/.worktrees"
     ]
   },
   "linter": {


### PR DESCRIPTION
## What

Rewrites §11 of `.agents/agents.md` from a blanket worktree **ban** to an **allow-but-stay-integrated** policy, plus the supporting config so in-repo worktrees don't collide with tooling.

## Why

§11 forbade worktrees entirely (`Do not run git worktree add`) to stop work disappearing under `$TMPDIR` where editors/GUIs bound to this directory couldn't see it. But that sacrificed the one real benefit of worktrees — working on multiple branches at once (branches alone serialize you, since one working tree = one checked-out branch). The actual failure mode was *invisibility*, not isolation.

The new policy keeps the protection (work stays visible to bound tools) while enabling parallel branch work: worktrees are allowed **inside** the repo under `.worktrees/<branch>/`, never out-of-tree.

## Changes

- **`.agents/agents.md`** — §11 "Work in-tree" → "Work in-tree, isolate in-tree":
  - Worktrees allowed under `.worktrees/<branch>/` (gitignored); `$TMPDIR`/scratch paths still banned.
  - Notes `.git/worktrees/` is git's internal metadata store, not a working-tree location.
  - Lifecycle guidance: `git worktree add -b`, `remove` (clean only / `--force`), never `rm -rf` (use `prune`), `move` not manual `mv`.
  - Each worktree needs its own `pnpm install`.
  - Routes isolation through the coding agent's native tooling when available; falls back to hand-off if a host can only isolate out-of-tree.
  - Instructs glob/grep to scope to `packages/` + `apps/` to avoid duplicate results.
  - Keeps the existing guardrails: clean-tree start, dedicated branch, never commit/push to `main`, in-tree review.
- **`.gitignore`** — ignore `.worktrees/`.
- **`biome.json`** — add `!**/.worktrees` exclude (its `**/packages/**` includes would otherwise lint worktree copies).

## Verification

`pnpm gate` green (lint + build + typecheck + test across all packages).
