### PR TITLE
feat(prompt): forward download monitor on createSession() and useSession()

### DIFF
--- a/.changeset/011-session-monitor.md
+++ b/.changeset/011-session-monitor.md
@@ -1,0 +1,8 @@
+---
+"@web-ai-sdk/prompt": minor
+---
+
+Add `monitor` option to `createSession()` and `useSession()`, forwarding the
+first-call download-progress callback to `LanguageModel.create()` — the same
+parity `ask()` already has. When both top-level `monitor` and
+`createOptions.monitor` are set, the top-level one wins.

--- a/apps/site/src/content/docs/packages/prompt.md
+++ b/apps/site/src/content/docs/packages/prompt.md
@@ -190,6 +190,7 @@ interface CreateSessionOptions {
   expectedInputs?: LanguageModelExpectedInput[];
   expectedOutputs?: LanguageModelExpectedOutput[];
   tools?: LanguageModelTool[]; // experimental: native function-calling passthrough
+  monitor?: (m: CreateMonitor) => void;     // observe first-call model download; wins over createOptions.monitor
   // Pass `initialPrompts` here to seed multi-turn context.
   createOptions?: Partial<LanguageModelCreateOptions>;
 }

--- a/packages/prompt/README.md
+++ b/packages/prompt/README.md
@@ -183,6 +183,7 @@ interface CreateSessionOptions {
   expectedInputs?: LanguageModelExpectedInput[];
   expectedOutputs?: LanguageModelExpectedOutput[];
   tools?: LanguageModelTool[]; // experimental: native function-calling passthrough
+  monitor?: (m: CreateMonitor) => void;     // observe first-call model download; wins over createOptions.monitor
   // Pass `initialPrompts` here to seed multi-turn context.
   createOptions?: Partial<LanguageModelCreateOptions>;
 }

--- a/packages/prompt/src/index.test.ts
+++ b/packages/prompt/src/index.test.ts
@@ -967,6 +967,32 @@ describe("createSession", () => {
     session.destroy();
   });
 
+  it("forwards monitor to the underlying LanguageModel.create()", async () => {
+    const fake = installFakeLanguageModel({ response: "ok" });
+    const monitor = vi.fn();
+    const session = createSession({ systemPrompt: "S", monitor });
+    await session.send("warm");
+    const createOpts = fake.create.mock.calls[0]?.[0];
+    expect(createOpts).toMatchObject({ monitor });
+    session.destroy();
+  });
+
+  it("top-level monitor wins over createOptions.monitor", async () => {
+    const fake = installFakeLanguageModel({ response: "ok" });
+    const top = vi.fn();
+    const inner = vi.fn();
+    const session = createSession({
+      systemPrompt: "S",
+      monitor: top,
+      createOptions: { monitor: inner },
+    });
+    await session.send("warm");
+    const createOpts = fake.create.mock.calls[0]?.[0];
+    expect(createOpts).toMatchObject({ monitor: top });
+    expect(createOpts).not.toMatchObject({ monitor: inner });
+    session.destroy();
+  });
+
   it("rejects createSession options that mix semantic and raw sampling", () => {
     installFakeLanguageModel({ response: "ok" });
     expect(() =>

--- a/packages/prompt/src/react/index.test.tsx
+++ b/packages/prompt/src/react/index.test.tsx
@@ -250,4 +250,15 @@ describe("useSession", () => {
     rerender({ samplingMode: "creative" });
     expect(api.create).toHaveBeenCalledTimes(2);
   });
+
+  it("forwards monitor onto the LanguageModel.create() call", async () => {
+    const api = installFakeLanguageModel();
+    const monitor = vi.fn();
+    const { result } = renderHook(() =>
+      useSession({ systemPrompt: "S", monitor }),
+    );
+    await waitFor(() => expect(result.current.status).toBe("ready"));
+    const createOpts = api.create.mock.calls[0]?.[0];
+    expect(createOpts).toMatchObject({ monitor });
+  });
 });

--- a/packages/prompt/src/react/index.ts
+++ b/packages/prompt/src/react/index.ts
@@ -152,7 +152,7 @@ export interface UseSessionReturn {
  * sampling, and lifecycle — `abort()` / `destroy()` on one component's
  * session never touch another's — and the session is destroyed on unmount
  * or when any primitive option (`systemPrompt`, `samplingMode`,
- * `temperature`, `topK`, `language`, `enabled`) changes.
+ * `temperature`, `topK`, `language`, `enabled`, `monitor`) changes.
  *
  * Token-level interleaving across sessions is browser-defined: the
  * underlying on-device model is single-instance, so Chrome 148 / Edge 138
@@ -183,6 +183,7 @@ export const useSession = (
     expectedInputs,
     expectedOutputs,
     tools,
+    monitor,
     createOptions,
   } = options;
 
@@ -216,6 +217,7 @@ export const useSession = (
         expectedInputs,
         expectedOutputs,
         tools,
+        monitor,
         createOptions,
       });
       session = created.session;
@@ -261,6 +263,7 @@ export const useSession = (
     expectedInputs,
     expectedOutputs,
     tools,
+    monitor,
     createOptions,
   ]);
 

--- a/packages/prompt/src/session.ts
+++ b/packages/prompt/src/session.ts
@@ -17,6 +17,7 @@
  */
 
 import {
+  type CreateMonitor,
   getLanguageModelApi,
   type LanguageModelApi,
   type LanguageModelCreateOptions,
@@ -181,6 +182,12 @@ export interface CreateSessionOptions {
    */
   tools?: LanguageModelTool[];
   /**
+   * Observe the first-call model download (~1.7 GB on a fresh profile).
+   * Forwarded to `LanguageModel.create()`. When both this and
+   * `createOptions.monitor` are set, the top-level `monitor` wins.
+   */
+  monitor?: (m: CreateMonitor) => void;
+  /**
    * Override `LanguageModel.create()` options entirely. Merged on top of
    * defaults. Pass `initialPrompts` here to seed multi-turn context (e.g.
    * restoring a conversation from storage).
@@ -311,6 +318,7 @@ const buildCreateOptions = (
         : {}),
     ...(options.tools ? { tools: options.tools } : {}),
     ...options.createOptions,
+    ...(options.monitor ? { monitor: options.monitor } : {}),
   };
 };
 


### PR DESCRIPTION
## What

Chat-shaped apps using `createSession()` with custom personas pay the same cold-start model download (~1.7 GB on a fresh profile) as one-shot `ask()`, but `createSession()` had no `monitor` hook for download-progress UI. This closes that parity gap.

## Changes

- `CreateSessionOptions.monitor` — new option, forwarded to `LanguageModel.create()`.
- Forwarding happens in `buildCreateOptions` **after** the `...options.createOptions` spread, so an explicit top-level `monitor` wins over `createOptions.monitor` (documented precedence).
- `useSession()` threads `monitor` through destructure → `createSessionWithReady` → effect deps, and the jsdoc recreate-options list.
- README + checked-in docs mirror (`apps/site/.../prompt.md`) updated; kept in sync via `docs:sync`.

## Why after `...options.createOptions`

`buildCreateOptions` spreads `createOptions` last, so any field added before it would be silently overridden. `ask()`'s equivalent has no `createOptions` passthrough so it doesn't hit this trap — the placement differs on purpose. A dedicated test asserts top-level wins.

## Verification

- `pnpm --filter @web-ai-sdk/prompt test` → 85 passed
- `pnpm gate` → exit 0 (lint + build + typecheck + test)
- New tests: vanilla forwarding + precedence ordering, plus a React `useSession` forwarding test.
