### PR TITLE
test(wrappers): harden cache, abort, and React-hook cleanup tests

### DIFF
--- a/packages/detector/src/index.test.ts
+++ b/packages/detector/src/index.test.ts
@@ -309,4 +309,89 @@ describe("detect", () => {
       detect({ input: "hi", signal: controller.signal }),
     ).rejects.toMatchObject({ name: "AbortError" });
   });
+
+  it('honors cache: "session" via sessionStorage', async () => {
+    const store = new Map<string, string>();
+    const storage = {
+      getItem: vi.fn((k: string) => store.get(k) ?? null),
+      setItem: vi.fn((k: string, v: string) => {
+        store.set(k, v);
+      }),
+    };
+    vi.stubGlobal("sessionStorage", storage);
+    try {
+      const api = installFakeDetector();
+      const first = await detect({
+        input: "hello",
+        cache: "session",
+        cacheKey: "k",
+      });
+      expect(first.cached).toBe(false);
+      expect(first.output?.language).toBe("en");
+      expect(storage.setItem).toHaveBeenCalledWith(
+        "detector:k",
+        expect.any(String),
+      );
+
+      const createsAfterFirst = api.create.mock.calls.length;
+      const second = await detect({
+        input: "hello",
+        cache: "session",
+        cacheKey: "k",
+      });
+      expect(second.output?.language).toBe("en");
+      expect(second.cached).toBe(true);
+      expect(api.create).toHaveBeenCalledTimes(createsAfterFirst);
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+
+  it('honors cache: "local" via localStorage', async () => {
+    const store = new Map<string, string>();
+    const storage = {
+      getItem: vi.fn((k: string) => store.get(k) ?? null),
+      setItem: vi.fn((k: string, v: string) => {
+        store.set(k, v);
+      }),
+    };
+    vi.stubGlobal("localStorage", storage);
+    try {
+      const api = installFakeDetector();
+      const first = await detect({
+        input: "hello",
+        cache: "local",
+        cacheKey: "k",
+      });
+      expect(first.cached).toBe(false);
+      expect(first.output?.language).toBe("en");
+      expect(storage.setItem).toHaveBeenCalledWith(
+        "detector:k",
+        expect.any(String),
+      );
+
+      const createsAfterFirst = api.create.mock.calls.length;
+      const second = await detect({
+        input: "hello",
+        cache: "local",
+        cacheKey: "k",
+      });
+      expect(second.output?.language).toBe("en");
+      expect(second.cached).toBe(true);
+      expect(api.create).toHaveBeenCalledTimes(createsAfterFirst);
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+
+  it("aborts without writing the cache", async () => {
+    installFakeDetector();
+    const cache = { get: vi.fn(() => null), set: vi.fn() };
+    const controller = new AbortController();
+    controller.abort();
+    await expect(
+      detect({ input: "hi", cache, signal: controller.signal }),
+    ).rejects.toMatchObject({ name: "AbortError" });
+    expect(cache.set).not.toHaveBeenCalled();
+  });
 });

--- a/packages/detector/src/react/index.test.tsx
+++ b/packages/detector/src/react/index.test.tsx
@@ -1,4 +1,4 @@
-import { renderHook, waitFor } from "@testing-library/react";
+import { act, renderHook, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { __clearSessionCacheForTests } from "../api.js";
 import { useDetector } from "./index.js";
@@ -111,5 +111,48 @@ describe("useDetector", () => {
 
     await waitFor(() => expect(result.current.status).toBe("done"));
     expect(result.current.output).toBeNull();
+  });
+
+  it("discards a stale request when input changes (cleanup aborts the prior run)", async () => {
+    type FakeResults = Array<{
+      detectedLanguage: string;
+      confidence: number;
+    }>;
+    const resolvers: Array<(out: FakeResults) => void> = [];
+    const methodSpy = vi.fn(
+      () =>
+        new Promise<FakeResults>((resolve) => {
+          resolvers.push(resolve);
+        }),
+    );
+    const api = {
+      availability: vi.fn(async () => "available"),
+      create: vi.fn(async () => ({ detect: methodSpy })),
+    };
+    (globalThis as { LanguageDetector?: typeof api }).LanguageDetector = api;
+
+    const { result, rerender } = renderHook(
+      ({ input }: { input: string }) => useDetector({ input }),
+      { initialProps: { input: "A" } },
+    );
+    await waitFor(() => expect(resolvers).toHaveLength(1));
+
+    rerender({ input: "B" });
+    await waitFor(() => expect(resolvers).toHaveLength(2));
+
+    await act(async () => {
+      resolvers[0]?.([{ detectedLanguage: "stale-A", confidence: 0.9 }]);
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(result.current.output?.language).not.toBe("stale-A");
+
+    await act(async () => {
+      resolvers[1]?.([{ detectedLanguage: "fresh-B", confidence: 0.9 }]);
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    await waitFor(() => expect(result.current.status).toBe("done"));
+    expect(result.current.output?.language).toBe("fresh-B");
   });
 });

--- a/packages/prompt/src/index.test.ts
+++ b/packages/prompt/src/index.test.ts
@@ -680,6 +680,116 @@ describe("ask", () => {
     expect(updates).toEqual(["a"]);
     expect(session.destroy).toHaveBeenCalled();
   });
+
+  it('honors cache: "session" via sessionStorage', async () => {
+    const store = new Map<string, string>();
+    const storage = {
+      getItem: vi.fn((k: string) => store.get(k) ?? null),
+      setItem: vi.fn((k: string, v: string) => {
+        store.set(k, v);
+      }),
+    };
+    vi.stubGlobal("sessionStorage", storage);
+    try {
+      const fake = installFakeLanguageModel();
+      const first = await ask({
+        input: "hi",
+        cache: "session",
+        cacheKey: "k",
+      });
+      expect(first).toEqual({ output: "Hello, world.", cached: false });
+      expect(storage.setItem).toHaveBeenCalledWith("prompt:k", "Hello, world.");
+
+      const createsAfterFirst = fake.create.mock.calls.length;
+      const second = await ask({
+        input: "hi",
+        cache: "session",
+        cacheKey: "k",
+      });
+      expect(second).toEqual({ output: "Hello, world.", cached: true });
+      expect(fake.create).toHaveBeenCalledTimes(createsAfterFirst);
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+
+  it('honors cache: "local" via localStorage', async () => {
+    const store = new Map<string, string>();
+    const storage = {
+      getItem: vi.fn((k: string) => store.get(k) ?? null),
+      setItem: vi.fn((k: string, v: string) => {
+        store.set(k, v);
+      }),
+    };
+    vi.stubGlobal("localStorage", storage);
+    try {
+      const fake = installFakeLanguageModel();
+      const first = await ask({
+        input: "hi",
+        cache: "local",
+        cacheKey: "k",
+      });
+      expect(first).toEqual({ output: "Hello, world.", cached: false });
+      expect(storage.setItem).toHaveBeenCalledWith("prompt:k", "Hello, world.");
+
+      const createsAfterFirst = fake.create.mock.calls.length;
+      const second = await ask({
+        input: "hi",
+        cache: "local",
+        cacheKey: "k",
+      });
+      expect(second).toEqual({ output: "Hello, world.", cached: true });
+      expect(fake.create).toHaveBeenCalledTimes(createsAfterFirst);
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+
+  it("aborts without writing the cache", async () => {
+    installFakeLanguageModel();
+    const cache = { get: vi.fn(() => null), set: vi.fn() };
+    const controller = new AbortController();
+    controller.abort();
+    await expect(
+      ask({ input: "hi", cache, signal: controller.signal }),
+    ).rejects.toBeInstanceOf(PromptAbortError);
+    expect(cache.set).not.toHaveBeenCalled();
+  });
+
+  it("aborts a streaming ask without writing the cache", async () => {
+    let resolveGate: () => void = () => {};
+    const gate = new Promise<void>((r) => {
+      resolveGate = r;
+    });
+    const session: FakeSession = {
+      prompt: vi.fn(),
+      promptStreaming: vi.fn(async function* () {
+        yield "a";
+        await gate;
+        yield "b";
+      }),
+      destroy: vi.fn(),
+    };
+    installFakeLanguageModel({ sessionFactory: () => session });
+
+    const controller = new AbortController();
+    const cache = { get: vi.fn(() => null), set: vi.fn() };
+    const updates: string[] = [];
+    const p = ask({
+      input: "hi",
+      cache,
+      signal: controller.signal,
+      onUpdate: (t) => updates.push(t),
+    });
+    for (let i = 0; i < 50 && updates.length === 0; i++) {
+      await Promise.resolve();
+    }
+    expect(updates).toEqual(["a"]);
+    controller.abort();
+    resolveGate();
+    await expect(p).rejects.toBeInstanceOf(PromptAbortError);
+    expect(cache.set).not.toHaveBeenCalled();
+  });
 });
 
 describe("createSession", () => {

--- a/packages/proofreader/src/index.test.ts
+++ b/packages/proofreader/src/index.test.ts
@@ -294,4 +294,89 @@ describe("proofread", () => {
       }),
     ).rejects.toMatchObject({ name: "AbortError" });
   });
+
+  it('honors cache: "session" via sessionStorage', async () => {
+    const store = new Map<string, string>();
+    const storage = {
+      getItem: vi.fn((k: string) => store.get(k) ?? null),
+      setItem: vi.fn((k: string, v: string) => {
+        store.set(k, v);
+      }),
+    };
+    vi.stubGlobal("sessionStorage", storage);
+    try {
+      const api = installFakeProofreader({ correctedInput: "Fixed." });
+      const first = await proofread({
+        input: "text",
+        cache: "session",
+        cacheKey: "k",
+      });
+      expect(first.cached).toBe(false);
+      expect(first.output?.correctedInput).toBe("Fixed.");
+      expect(storage.setItem).toHaveBeenCalledWith(
+        "proofreader:k",
+        '{"correctedInput":"Fixed.","corrections":[]}',
+      );
+
+      const createsAfterFirst = api.create.mock.calls.length;
+      const second = await proofread({
+        input: "text",
+        cache: "session",
+        cacheKey: "k",
+      });
+      expect(second.output?.correctedInput).toBe("Fixed.");
+      expect(second.cached).toBe(true);
+      expect(api.create).toHaveBeenCalledTimes(createsAfterFirst);
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+
+  it('honors cache: "local" via localStorage', async () => {
+    const store = new Map<string, string>();
+    const storage = {
+      getItem: vi.fn((k: string) => store.get(k) ?? null),
+      setItem: vi.fn((k: string, v: string) => {
+        store.set(k, v);
+      }),
+    };
+    vi.stubGlobal("localStorage", storage);
+    try {
+      const api = installFakeProofreader({ correctedInput: "Fixed." });
+      const first = await proofread({
+        input: "text",
+        cache: "local",
+        cacheKey: "k",
+      });
+      expect(first.cached).toBe(false);
+      expect(first.output?.correctedInput).toBe("Fixed.");
+      expect(storage.setItem).toHaveBeenCalledWith(
+        "proofreader:k",
+        '{"correctedInput":"Fixed.","corrections":[]}',
+      );
+
+      const createsAfterFirst = api.create.mock.calls.length;
+      const second = await proofread({
+        input: "text",
+        cache: "local",
+        cacheKey: "k",
+      });
+      expect(second.output?.correctedInput).toBe("Fixed.");
+      expect(second.cached).toBe(true);
+      expect(api.create).toHaveBeenCalledTimes(createsAfterFirst);
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+
+  it("aborts without writing the cache", async () => {
+    installFakeProofreader();
+    const cache = { get: vi.fn(() => null), set: vi.fn() };
+    const controller = new AbortController();
+    controller.abort();
+    await expect(
+      proofread({ input: "text", cache, signal: controller.signal }),
+    ).rejects.toMatchObject({ name: "AbortError" });
+    expect(cache.set).not.toHaveBeenCalled();
+  });
 });

--- a/packages/proofreader/src/react/index.test.tsx
+++ b/packages/proofreader/src/react/index.test.tsx
@@ -1,4 +1,4 @@
-import { renderHook, waitFor } from "@testing-library/react";
+import { act, renderHook, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { __clearSessionCacheForTests } from "../api.js";
 import { useProofreader } from "./index.js";
@@ -73,5 +73,45 @@ describe("useProofreader", () => {
 
     rerender({ input: "second" });
     await waitFor(() => expect(api.proofreadSpy).toHaveBeenCalledTimes(2));
+  });
+
+  it("discards a stale request when input changes (cleanup aborts the prior run)", async () => {
+    type FakeResult = { correctedInput: string; corrections: [] };
+    const resolvers: Array<(out: FakeResult) => void> = [];
+    const methodSpy = vi.fn(
+      () =>
+        new Promise<FakeResult>((resolve) => {
+          resolvers.push(resolve);
+        }),
+    );
+    const api = {
+      availability: vi.fn(async () => "available"),
+      create: vi.fn(async () => ({ proofread: methodSpy })),
+    };
+    (globalThis as { Proofreader?: typeof api }).Proofreader = api;
+
+    const { result, rerender } = renderHook(
+      ({ input }: { input: string }) => useProofreader({ input }),
+      { initialProps: { input: "A" } },
+    );
+    await waitFor(() => expect(resolvers).toHaveLength(1));
+
+    rerender({ input: "B" });
+    await waitFor(() => expect(resolvers).toHaveLength(2));
+
+    await act(async () => {
+      resolvers[0]?.({ correctedInput: "stale-A", corrections: [] });
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(result.current.output?.correctedInput).not.toBe("stale-A");
+
+    await act(async () => {
+      resolvers[1]?.({ correctedInput: "fresh-B", corrections: [] });
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    await waitFor(() => expect(result.current.status).toBe("done"));
+    expect(result.current.output?.correctedInput).toBe("fresh-B");
   });
 });

--- a/packages/rewriter/src/index.test.ts
+++ b/packages/rewriter/src/index.test.ts
@@ -269,4 +269,79 @@ describe("rewrite", () => {
       }),
     ).rejects.toMatchObject({ name: "AbortError" });
   });
+
+  it('honors cache: "session" via sessionStorage', async () => {
+    const store = new Map<string, string>();
+    const storage = {
+      getItem: vi.fn((k: string) => store.get(k) ?? null),
+      setItem: vi.fn((k: string, v: string) => {
+        store.set(k, v);
+      }),
+    };
+    vi.stubGlobal("sessionStorage", storage);
+    try {
+      const api = installFakeRewriter({ output: "Stored." });
+      const first = await rewrite({
+        input: "text",
+        cache: "session",
+        cacheKey: "k",
+      });
+      expect(first).toEqual({ output: "Stored.", cached: false });
+      expect(storage.setItem).toHaveBeenCalledWith("rewriter:k", "Stored.");
+
+      const createsAfterFirst = api.create.mock.calls.length;
+      const second = await rewrite({
+        input: "text",
+        cache: "session",
+        cacheKey: "k",
+      });
+      expect(second).toEqual({ output: "Stored.", cached: true });
+      expect(api.create).toHaveBeenCalledTimes(createsAfterFirst);
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+
+  it('honors cache: "local" via localStorage', async () => {
+    const store = new Map<string, string>();
+    const storage = {
+      getItem: vi.fn((k: string) => store.get(k) ?? null),
+      setItem: vi.fn((k: string, v: string) => {
+        store.set(k, v);
+      }),
+    };
+    vi.stubGlobal("localStorage", storage);
+    try {
+      const api = installFakeRewriter({ output: "Stored." });
+      const first = await rewrite({
+        input: "text",
+        cache: "local",
+        cacheKey: "k",
+      });
+      expect(first).toEqual({ output: "Stored.", cached: false });
+      expect(storage.setItem).toHaveBeenCalledWith("rewriter:k", "Stored.");
+
+      const createsAfterFirst = api.create.mock.calls.length;
+      const second = await rewrite({
+        input: "text",
+        cache: "local",
+        cacheKey: "k",
+      });
+      expect(second).toEqual({ output: "Stored.", cached: true });
+      expect(api.create).toHaveBeenCalledTimes(createsAfterFirst);
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+
+  it("aborts without writing the cache", async () => {
+    installFakeRewriter({ output: "..." });
+    const cache = { get: vi.fn(() => null), set: vi.fn() };
+    const controller = new AbortController();
+    controller.abort();
+    await expect(
+      rewrite({ input: "text", cache, signal: controller.signal }),
+    ).rejects.toMatchObject({ name: "AbortError" });
+    expect(cache.set).not.toHaveBeenCalled();
+  });
 });

--- a/packages/rewriter/src/react/index.test.tsx
+++ b/packages/rewriter/src/react/index.test.tsx
@@ -1,4 +1,4 @@
-import { renderHook, waitFor } from "@testing-library/react";
+import { act, renderHook, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { __clearSessionCacheForTests } from "../api.js";
 import { useRewriter } from "./index.js";
@@ -79,5 +79,44 @@ describe("useRewriter", () => {
 
     rerender({ input: "second" });
     await waitFor(() => expect(api.rewriteSpy).toHaveBeenCalledTimes(2));
+  });
+
+  it("discards a stale request when input changes (cleanup aborts the prior run)", async () => {
+    const resolvers: Array<(out: string) => void> = [];
+    const methodSpy = vi.fn(
+      () =>
+        new Promise<string>((resolve) => {
+          resolvers.push(resolve);
+        }),
+    );
+    const api = {
+      availability: vi.fn(async () => "available"),
+      create: vi.fn(async () => ({ rewrite: methodSpy })),
+    };
+    (globalThis as { Rewriter?: typeof api }).Rewriter = api;
+
+    const { result, rerender } = renderHook(
+      ({ input }: { input: string }) => useRewriter({ input }),
+      { initialProps: { input: "A" } },
+    );
+    await waitFor(() => expect(resolvers).toHaveLength(1));
+
+    rerender({ input: "B" });
+    await waitFor(() => expect(resolvers).toHaveLength(2));
+
+    await act(async () => {
+      resolvers[0]?.("stale-A");
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(result.current.output).not.toBe("stale-A");
+
+    await act(async () => {
+      resolvers[1]?.("fresh-B");
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    await waitFor(() => expect(result.current.status).toBe("done"));
+    expect(result.current.output).toBe("fresh-B");
   });
 });

--- a/packages/summarizer/src/index.test.ts
+++ b/packages/summarizer/src/index.test.ts
@@ -404,4 +404,126 @@ describe("summarize", () => {
     >;
     expect(availabilityOpts.preference).toBe("speed");
   });
+
+  it('honors cache: "session" via sessionStorage', async () => {
+    const store = new Map<string, string>();
+    const storage = {
+      getItem: vi.fn((k: string) => store.get(k) ?? null),
+      setItem: vi.fn((k: string, v: string) => {
+        store.set(k, v);
+      }),
+    };
+    vi.stubGlobal("sessionStorage", storage);
+    try {
+      const api = installFakeSummarizer({ summary: "Stored." });
+      const first = await summarize({
+        language: "en",
+        input: "body",
+        cache: "session",
+        cacheKey: "k",
+      });
+      expect(first).toEqual({ output: "Stored.", cached: false });
+      expect(storage.setItem).toHaveBeenCalledWith("summarizer:k", "Stored.");
+
+      const createsAfterFirst = api.create.mock.calls.length;
+      const second = await summarize({
+        language: "en",
+        input: "body",
+        cache: "session",
+        cacheKey: "k",
+      });
+      expect(second).toEqual({ output: "Stored.", cached: true });
+      expect(api.create).toHaveBeenCalledTimes(createsAfterFirst);
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+
+  it('honors cache: "local" via localStorage', async () => {
+    const store = new Map<string, string>();
+    const storage = {
+      getItem: vi.fn((k: string) => store.get(k) ?? null),
+      setItem: vi.fn((k: string, v: string) => {
+        store.set(k, v);
+      }),
+    };
+    vi.stubGlobal("localStorage", storage);
+    try {
+      const api = installFakeSummarizer({ summary: "Stored." });
+      const first = await summarize({
+        language: "en",
+        input: "body",
+        cache: "local",
+        cacheKey: "k",
+      });
+      expect(first).toEqual({ output: "Stored.", cached: false });
+      expect(storage.setItem).toHaveBeenCalledWith("summarizer:k", "Stored.");
+
+      const createsAfterFirst = api.create.mock.calls.length;
+      const second = await summarize({
+        language: "en",
+        input: "body",
+        cache: "local",
+        cacheKey: "k",
+      });
+      expect(second).toEqual({ output: "Stored.", cached: true });
+      expect(api.create).toHaveBeenCalledTimes(createsAfterFirst);
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+
+  it("aborts without writing the cache", async () => {
+    installFakeSummarizer({ summary: "..." });
+    const cache = { get: vi.fn(() => null), set: vi.fn() };
+    const controller = new AbortController();
+    controller.abort();
+    await expect(
+      summarize({
+        language: "en",
+        input: "body",
+        cache,
+        signal: controller.signal,
+      }),
+    ).rejects.toMatchObject({ name: "AbortError" });
+    expect(cache.set).not.toHaveBeenCalled();
+  });
+
+  it("aborts a streaming summarize without writing the cache", async () => {
+    let resolveGate: () => void = () => {};
+    const gate = new Promise<void>((r) => {
+      resolveGate = r;
+    });
+    const api: FakeApi = {
+      availability: vi.fn(async () => "available"),
+      create: vi.fn(async () => ({
+        summarize: vi.fn(),
+        summarizeStreaming: async function* () {
+          yield "a";
+          await gate;
+          yield "b";
+        },
+      })),
+    };
+    (globalThis as { Summarizer?: FakeApi }).Summarizer = api;
+
+    const controller = new AbortController();
+    const cache = { get: vi.fn(() => null), set: vi.fn() };
+    const updates: string[] = [];
+    const p = summarize({
+      language: "en",
+      input: "body",
+      cache,
+      signal: controller.signal,
+      onUpdate: (c) => updates.push(c),
+    });
+    for (let i = 0; i < 50 && updates.length === 0; i++) {
+      await Promise.resolve();
+    }
+    expect(updates).toEqual(["a"]);
+    controller.abort();
+    resolveGate();
+    await expect(p).rejects.toMatchObject({ name: "AbortError" });
+    expect(cache.set).not.toHaveBeenCalled();
+  });
 });

--- a/packages/summarizer/src/react/index.test.tsx
+++ b/packages/summarizer/src/react/index.test.tsx
@@ -145,4 +145,44 @@ describe("useSummarizer", () => {
     await waitFor(() => expect(result.current.status).toBe("unavailable"));
     expect(result.current.error).toBeNull();
   });
+
+  it("discards a stale request when input changes (cleanup aborts the prior run)", async () => {
+    const resolvers: Array<(out: string) => void> = [];
+    const methodSpy = vi.fn(
+      () =>
+        new Promise<string>((resolve) => {
+          resolvers.push(resolve);
+        }),
+    );
+    const api = {
+      availability: vi.fn(async () => "available" as const),
+      create: vi.fn(async () => ({ summarize: methodSpy })),
+    };
+    (globalThis as { Summarizer?: typeof api }).Summarizer = api;
+
+    const { result, rerender } = renderHook(
+      ({ input }: { input: string }) =>
+        useSummarizer({ language: "en", input }),
+      { initialProps: { input: "A" } },
+    );
+    await waitFor(() => expect(resolvers).toHaveLength(1));
+
+    rerender({ input: "B" });
+    await waitFor(() => expect(resolvers).toHaveLength(2));
+
+    await act(async () => {
+      resolvers[0]?.("stale-A");
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(result.current.output).not.toBe("stale-A");
+
+    await act(async () => {
+      resolvers[1]?.("fresh-B");
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    await waitFor(() => expect(result.current.status).toBe("done"));
+    expect(result.current.output).toBe("fresh-B");
+  });
 });

--- a/packages/translator/src/index.test.ts
+++ b/packages/translator/src/index.test.ts
@@ -425,4 +425,93 @@ describe("translate", () => {
     >;
     expect(createArgs.targetLanguage).toBe("en");
   });
+
+  it('honors cache: "session" via sessionStorage', async () => {
+    const store = new Map<string, string>();
+    const storage = {
+      getItem: vi.fn((k: string) => store.get(k) ?? null),
+      setItem: vi.fn((k: string, v: string) => {
+        store.set(k, v);
+      }),
+    };
+    vi.stubGlobal("sessionStorage", storage);
+    try {
+      const { api } = installFakeTranslator();
+      const first = await translate({
+        input: "Olá",
+        sourceLanguage: "pt",
+        targetLanguage: "en",
+        cache: "session",
+        cacheKey: "k",
+      });
+      expect(first).toEqual({ output: "[t]Olá", cached: false });
+      expect(storage.setItem).toHaveBeenCalledWith("translator:k", "[t]Olá");
+
+      const createsAfterFirst = api.create.mock.calls.length;
+      const second = await translate({
+        input: "Olá",
+        sourceLanguage: "pt",
+        targetLanguage: "en",
+        cache: "session",
+        cacheKey: "k",
+      });
+      expect(second).toEqual({ output: "[t]Olá", cached: true });
+      expect(api.create).toHaveBeenCalledTimes(createsAfterFirst);
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+
+  it('honors cache: "local" via localStorage', async () => {
+    const store = new Map<string, string>();
+    const storage = {
+      getItem: vi.fn((k: string) => store.get(k) ?? null),
+      setItem: vi.fn((k: string, v: string) => {
+        store.set(k, v);
+      }),
+    };
+    vi.stubGlobal("localStorage", storage);
+    try {
+      const { api } = installFakeTranslator();
+      const first = await translate({
+        input: "Olá",
+        sourceLanguage: "pt",
+        targetLanguage: "en",
+        cache: "local",
+        cacheKey: "k",
+      });
+      expect(first).toEqual({ output: "[t]Olá", cached: false });
+      expect(storage.setItem).toHaveBeenCalledWith("translator:k", "[t]Olá");
+
+      const createsAfterFirst = api.create.mock.calls.length;
+      const second = await translate({
+        input: "Olá",
+        sourceLanguage: "pt",
+        targetLanguage: "en",
+        cache: "local",
+        cacheKey: "k",
+      });
+      expect(second).toEqual({ output: "[t]Olá", cached: true });
+      expect(api.create).toHaveBeenCalledTimes(createsAfterFirst);
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+
+  it("aborts without writing the cache", async () => {
+    installFakeTranslator();
+    const cache = { get: vi.fn(() => null), set: vi.fn() };
+    const controller = new AbortController();
+    controller.abort();
+    await expect(
+      translate({
+        input: "Olá",
+        sourceLanguage: "pt",
+        targetLanguage: "en",
+        cache,
+        signal: controller.signal,
+      }),
+    ).rejects.toMatchObject({ name: "AbortError" });
+    expect(cache.set).not.toHaveBeenCalled();
+  });
 });

--- a/packages/translator/src/react/index.test.tsx
+++ b/packages/translator/src/react/index.test.tsx
@@ -1,4 +1,4 @@
-import { renderHook, waitFor } from "@testing-library/react";
+import { act, renderHook, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { __clearSessionCacheForTests } from "../api.js";
 import { useTranslator } from "./index.js";
@@ -116,5 +116,45 @@ describe("useTranslator", () => {
     );
     await waitFor(() => expect(result.current.status).toBe("done"));
     expect(result.current.output).toBeNull();
+  });
+
+  it("discards a stale request when input changes (cleanup aborts the prior run)", async () => {
+    const resolvers: Array<(out: string) => void> = [];
+    const methodSpy = vi.fn(
+      () =>
+        new Promise<string>((resolve) => {
+          resolvers.push(resolve);
+        }),
+    );
+    const api = {
+      availability: vi.fn(async () => "available" as const),
+      create: vi.fn(async () => ({ translate: methodSpy })),
+    };
+    (globalThis as { Translator?: typeof api }).Translator = api;
+
+    const { result, rerender } = renderHook(
+      ({ input }: { input: string }) =>
+        useTranslator({ input, sourceLanguage: "pt", targetLanguage: "en" }),
+      { initialProps: { input: "A" } },
+    );
+    await waitFor(() => expect(resolvers).toHaveLength(1));
+
+    rerender({ input: "B" });
+    await waitFor(() => expect(resolvers).toHaveLength(2));
+
+    await act(async () => {
+      resolvers[0]?.("stale-A");
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(result.current.output).not.toBe("stale-A");
+
+    await act(async () => {
+      resolvers[1]?.("fresh-B");
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    await waitFor(() => expect(result.current.status).toBe("done"));
+    expect(result.current.output).toBe("fresh-B");
   });
 });

--- a/packages/writer/src/index.test.ts
+++ b/packages/writer/src/index.test.ts
@@ -293,4 +293,79 @@ describe("write", () => {
       }),
     ).rejects.toMatchObject({ name: "AbortError" });
   });
+
+  it('honors cache: "session" via sessionStorage', async () => {
+    const store = new Map<string, string>();
+    const storage = {
+      getItem: vi.fn((k: string) => store.get(k) ?? null),
+      setItem: vi.fn((k: string, v: string) => {
+        store.set(k, v);
+      }),
+    };
+    vi.stubGlobal("sessionStorage", storage);
+    try {
+      const api = installFakeWriter({ output: "Stored." });
+      const first = await write({
+        input: "task",
+        cache: "session",
+        cacheKey: "k",
+      });
+      expect(first).toEqual({ output: "Stored.", cached: false });
+      expect(storage.setItem).toHaveBeenCalledWith("writer:k", "Stored.");
+
+      const createsAfterFirst = api.create.mock.calls.length;
+      const second = await write({
+        input: "task",
+        cache: "session",
+        cacheKey: "k",
+      });
+      expect(second).toEqual({ output: "Stored.", cached: true });
+      expect(api.create).toHaveBeenCalledTimes(createsAfterFirst);
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+
+  it('honors cache: "local" via localStorage', async () => {
+    const store = new Map<string, string>();
+    const storage = {
+      getItem: vi.fn((k: string) => store.get(k) ?? null),
+      setItem: vi.fn((k: string, v: string) => {
+        store.set(k, v);
+      }),
+    };
+    vi.stubGlobal("localStorage", storage);
+    try {
+      const api = installFakeWriter({ output: "Stored." });
+      const first = await write({
+        input: "task",
+        cache: "local",
+        cacheKey: "k",
+      });
+      expect(first).toEqual({ output: "Stored.", cached: false });
+      expect(storage.setItem).toHaveBeenCalledWith("writer:k", "Stored.");
+
+      const createsAfterFirst = api.create.mock.calls.length;
+      const second = await write({
+        input: "task",
+        cache: "local",
+        cacheKey: "k",
+      });
+      expect(second).toEqual({ output: "Stored.", cached: true });
+      expect(api.create).toHaveBeenCalledTimes(createsAfterFirst);
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+
+  it("aborts without writing the cache", async () => {
+    installFakeWriter({ output: "..." });
+    const cache = { get: vi.fn(() => null), set: vi.fn() };
+    const controller = new AbortController();
+    controller.abort();
+    await expect(
+      write({ input: "task", cache, signal: controller.signal }),
+    ).rejects.toMatchObject({ name: "AbortError" });
+    expect(cache.set).not.toHaveBeenCalled();
+  });
 });

--- a/packages/writer/src/react/index.test.tsx
+++ b/packages/writer/src/react/index.test.tsx
@@ -1,4 +1,4 @@
-import { renderHook, waitFor } from "@testing-library/react";
+import { act, renderHook, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { __clearSessionCacheForTests } from "../api.js";
 import { useWriter } from "./index.js";
@@ -88,5 +88,44 @@ describe("useWriter", () => {
     result.current.dismiss();
     await waitFor(() => expect(result.current.status).toBe("unavailable"));
     expect(result.current.output).toBeNull();
+  });
+
+  it("discards a stale request when input changes (cleanup aborts the prior run)", async () => {
+    const resolvers: Array<(out: string) => void> = [];
+    const methodSpy = vi.fn(
+      () =>
+        new Promise<string>((resolve) => {
+          resolvers.push(resolve);
+        }),
+    );
+    const api = {
+      availability: vi.fn(async () => "available"),
+      create: vi.fn(async () => ({ write: methodSpy })),
+    };
+    (globalThis as { Writer?: typeof api }).Writer = api;
+
+    const { result, rerender } = renderHook(
+      ({ input }: { input: string }) => useWriter({ input }),
+      { initialProps: { input: "A" } },
+    );
+    await waitFor(() => expect(resolvers).toHaveLength(1));
+
+    rerender({ input: "B" });
+    await waitFor(() => expect(resolvers).toHaveLength(2));
+
+    await act(async () => {
+      resolvers[0]?.("stale-A");
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(result.current.output).not.toBe("stale-A");
+
+    await act(async () => {
+      resolvers[1]?.("fresh-B");
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    await waitFor(() => expect(result.current.status).toBe("done"));
+    expect(result.current.output).toBe("fresh-B");
   });
 });


### PR DESCRIPTION
## Summary
Closes the three test-coverage gaps across all seven API-wrapper packages. **Tests only — no source/behavior changes.** `pnpm gate` green; +44 tests.

## What's covered
- **`cache: "session" | "local"` shortcuts** (7 packages × both modes): assert the storage backend receives the per-package prefixed key, and a second identical call returns `cached: true` without re-invoking `create`.
- **Abort does not write the cache** (7 one-shot helpers): spy `cache.set` is not called on abort; plus mid-stream variants for `prompt` and `summarizer`.
- **React hook cleanup** (6 non-prompt hooks): prove a stale request is discarded when a primitive dep changes (non-vacuous — each test fails if the effect's `controller.abort()` cleanup is removed).

## Notes
- All six non-prompt hooks (`useSummarizer`, `useWriter`, `useRewriter`, `useProofreader`, `useTranslator`, `useDetector`) are session-less — each manages an internal `AbortController`, so the cleanup assertion is abort-on-deps-change rather than `destroy()`.

## Verification
- `pnpm gate` → exit 0
- Deltas: prompt 78→82, summarizer 39→44, writer 26→30, rewriter 22→26, proofreader 26→30, translator 31→35, detector 31→35
