### PR TITLE
feat(site): add Organization entity + sameAs to JSON-LD

### DIFF
--- a/apps/site/src/features/docs/components/Head.astro
+++ b/apps/site/src/features/docs/components/Head.astro
@@ -33,11 +33,16 @@ const ld = {
     "@type": "Person",
     name: "Beto Muniz",
     url: "https://github.com/obetomuniz",
+    sameAs: ["https://github.com/obetomuniz", "https://betomuniz.com"],
   },
   publisher: {
     "@type": "Organization",
     name: "web-ai-sdk",
     url: "https://web-ai-sdk.dev/",
+    sameAs: [
+      "https://github.com/obetomuniz/web-ai-sdk",
+      "https://www.npmjs.com/org/web-ai-sdk",
+    ],
   },
   isPartOf: {
     "@type": "WebSite",

--- a/apps/site/src/pages/index.astro
+++ b/apps/site/src/pages/index.astro
@@ -49,6 +49,15 @@ const structuredData = {
   "@context": "https://schema.org",
   "@graph": [
     {
+      "@type": "Organization",
+      "@id": "https://web-ai-sdk.dev/#org",
+      name: "web-ai-sdk",
+      url: CANONICAL_URL,
+      description:
+        "web-ai-sdk is a TypeScript SDK for the Web's Built-in AI APIs: Prompt, Writer, Rewriter, Proofreader, Translator, Summarizer, Language Detector, and WebMCP.",
+      sameAs: [repoUrl, npmOrgUrl, "https://github.com/obetomuniz"],
+    },
+    {
       "@type": "WebSite",
       "@id": "https://web-ai-sdk.dev/#website",
       name: "web-ai-sdk",
@@ -73,7 +82,9 @@ const structuredData = {
         "@type": "Person",
         name: "Beto Muniz",
         url: "https://github.com/obetomuniz",
+        sameAs: ["https://github.com/obetomuniz", authorUrl],
       },
+      publisher: { "@id": "https://web-ai-sdk.dev/#org" },
       mainEntityOfPage: { "@id": "https://web-ai-sdk.dev/#website" },
     },
     {
@@ -93,7 +104,9 @@ const structuredData = {
         "@type": "Person",
         name: "Beto Muniz",
         url: "https://github.com/obetomuniz",
+        sameAs: ["https://github.com/obetomuniz", authorUrl],
       },
+      publisher: { "@id": "https://web-ai-sdk.dev/#org" },
       offers: {
         "@type": "Offer",
         price: "0",


### PR DESCRIPTION
## Summary
The homepage ships a rich JSON-LD `@graph` and each docs page ships a `TechArticle`, but none declares an `Organization` with `sameAs` — the one schema.org addition with credible value for AI answer-engine entity clarity. Without it, `web-ai-sdk` is easily conflated with the generic "AI SDK" (Vercel); `sameAs` linking the canonical off-site identities (GitHub repo, npm org, author) is what answer engines use to disambiguate and attribute the brand. Broader schema expansion is deliberately out of scope — controlled tests show added schema volume doesn't move AI citations.

## Changes
- `apps/site/src/pages/index.astro` — new `Organization` node as the first entry in the homepage `@graph` (`@id …/#org`, reuses the existing `CANONICAL_URL`/`repoUrl`/`npmOrgUrl` consts; `description` copied verbatim from `SoftwareSourceCode.description`); `author.sameAs` + `publisher: { "@id": "…/#org" }` added to both the `SoftwareSourceCode` and `SoftwareApplication` nodes.
- `apps/site/src/features/docs/components/Head.astro` — `sameAs` added to the `author` Person and the `publisher` Organization in the per-doc `TechArticle`.

## Verification
- `pnpm gate` (lint, build, typecheck, test) — green.
- Homepage `ld+json` parses as valid JSON; `@graph` order is `[Organization, WebSite, SoftwareSourceCode, SoftwareApplication, FAQPage]`.
- Built `apps/site/dist/index.html` contains the `Organization` node; both software nodes carry `publisher: { "@id": "…/#org" }`; `Organization.sameAs` resolves to the repo, npm org, and author profile URLs.
- Scope audit: only `Organization` is a new `@type` — no schema-type bloat.
