### PR TITLE
feat(prompt): add Session.append() for context without a turn

### DIFF
--- a/.changeset/prompt-session-append.md
+++ b/.changeset/prompt-session-append.md
@@ -1,0 +1,5 @@
+---
+"@web-ai-sdk/prompt": minor
+---
+
+Add `Session.append()`: push messages into a session's conversation history without running a model turn, for agent loops that need to inject tool results or other context between turns. Forwards to the native `LanguageModel.append()`; throws `PromptUnavailableError` when unsupported, `SessionDestroyedError` after destroy, and `PromptAbortError` on abort, consistent with `send()` / `clone()`.

--- a/apps/site/src/content/docs/guides/prompt.mdx
+++ b/apps/site/src/content/docs/guides/prompt.mdx
@@ -128,6 +128,24 @@ try {
 
 `clone()` throws `SessionDestroyedError` if the base has been destroyed, and `PromptUnavailableError` if the underlying browser instance doesn't support cloning. The clone is fully independent: destroying it never affects the base, and vice versa. The React `useSession` hook returns the `Session` directly, so `session.clone()` is available there too.
 
+## Injecting context without a turn — `Session.append()`
+
+Agent loops often need to push tool results or other context into history **without** triggering a model turn. Faking this with an extra `send()` wastes tokens and latency on an empty intermediate response. `session.append()` forwards to the native `LanguageModel.append()`: the messages land in history, and the next `send` / `sendStreaming` sees them as prior turns.
+
+```ts
+const session = createSession({ systemPrompt });
+await session.send("What's the weather in Tokyo?");
+// The model asked to call a tool; run it yourself, then inject the result:
+await session.append([
+  { role: "assistant", content: "I'll check the weather." },
+  { role: "user", content: "tool result: 24°C, clear" },
+]);
+// The next turn sees the tool result as history — no wasted intermediate turn.
+const plan = await session.send("Based on that, suggest an outfit.");
+```
+
+`append()` throws `SessionDestroyedError` if the session is destroyed and `PromptUnavailableError` if the browser instance doesn't support `append()`. Aborts reject with `PromptAbortError`.
+
 ## Context-window introspection
 
 `Session` surfaces the live token budget the native instance reports, so consumers can size work to the real context window instead of hardcoding a char cap (the exact bypass — reaching past the SDK to `globalThis.LanguageModel` — that this avoids):

--- a/apps/site/src/content/docs/packages/prompt.md
+++ b/apps/site/src/content/docs/packages/prompt.md
@@ -208,6 +208,7 @@ interface Session {
   sendStreaming(input: string, options?: SessionSendOptions): AsyncIterable<string>;
   abort(): void;
   clone(options?: { signal?: AbortSignal }): Promise<Session>;
+  append(messages: LanguageModelMessage[], options?: { signal?: AbortSignal }): Promise<void>; // context without a turn
   onContextOverflow(listener: () => void): () => void; // returns an idempotent cleanup
   destroy(): void;
 }
@@ -265,6 +266,24 @@ try {
 ```
 
 `clone()` throws `SessionDestroyedError` if the base is destroyed and `PromptUnavailableError` if the browser instance doesn't support cloning. Destroying a clone never affects the base, and vice versa.
+
+### Injecting context without a turn — `Session.append()`
+
+Agent loops often need to push tool results or other context into conversation history **without** triggering a model turn. Faking this with an extra `send()` wastes tokens and latency on an empty intermediate response. `Session.append()` forwards to the native `LanguageModel.append()`: the messages land in history, and the next `send` / `sendStreaming` sees them as prior turns.
+
+```ts
+const session = createSession({ systemPrompt });
+await session.send("What's the weather in Tokyo?");
+// The model asked to call a tool; run it yourself, then inject the result:
+await session.append([
+  { role: "assistant", content: "I'll check the weather." },
+  { role: "user", content: "tool result: 24°C, clear" },
+]);
+// The next turn sees the tool result as history — no wasted intermediate turn.
+const plan = await session.send("Based on that, suggest an outfit.");
+```
+
+`append()` throws `SessionDestroyedError` if the session is destroyed and `PromptUnavailableError` if the browser instance doesn't support `append()`. Aborts reject with `PromptAbortError`.
 
 ### Context-window introspection
 

--- a/packages/prompt/README.md
+++ b/packages/prompt/README.md
@@ -201,6 +201,7 @@ interface Session {
   sendStreaming(input: string, options?: SessionSendOptions): AsyncIterable<string>;
   abort(): void;
   clone(options?: { signal?: AbortSignal }): Promise<Session>;
+  append(messages: LanguageModelMessage[], options?: { signal?: AbortSignal }): Promise<void>; // context without a turn
   onContextOverflow(listener: () => void): () => void; // returns an idempotent cleanup
   destroy(): void;
 }
@@ -258,6 +259,24 @@ try {
 ```
 
 `clone()` throws `SessionDestroyedError` if the base is destroyed and `PromptUnavailableError` if the browser instance doesn't support cloning. Destroying a clone never affects the base, and vice versa.
+
+### Injecting context without a turn — `Session.append()`
+
+Agent loops often need to push tool results or other context into conversation history **without** triggering a model turn. Faking this with an extra `send()` wastes tokens and latency on an empty intermediate response. `Session.append()` forwards to the native `LanguageModel.append()`: the messages land in history, and the next `send` / `sendStreaming` sees them as prior turns.
+
+```ts
+const session = createSession({ systemPrompt });
+await session.send("What's the weather in Tokyo?");
+// The model asked to call a tool; run it yourself, then inject the result:
+await session.append([
+  { role: "assistant", content: "I'll check the weather." },
+  { role: "user", content: "tool result: 24°C, clear" },
+]);
+// The next turn sees the tool result as history — no wasted intermediate turn.
+const plan = await session.send("Based on that, suggest an outfit.");
+```
+
+`append()` throws `SessionDestroyedError` if the session is destroyed and `PromptUnavailableError` if the browser instance doesn't support `append()`. Aborts reject with `PromptAbortError`.
 
 ### Context-window introspection
 

--- a/packages/prompt/src/api.ts
+++ b/packages/prompt/src/api.ts
@@ -107,6 +107,10 @@ export interface LanguageModelInstance {
     input: string | LanguageModelMessage[],
     options?: LanguageModelPromptOptions,
   ): AsyncIterable<string>;
+  append?(
+    messages: LanguageModelMessage[],
+    options?: { signal?: AbortSignal },
+  ): Promise<void>;
   clone?(options?: { signal?: AbortSignal }): Promise<LanguageModelInstance>;
   destroy?(): void;
   /**

--- a/packages/prompt/src/index.test.ts
+++ b/packages/prompt/src/index.test.ts
@@ -17,6 +17,7 @@ interface FakeSession {
   promptStreaming?: ReturnType<typeof vi.fn>;
   destroy?: ReturnType<typeof vi.fn>;
   clone?: ReturnType<typeof vi.fn>;
+  append?: ReturnType<typeof vi.fn>;
   contextWindow?: number;
   contextUsage?: number;
   inputQuota?: number;
@@ -901,6 +902,81 @@ describe("Session.clone", () => {
     await expect(base.clone()).rejects.toMatchObject({
       name: "SessionDestroyedError",
     });
+  });
+});
+
+describe("Session.append", () => {
+  it("forwards messages to the native instance.append()", async () => {
+    const appendSpy = vi.fn(async () => {});
+    installFakeLanguageModel({
+      sessionFactory: () => ({
+        prompt: vi.fn(async () => "ok"),
+        append: appendSpy,
+        destroy: vi.fn(),
+      }),
+    });
+    const session = createSession();
+    await session.send("warm");
+    const messages = [
+      { role: "assistant" as const, content: "I called a tool." },
+      { role: "user" as const, content: "tool result: 42" },
+    ];
+    await session.append(messages);
+    expect(appendSpy).toHaveBeenCalledTimes(1);
+    expect(appendSpy).toHaveBeenCalledWith(
+      messages,
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+    );
+    session.destroy();
+  });
+
+  it("throws PromptUnavailableError when the instance has no append()", async () => {
+    installFakeLanguageModel({
+      sessionFactory: () => ({ prompt: vi.fn(async () => "x") }),
+    });
+    const session = createSession();
+    await session.send("warm");
+    await expect(
+      session.append([{ role: "user", content: "hi" }]),
+    ).rejects.toBeInstanceOf(PromptUnavailableError);
+    session.destroy();
+  });
+
+  it("throws SessionDestroyedError when appending to a destroyed session", async () => {
+    installFakeLanguageModel({
+      sessionFactory: () => ({
+        prompt: vi.fn(async () => "x"),
+        append: vi.fn(async () => {}),
+        destroy: vi.fn(),
+      }),
+    });
+    const session = createSession();
+    await session.send("warm");
+    session.destroy();
+    await expect(
+      session.append([{ role: "user", content: "hi" }]),
+    ).rejects.toMatchObject({ name: "SessionDestroyedError" });
+  });
+
+  it("rejects with PromptAbortError when the signal aborts", async () => {
+    installFakeLanguageModel({
+      sessionFactory: () => ({
+        prompt: vi.fn(async () => "ok"),
+        append: vi.fn(async () => {
+          await new Promise((r) => setTimeout(r, 20));
+        }),
+        destroy: vi.fn(),
+      }),
+    });
+    const session = createSession();
+    await session.send("warm");
+    const controller = new AbortController();
+    const pending = session.append([{ role: "user", content: "hi" }], {
+      signal: controller.signal,
+    });
+    controller.abort();
+    await expect(pending).rejects.toBeInstanceOf(PromptAbortError);
+    session.destroy();
   });
 });
 

--- a/packages/prompt/src/session.ts
+++ b/packages/prompt/src/session.ts
@@ -23,6 +23,7 @@ import {
   type LanguageModelExpectedInput,
   type LanguageModelExpectedOutput,
   type LanguageModelInstance,
+  type LanguageModelMessage,
   type LanguageModelPromptOptions,
   type LanguageModelSamplingMode,
   type LanguageModelTool,
@@ -228,6 +229,20 @@ export interface Session {
    * vice versa.
    */
   clone(options?: { signal?: AbortSignal }): Promise<Session>;
+  /**
+   * Push messages into the session's conversation history **without** running a
+   * model turn. Use it to inject tool results or other context between turns
+   * — the next `send` / `sendStreaming` sees the appended messages as prior
+   * history, with no wasted tokens or latency on an empty intermediate turn.
+   *
+   * Throws `SessionDestroyedError` if the session is destroyed, and
+   * `PromptUnavailableError` if the underlying browser instance doesn't
+   * support `append()`. Aborts reject with `PromptAbortError`.
+   */
+  append(
+    messages: LanguageModelMessage[],
+    options?: { signal?: AbortSignal },
+  ): Promise<void>;
   /**
    * Max input tokens for this session (the context window), as reported by
    * the underlying instance — mirrors the native `contextWindow`. `undefined`
@@ -510,6 +525,34 @@ const wrapInstance = (
     }
   };
 
+  const append = async (
+    messages: LanguageModelMessage[],
+    options?: { signal?: AbortSignal },
+  ): Promise<void> => {
+    ensureLive();
+    const { instance } = await ready;
+    ensureLive();
+    if (typeof instance.append !== "function") {
+      throw new PromptUnavailableError(
+        "This LanguageModel instance does not support append() in this browser.",
+      );
+    }
+
+    const { controller, cleanup } = setupController(options?.signal);
+
+    try {
+      await instance.append(messages, { signal: controller.signal });
+      if (controller.signal.aborted) throw new PromptAbortError();
+    } catch (err) {
+      if ((err as { name?: string })?.name === "AbortError") {
+        throw new PromptAbortError();
+      }
+      throw err;
+    } finally {
+      cleanup();
+    }
+  };
+
   const destroy = (): void => {
     if (destroyed) return;
     destroyed = true;
@@ -544,6 +587,7 @@ const wrapInstance = (
     sendStreaming,
     abort,
     clone,
+    append,
     onContextOverflow,
     destroy,
   };


### PR DESCRIPTION
## Summary

Surfaces the native `LanguageModel.append()` on the SDK's `Session`, so agent
loops can push tool results or other context into conversation history **without**
triggering a model turn. Today consumers fake this with an extra `send()`, wasting
tokens and latency on an empty intermediate response.

```ts
const session = createSession({ systemPrompt });
await session.send("What's the weather in Tokyo?");
// model asked for a tool; run it, then inject the result:
await session.append([
  { role: "assistant", content: "I'll check the weather." },
  { role: "user", content: "tool result: 24°C, clear" },
]);
// next turn sees the tool result as history — no wasted intermediate turn
const plan = await session.send("Based on that, suggest an outfit.");
```

## Changes

- `packages/prompt/src/api.ts` — `append?` on `LanguageModelInstance` (native type)
- `packages/prompt/src/session.ts` — `Session.append()` (interface + impl), mirroring the `send()` / `clone()` lifecycle: lazy-create guard, feature-detect, abort wiring
- `packages/prompt/src/index.test.ts` — 4 tests (happy / unavailable / destroyed / abort); prompt suite 72 → 76
- `packages/prompt/README.md` + `apps/site/src/content/docs/guides/prompt.mdx` + regenerated `apps/site/src/content/docs/packages/prompt.md`

## Behavior

Throws `PromptUnavailableError` when the browser instance lacks `append()`, `SessionDestroyedError` after `destroy()`, and `PromptAbortError` on abort — consistent with `send()` / `clone()`.

## Verification

`pnpm gate` → exit 0 (lint, docs:check, build, typecheck, test across 9 packages).
