### PR TITLE
fix(webmcp): stop uncaught throw on non-duplicate register retry

### DIFF
--- a/.changeset/webmcp-retry-no-throw.md
+++ b/.changeset/webmcp-retry-no-throw.md
@@ -1,0 +1,5 @@
+---
+"@web-ai-sdk/webmcp": patch
+---
+
+Stop the `registerTool` microtask retry from throwing uncaught exceptions on non-duplicate failures. The retry path now logs via `console.error` and gives up, matching the duplicate-error branch and the package's "feature detect, never throw" contract, instead of re-throwing from inside `queueMicrotask` — a throw that was uncatchable (the call had already returned) and could surface as an uncaught `window.error` in browsers or terminate Node SSR/SSG builds.

--- a/.changeset/webmcp-retry-no-throw.md
+++ b/.changeset/webmcp-retry-no-throw.md
@@ -2,4 +2,4 @@
 "@web-ai-sdk/webmcp": patch
 ---
 
-Stop the `registerTool` microtask retry from throwing uncaught exceptions on non-duplicate failures. The retry path now logs via `console.error` and gives up, matching the duplicate-error branch and the package's "feature detect, never throw" contract, instead of re-throwing from inside `queueMicrotask` — a throw that was uncatchable (the call had already returned) and could surface as an uncaught `window.error` in browsers or terminate Node SSR/SSG builds.
+Stop the `registerTool` microtask retry from throwing uncaught exceptions on non-duplicate failures. The retry path now logs via `console.error` and gives up, mirroring the duplicate-error branch's log-and-give-up structure (at `error` severity rather than `warn`, since a non-duplicate failure is unrecoverable) and the package's "feature detect, never throw" contract, instead of re-throwing from inside `queueMicrotask` — a throw that was uncatchable (the call had already returned) and could surface as an uncaught `window.error` in browsers or terminate Node SSR/SSG builds.

--- a/packages/webmcp/src/index.test.ts
+++ b/packages/webmcp/src/index.test.ts
@@ -312,6 +312,40 @@ describe("registerTool", () => {
     expect(map.has("t")).toBe(true); // retry landed it
     expect(registerTool_).toHaveBeenCalledTimes(2);
   });
+
+  it("logs and gives up (no uncaught throw) when the retry fails with a non-duplicate error", async () => {
+    let calls = 0;
+    const registerTool_ = vi.fn(() => {
+      calls += 1;
+      // First call: duplicate (enters the microtask retry path). Retry
+      // call: a non-duplicate failure that the old code re-threw from
+      // inside queueMicrotask (uncaught by construction).
+      if (calls === 1) {
+        throw new Error(
+          "Failed to execute 'registerTool' on 'ModelContext': Duplicate tool name",
+        );
+      }
+      throw new Error("InvalidStateError: sandbox unavailable");
+    });
+    Object.defineProperty(navigator, "modelContext", {
+      value: { registerTool: registerTool_ },
+      configurable: true,
+    });
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    expect(() =>
+      registerTool({ name: "t", description: "d", execute: async () => ({}) }),
+    ).not.toThrow();
+    await Promise.resolve(); // flush microtask; if the throw survived it would surface here
+
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringMatching(/could not be registered after retry/),
+    );
+    expect(warnSpy).not.toHaveBeenCalled();
+    errorSpy.mockRestore();
+    warnSpy.mockRestore();
+  });
 });
 
 describe("defineTool", () => {

--- a/packages/webmcp/src/index.ts
+++ b/packages/webmcp/src/index.ts
@@ -297,7 +297,11 @@ const registerOne = (
           }
           return;
         }
-        throw retryErr;
+        if (typeof console !== "undefined") {
+          console.error(
+            `[@web-ai-sdk/webmcp] tool "${registered.name}" could not be registered after retry: ${(retryErr as Error)?.message ?? String(retryErr)}`,
+          );
+        }
       }
     });
     return false;


### PR DESCRIPTION
## Summary
The `registerTool` microtask retry re-threw non-duplicate errors from inside
`queueMicrotask`, where nothing could catch them — surfacing as an uncaught
`window.error` in browsers and able to terminate Node SSR/SSG builds. This
violates the package's "feature detect, never throw" core contract and
contradicts the comment above the throw ("If the retry also fails, log and
give up").

## Changes
- `packages/webmcp/src/index.ts` — the retry `catch` now logs non-duplicate
  failures via `console.error` and gives up, mirroring the duplicate-error
  branch's log-and-give-up structure (at `error` severity rather than `warn`,
  since a non-duplicate failure is unrecoverable). The duplicate branch is
  unchanged.
- `packages/webmcp/src/index.test.ts` — regression test: non-duplicate retry
  failure → `console.error`, no uncaught throw.

## Verification
- `pnpm gate` (lint, docs:check, build, typecheck, test) — green.
- webmcp tests: 28 passed.
- The new test fails against the old code (surfaces an uncaught exception);
  green after the fix.

## Notes
- The synchronous first-call `throw err` is intentionally left in place — it's
  on the main call stack and is catchable by the caller.
- Includes a changeset (`@web-ai-sdk/webmcp`: patch).
