### PR TITLE
docs(site): lead with the capability moat across site and docs

### DIFF
--- a/.agents/agents.md
+++ b/.agents/agents.md
@@ -73,7 +73,7 @@ Full rules in [`CONTRIBUTING.md` § Governance](../CONTRIBUTING.md#governance); 
 │   │   ├── tsup.config.ts
 │   │   ├── vitest.config.ts
 │   │   └── README.md
-│   ├── translator/               # same shape; adds serialize.ts for DOM block walking
+│   ├── translator/               # same shape; adds api.ts + cache.ts
 │   ├── summarizer/               # same shape; adds skeleton.ts + cache.ts
 │   ├── prompt/                   # same shape; adds api.ts + cache.ts
 │   ├── detector/                 # same shape; adds api.ts + cache.ts
@@ -150,7 +150,7 @@ These rules apply to the API-wrapper packages (`@web-ai-sdk/prompt`, `webmcp`, `
 
 - **No UI components in the core wrappers.** A core package may never render DOM. The React adapter is a hook, not a component. UI primitives would ship as a separate `@web-ai-sdk/ui` package, not bolted into a wrapper.
 - **Feature detect, never throw.** If the underlying browser API is missing, the package is a no-op (return a no-op cleanup, return `undefined`, etc.) so consumers can ship the same code to all browsers.
-- **Configurable selectors / roots.** Don't hardcode page-specific assumptions. The translator's `[data-translate-root]` is a default, not a requirement; every selector / root element must be overridable via the API.
+- **Configurable selectors / roots.** Don't hardcode page-specific assumptions; every selector or root element an SDK helper accepts must be overridable via the API.
 - **Cleanup must be idempotent.** Returning a cleanup function from `register*` / `start*` is the universal lifecycle. Calling it twice must not throw.
 
 ### React adapter shape

--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ A small, focused monorepo of framework-agnostic packages that smooth over the gn
 
 The Web's Built-in AI APIs are promising but still early and shifting. Every app that touches them re-implements the same lifecycle: feature-detect, wait for model availability, create and reuse sessions, stream chunks, abort cleanly, and fall back when the capability is missing. web-ai-sdk owns that layer so you build against one stable, typed surface rather than coupling your whole app to today's experimental API shape. The wrappers feature-detect and no-op when a browser lacks the API, so the same code ships everywhere.
 
+The SDK is per-capability because the Web ships more than one AI surface. Six specialized built-ins (Translator, Summarizer, Writer, Rewriter, Proofreader, Language Detector) each carry option spaces a single text-model abstraction cannot express, and WebMCP (`document.modelContext`) is an agent surface rather than a model at all. That breadth is the point, not an accident. One package per capability, and the model abstraction is one of them rather than the whole product.
+
 ## What it is
 
 **`web-ai-sdk`** ships one package per browser capability. Zero runtime dependencies. Written in TypeScript. That's it. The SDK tracks a moving browser spec and intentionally stays out of the way of *how* you build an app.

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ See [`apps/site/src/content/docs/architecture.mdx`](./apps/site/src/content/docs
 | Package                                          | Wraps                                          | Highlights                                                                |
 | ------------------------------------------------ | ---------------------------------------------- | ------------------------------------------------------------------------- |
 | [`@web-ai-sdk/webmcp`](./packages/webmcp)            | `document.modelContext` (W3C WebMCP)           | Safe register/unregister, shorthand annotations, `useWebMCP` hook         |
-| [`@web-ai-sdk/translator`](./packages/translator)    | Web Built-in `Translator`                   | Block serialization, casing restoration, snapshot-based restore           |
+| [`@web-ai-sdk/translator`](./packages/translator)    | Web Built-in `Translator`                   | String-mode translation, pair-cached sessions, opt-in result caching       |
 | [`@web-ai-sdk/summarizer`](./packages/summarizer)    | Web Built-in `Summarizer`                   | Skeleton extraction, sessionStorage caching, streaming chunks             |
 | [`@web-ai-sdk/prompt`](./packages/prompt)            | Web Built-in `LanguageModel` (Prompt API)   | System prompt + sampling, session reuse, streaming, result cache          |
 | [`@web-ai-sdk/detector`](./packages/detector)        | Web Built-in `LanguageDetector`             | Confidence thresholds, bias hints, session reuse, `useDetector` hook      |

--- a/apps/site/src/content/docs/architecture.mdx
+++ b/apps/site/src/content/docs/architecture.mdx
@@ -25,6 +25,8 @@ The capability can originate from an official Built-in AI API (`LanguageModel`, 
 
 The structural rule is mechanical: **one package = one cohesive capability**. If the description of a package needs the word "and" to be honest about its scope, it's probably two packages.
 
+This is forced by shape, not just taste. The specialized built-ins carry option surfaces (target language, tone, length, confidence thresholds, per-issue offsets) that a single text-model abstraction cannot express, and WebMCP is an agent surface rather than a model. One capability per package is the only honest boundary.
+
 No SDK package imports from another published SDK package. Composition across capabilities (running a Prompt session over a tool registered with WebMCP, for example) is something you write in your application code.
 
 ## Zero-dependency policy

--- a/apps/site/src/content/docs/index.mdx
+++ b/apps/site/src/content/docs/index.mdx
@@ -30,6 +30,10 @@ article-aware summarization, detect-then-summarize chains) are
 deliberately out of scope — the SDK wraps one capability per package;
 composition is your code.
 
+## One capability per package, on purpose
+
+A single text-generation model abstraction reaches exactly one of these built-ins, `LanguageModel` (Prompt). The other seven carry options it cannot express (target language, tone, length, confidence thresholds, per-issue offsets), and one of them, WebMCP, is an *agent* surface rather than a model. That breadth is why the SDK is per-capability rather than one provider adapter. The model abstraction is one surface among eight, not the whole product. See [Why web-ai-sdk](/docs/why-web-ai-sdk/) for the full argument.
+
 ## Why not just use the APIs directly?
 
 You can, and nothing here stops you. The browser's built-in AI APIs are the foundation; web-ai-sdk owns the thin, repetitive lifecycle layer you'd otherwise rewrite in every component, and nothing more.

--- a/apps/site/src/content/docs/why-web-ai-sdk.mdx
+++ b/apps/site/src/content/docs/why-web-ai-sdk.mdx
@@ -15,7 +15,7 @@ If your code calls a hosted model behind an API key, reach for a provider SDK. I
 
 A single text-generation model abstraction can only express one of these surfaces, `LanguageModel` (Prompt). The other seven cannot be funneled through it, because each carries options a text-out contract has no room for.
 
-- **Translator** takes a target language and serializes whole DOM blocks, with sessions cached per source-target pair.
+- **Translator** takes a source and target language and caches a session per language pair.
 - **Summarizer** is shaped by type (key-points, TL;DR, headlines) and length.
 - **Writer** is parameterized by tone, format, and length.
 - **Rewriter** applies relative shifts (shorter, longer, more formal) to existing text.

--- a/apps/site/src/content/docs/why-web-ai-sdk.mdx
+++ b/apps/site/src/content/docs/why-web-ai-sdk.mdx
@@ -11,6 +11,20 @@ It is not a provider SDK for OpenAI, Anthropic, Google AI Studio, or other serve
 
 If your code calls a hosted model behind an API key, reach for a provider SDK. If your code wants to run on the model the browser ships, on-device, with no key and no server, that is what `web-ai-sdk` wraps.
 
+## Specialized built-ins, not just one model
+
+A single text-generation model abstraction can only express one of these surfaces, `LanguageModel` (Prompt). The other seven cannot be funneled through it, because each carries options a text-out contract has no room for.
+
+- **Translator** takes a target language and serializes whole DOM blocks, with sessions cached per source-target pair.
+- **Summarizer** is shaped by type (key-points, TL;DR, headlines) and length.
+- **Writer** is parameterized by tone, format, and length.
+- **Rewriter** applies relative shifts (shorter, longer, more formal) to existing text.
+- **Proofreader** returns per-issue corrections with offsets into the original input.
+- **Detector** returns a confidence-scored, sorted list of language alternates.
+- **WebMCP** (`document.modelContext`) is an *agent* surface, not a model surface. Tools call into the page, and it does not generate text.
+
+That breadth is the point, not an accident. The model abstraction is one surface among eight, so `web-ai-sdk` is per-capability by design, a thin layer over each, built to get thinner as the platform matures.
+
 ## What the SDK owns
 
 The Built-in AI APIs are young and shifting. Every app that touches them re-implements the same lifecycle, so `web-ai-sdk` owns it once:

--- a/apps/site/src/pages/index.astro
+++ b/apps/site/src/pages/index.astro
@@ -548,7 +548,7 @@ const supportVersionTone = (value: string) => {
                 The rest carry options a text-out contract cannot hold, so each gets its own thin package.
               </p>
               <ul class={ui.philosophyList}>
-                <li>Translator (target language, block serialization)</li>
+                <li>Translator (source + target language, pair-cached sessions)</li>
                 <li>Summarizer (type and length)</li>
                 <li>Writer (tone, format, length)</li>
                 <li>Rewriter (relative tone/length shifts)</li>

--- a/apps/site/src/pages/index.astro
+++ b/apps/site/src/pages/index.astro
@@ -442,6 +442,7 @@ const supportVersionTone = (value: string) => {
         </a>
         <div class={ui.navLinks}>
           <a href="#why-raw">Why not raw?</a>
+          <a href="#why-sdk">Why per-capability</a>
           <a href="#packages">Packages</a>
           <a href="#philosophy">Why composable</a>
           <a href="#how">How</a>
@@ -516,6 +517,45 @@ const supportVersionTone = (value: string) => {
                 web-ai-sdk owns the thin, repetitive lifecycle layer you would otherwise rewrite in every app: capability checks, model downloads, session reuse, streaming with chunk smoothing, AbortSignal cleanup, opt-in result caching, and feature-detected fallbacks. Drop down to the raw APIs whenever you want.
               </p>
               <a class={`${ui.pkgDocs} mt-5`} href="#philosophy">See why it's composable <span class={ui.pkgDocsArrow}>→</span></a>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section class={ui.section} data-section="why-sdk">
+        <div class={ui.container}>
+          <div class={`${ui.sectionHead} ${ui.sectionAnchor}`} id="why-sdk">
+            <div>
+              <div class={ui.sectionEyebrow}>coverage</div>
+              <h2 class="mt-2">Why one package per capability.</h2>
+            </div>
+            <a class={ui.permalink} href="#why-sdk"><span aria-hidden="true">§</span><span class={ui.srOnly}>Link to the why one package per capability section</span></a>
+          </div>
+          <div class={`${ui.twoCol} ${ui.reveal}`} data-reveal>
+            <div>
+              <h3 class={ui.philosophyTitle}><span class={ui.philosophyNum}>01</span> One model surface.</h3>
+              <p class={ui.philosophyText}>
+                A single text-generation model abstraction reaches exactly one of these built-ins, <code>LanguageModel</code> (Prompt). Useful, but one surface, not the whole product.
+              </p>
+              <ul class={ui.philosophyList}>
+                <li>Prompt / LanguageModel only</li>
+                <li>Text, tools, structured output</li>
+              </ul>
+            </div>
+            <div>
+              <h3 class={ui.philosophyTitle}><span class={ui.philosophyNum}>02</span> Seven surfaces beyond it.</h3>
+              <p class={ui.philosophyText}>
+                The rest carry options a text-out contract cannot hold, so each gets its own thin package.
+              </p>
+              <ul class={ui.philosophyList}>
+                <li>Translator (target language, block serialization)</li>
+                <li>Summarizer (type and length)</li>
+                <li>Writer (tone, format, length)</li>
+                <li>Rewriter (relative tone/length shifts)</li>
+                <li>Proofreader (per-issue offsets)</li>
+                <li>Detector (confidence scores, alternates)</li>
+                <li>WebMCP (an agent surface, not a model)</li>
+              </ul>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## What

Lead with web-ai-sdk's capability moat instead of only the "SDK vs raw APIs" framing. A single text-generation model abstraction reaches exactly one built-in (`LanguageModel`). The other seven surfaces plus WebMCP carry options it cannot express, so the SDK is per-capability by design.

Copy-only. No API, package, or schema changes.

## Where (5 files, +62)

- `apps/site/src/content/docs/why-web-ai-sdk.mdx` — new "Specialized built-ins, not just one model" section (one sentence per API, each verified against its package README)
- `apps/site/src/pages/index.astro` — new `#why-sdk` two-column section + nav link, built from existing `ui.*` utilities (no new CSS)
- `apps/site/src/content/docs/index.mdx` — "One capability per package, on purpose" framing block linking to the above
- `README.md` — one breadth paragraph under "Why this exists"
- `apps/site/src/content/docs/architecture.mdx` — one sentence on why per-capability is shape-forced

## Notes

- New copy frames by shape, not competitor brand, so it ages well. Existing "Vercel's AI SDK" mentions in `why-web-ai-sdk.mdx` (deployment-model contrast) are left as-is.
- Prose avoids em-dashes, semicolons, and colons per house style (`TL;DR` retained only as the literal Summarizer API type value).

## Verification

`pnpm gate` exits 0 (lint, docs:check, build, typecheck, 283 tests). `docs:check` confirms internal links and anchors resolve.
