### PR TITLE
chore(repo): align CI/Pages Node to .nvmrc, make pnpm check build-aware, refresh biome config

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
 
       - uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version-file: .nvmrc
           cache: pnpm
 
       - run: pnpm install --frozen-lockfile

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -46,7 +46,7 @@ jobs:
 
       - uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version-file: .nvmrc
           cache: pnpm
 
       - run: pnpm install --frozen-lockfile

--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.4.16/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.5.0/schema.json",
   "files": {
     "includes": [
       "**/packages/**/*.ts",
@@ -18,7 +18,7 @@
   "linter": {
     "enabled": true,
     "rules": {
-      "recommended": true
+      "preset": "recommended"
     }
   },
   "formatter": {

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "lint:fix": "biome check --write .",
     "format": "biome format --write .",
     "format:check": "biome format .",
-    "check": "pnpm lint && pnpm typecheck && pnpm test",
+    "check": "pnpm lint && pnpm build:packages && pnpm typecheck && pnpm test",
     "changeset": "changeset",
     "version-packages": "changeset version",
     "release": "pnpm build:packages && changeset publish",


### PR DESCRIPTION
## What

Three independent tooling-drift fixes (plan 027), plus a biome config
migration surfaced by the schema bump.

## Why

- **CI/Pages Node drift:** `ci.yml` and `pages.yml` hardcoded `node-version:
  22`, but `.nvmrc` (local dev) and `release.yml` (publish) use Node 24. A
  green gate was produced on a different runtime than the publish pipeline.
  Both now use `node-version-file: .nvmrc` — single source of truth, matching
  `release.yml`.
- **`pnpm check` not build-aware:** `@web-ai-sdk/all` resolves its workspace
  deps to `dist/` (gitignored), so on a fresh checkout `check`/`test`/`typecheck`
  failed for the meta-package until a build ran. `check` now runs
  `build:packages` first (mirrors `gate`), making it self-sufficient. `gate`
  is unchanged.
- **stale biome schema:** `$schema` was pinned to `2.4.16` while
  `@biomejs/biome` is `2.5.0`, emitting a "migrate the configuration" notice on
  every lint. Bumped to `2.5.0` and migrated the now-deprecated
  `linter.rules.recommended` → `preset: "recommended"`. `pnpm lint` is now
  fully clean (0 infos).

## Verification

- `pnpm lint` → exit 0, 0 infos
- `rm -rf packages/*/dist && pnpm check` → exit 0 (fresh-checkout safe)
- `pnpm gate` → exit 0

## Scope

CI/workflow + root tooling config only. No published package API or runtime
change — **no changeset**. `release.yml`, `.nvmrc`, `engines.node`, and `gate`
are untouched.
