### PR TITLE
test(prompt): cover mid-stream abort and destroy-during-stream

### DIFF
--- a/packages/prompt/src/index.test.ts
+++ b/packages/prompt/src/index.test.ts
@@ -646,6 +646,40 @@ describe("ask", () => {
       }),
     ).rejects.toThrow(/aborted/i);
   });
+
+  it("aborts a streaming ask between yielded chunks", async () => {
+    let resolveGate: () => void = () => {};
+    const gate = new Promise<void>((r) => {
+      resolveGate = r;
+    });
+    const session: FakeSession = {
+      prompt: vi.fn(),
+      promptStreaming: vi.fn(async function* () {
+        yield "a";
+        await gate;
+        yield "b";
+      }),
+      destroy: vi.fn(),
+    };
+    installFakeLanguageModel({ sessionFactory: () => session });
+
+    const controller = new AbortController();
+    const updates: string[] = [];
+    const p = ask({
+      input: "hi",
+      signal: controller.signal,
+      onUpdate: (t) => updates.push(t),
+    });
+    for (let i = 0; i < 50 && updates.length === 0; i++) {
+      await Promise.resolve();
+    }
+    expect(updates).toEqual(["a"]);
+    controller.abort();
+    resolveGate();
+    await expect(p).rejects.toBeInstanceOf(PromptAbortError);
+    expect(updates).toEqual(["a"]);
+    expect(session.destroy).toHaveBeenCalled();
+  });
 });
 
 describe("createSession", () => {
@@ -725,6 +759,45 @@ describe("createSession", () => {
     await expect(session.send("hi")).rejects.toMatchObject({
       name: "SessionDestroyedError",
     });
+  });
+
+  it("destroy() aborts an in-flight sendStreaming and marks the session destroyed", async () => {
+    let resolveGate: () => void = () => {};
+    const gate = new Promise<void>((r) => {
+      resolveGate = r;
+    });
+    installFakeLanguageModel({
+      sessionFactory: () => ({
+        prompt: vi.fn(),
+        promptStreaming: vi.fn(async function* () {
+          yield "a";
+          await gate;
+          yield "b";
+        }),
+        destroy: vi.fn(),
+      }),
+    });
+
+    const session = createSession();
+    const collected: string[] = [];
+    let rejection: unknown;
+    const drain = (async () => {
+      try {
+        for await (const d of session.sendStreaming("hi")) collected.push(d);
+      } catch (e) {
+        rejection = e;
+      }
+    })();
+    for (let i = 0; i < 50 && collected.length === 0; i++) {
+      await Promise.resolve();
+    }
+    expect(collected).toEqual(["a"]);
+    session.destroy();
+    expect(session.destroyed).toBe(true);
+    resolveGate();
+    await drain;
+    expect(collected).toEqual(["a"]);
+    expect(rejection).toBeInstanceOf(PromptAbortError);
   });
 
   it("does NOT queue concurrent sends; consumers handle sequencing themselves", async () => {


### PR DESCRIPTION
## What

Adds characterization tests for the prompt package's two highest-risk concurrency paths, which previously had **no coverage** (plan 026).

- **Mid-stream abort of `ask()`** — a gated async generator yields `"a"`, suspends, then the `AbortSignal` aborts between chunks. Asserts the call rejects with `PromptAbortError`, `onUpdate` stops at `["a"]` (no post-abort fire), and `session.destroy` runs in the `finally`. This is the path the existing pre-aborted test never touched.
- **`session.destroy()` during an in-flight `sendStreaming`** — destroy mid-stream aborts the in-flight controller; the resumed iteration rejects `PromptAbortError`, deltas stay `["a"]`, and `session.destroyed === true`.

No source changes — pure regression net (tests-only). Verified against the live `session.ts` contract: `destroy()` aborts `currentController` (`session.ts:559`) and the `sendStreaming` loop guard (`session.ts:445`) throws `PromptAbortError` on the aborted signal.

## Why

A regression that leaks the native stream, double-fires `onUpdate`, or fails to throw on mid-stream abort/destroy would otherwise go uncaught. The existing abort test only covers a **pre-aborted** signal.

## Verification

- `pnpm --filter @web-ai-sdk/prompt run test` → 78 pass (76 → 78)
- `pnpm gate` → exit 0
- Self-check: temporarily neutering the mid-loop guard at `index.ts:331` makes test 1 fail (resolves with `"ab"` instead of rejecting) → confirms it pins that exact line. Guard restored; source diff empty.
- Scope: only `packages/prompt/src/index.test.ts` (+73); `index.ts`/`session.ts`/`api.ts` untouched.

Plan: `plans/026-prompt-stream-abort-tests.md`