### PR TITLE
chore(repo): bump pnpm to v10 and move overrides to workspace config

### DIFF
--- a/.agents/agents.md
+++ b/.agents/agents.md
@@ -46,7 +46,7 @@ Full rules in [`CONTRIBUTING.md` § Governance](../CONTRIBUTING.md#governance); 
 ## 2. Stack & runtime
 
 - **TypeScript** strict, ESM (`"type": "module"`), `verbatimModuleSyntax`.
-- **pnpm 9** workspaces (declared in `pnpm-workspace.yaml`).
+- **pnpm 10** workspaces (declared in `pnpm-workspace.yaml`).
 - **tsup** for builds; emits ESM + CJS + `.d.ts` from `src/index.ts` and `src/react/index.ts`.
 - **Vitest + happy-dom** for tests.
 - **Biome** for lint + format (one tool, scoped to `packages/**` and `apps/**` `.ts`/`.tsx`). No ESLint, no Prettier.
@@ -87,7 +87,7 @@ Full rules in [`CONTRIBUTING.md` § Governance](../CONTRIBUTING.md#governance); 
 ├── .github/workflows/            # CI gate + release + Pages deploy
 ├── .nvmrc                        # pins Node 24 for local dev
 ├── biome.json                    # lint + format
-├── package.json                  # workspace root + every pnpm script (incl. "packageManager" → pnpm 9.15.0)
+├── package.json                  # workspace root + every pnpm script (incl. "packageManager" → pnpm@10.34.3)
 ├── pnpm-workspace.yaml
 ├── tsconfig.base.json            # shared compiler options
 ├── README.md                     # human onboarding entry point

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "url": "https://github.com/obetomuniz/web-ai-sdk/issues"
   },
   "type": "module",
-  "packageManager": "pnpm@9.15.0",
+  "packageManager": "pnpm@10.34.3",
   "engines": {
     "node": ">=22.12.0"
   },
@@ -61,13 +61,5 @@
     "@changesets/cli": "^2.27.10",
     "serve": "14.2.6",
     "typescript": "^6.0.3"
-  },
-  "pnpm": {
-    "overrides": {
-      "yaml@<2.8.3": ">=2.8.3 <3.0.0",
-      "js-yaml@<=4.1.1": "4.2.0",
-      "read-yaml-file>js-yaml": "3.14.2",
-      "esbuild": "0.28.1"
-    }
   }
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,13 @@
 packages:
   - "packages/*"
   - "apps/*"
+
+overrides:
+  yaml@<2.8.3: ">=2.8.3 <3.0.0"
+  js-yaml@<=4.1.1: "4.2.0"
+  read-yaml-file>js-yaml: 3.14.2
+  esbuild: 0.28.1
+
+onlyBuiltDependencies:
+  - esbuild
+  - sharp


### PR DESCRIPTION
## Summary

Bumps `packageManager` to `pnpm@10.34.3` and moves the four security-pin overrides (`yaml`, `js-yaml`, `read-yaml-file>js-yaml`, `esbuild`) from the ignored `package.json#pnpm.overrides` field into `pnpm-workspace.yaml`, the location pnpm 10 actually enforces.

- `package.json`: pin `pnpm@10.34.3`; drop the dead `pnpm` object (clears the ignored-field warning).
- `pnpm-workspace.yaml`: add the `overrides` block plus `onlyBuiltDependencies` (`esbuild`, `sharp`) so pnpm 10's build-script allowlisting keeps the toolchain working on fresh installs.
- `.agents/agents.md`: sync §2 "Stack & runtime" and the folder-map comment to pnpm 10.

## Why

On the pinned `pnpm@9.15.0` the security pins were **silently dead**: the manifest `pnpm.overrides` field is no longer read by pnpm, and workspace-config overrides aren't honored until pnpm 10. The pinned versions surviving in the lockfile were fossils from an earlier pnpm — any future re-resolution would have wiped them, leaving the `yaml`/`js-yaml`/`esbuild` advisories unmitigated. pnpm 10 enforces workspace-config overrides, so the pins are real again.

## Testing

- `pnpm --version` → `10.34.3`, no ignored-config warning.
- `pnpm install --frozen-lockfile` → exit 0; `pnpm-lock.yaml` unchanged (existing resolutions already matched the override targets; pnpm 10 now validates them as enforced).
- Overrides enforced, confirmed via lockfile: `esbuild@0.28.1`, `yaml@2.9.0` (≥2.8.3), `js-yaml@4.2.0` + `3.14.2`.
- `onlyBuiltDependencies` list verified against actual build scripts: `esbuild` (postinstall), `sharp` (install); `@biomejs/biome` correctly excluded (no scripts, ships platform binaries via optionalDependencies).
- `pnpm gate` → exit 0 (lint + docs:check + build + typecheck + test, 276 tests green).
- `pnpm audit --prod --audit-level high` → no known vulnerabilities.
- CI needs no workflow edit — `pnpm/action-setup@v6` reads `packageManager`.