### PR TITLE
feat(prompt): widen Session.send/sendStreaming to message arrays + prefix support

### DIFF
--- a/.changeset/prefill-message-arrays.md
+++ b/.changeset/prefill-message-arrays.md
@@ -1,0 +1,5 @@
+---
+"@web-ai-sdk/prompt": minor
+---
+
+Widen `Session.send` / `sendStreaming` to accept `string | LanguageModelMessage[]`. Add optional `prefix?: boolean` to `LanguageModelMessage` for assistant prefill (spec-canonical on the trailing assistant message). The empty-input guard now handles both shapes. Backward-compatible: existing string calls and the React hook are unchanged.

--- a/apps/site/src/content/docs/guides/prompt.mdx
+++ b/apps/site/src/content/docs/guides/prompt.mdx
@@ -146,6 +146,39 @@ const plan = await session.send("Based on that, suggest an outfit.");
 
 `append()` throws `SessionDestroyedError` if the session is destroyed and `PromptUnavailableError` if the browser instance doesn't support `append()`. Aborts reject with `PromptAbortError`.
 
+## Prefill and message arrays
+
+`Session.send` / `sendStreaming` accept either a single string turn or a full `LanguageModelMessage[]`. Passing an array lets you supply multi-message context, control roles per turn, and — most usefully — **prefill** the assistant's reply: set `prefix: true` on the trailing `assistant` message and the model treats its `content` as the start of its own answer rather than a turn to respond to.
+
+```ts
+const session = createSession({ systemPrompt });
+
+// Multi-message turn: full conversation context, roles per message.
+const reply = await session.send([
+  { role: "user", content: "What is RAG?" },
+  { role: "assistant", content: "Retrieval-Augmented Generation." },
+  { role: "user", content: "Give me the three-step recipe." },
+]);
+
+// Prefill: bias the model toward JSON without a full schema.
+const json = await session.send([
+  { role: "user", content: "Describe a cat in one word of JSON." },
+  { role: "assistant", content: '{"thought":"', prefix: true },
+]);
+// model completes: feline"}  ->  you parse {"thought":"feline"}
+```
+
+**Prefill vs `responseConstraint`** — both shape output, different trade-offs:
+
+- **Prefill** (`prefix: true`): cheaper per turn (no schema inlined into context), weaker guarantee — the model may drift off the prefixed format. Good for cheap nudges and structured-output hints that you parse defensively.
+- **`responseConstraint`**: enforced JSON Schema (the runtime validates against it), higher per-turn token cost when the schema is large. Use `omitResponseConstraintInput: true` to drop the inlined schema and keep only the enforced constraint.
+
+They compose: prefill the opening brace, set `responseConstraint` for the full shape.
+
+**Spec rule:** `prefix: true` is only valid on the **trailing** `assistant` message. Anywhere else (a non-final message, a non-assistant role) the browser throws a `"SyntaxError"` `DOMException` — the SDK does **not** catch this, so it propagates to your `send` / `sendStreaming` caller.
+
+> **Note on `content`:** `LanguageModelMessage.content` is currently `string` only. Multimodal `ContentPart[]` content (images, audio) is tracked as a future enhancement; no timeline is promised.
+
 ## Context-window introspection
 
 `Session` surfaces the live token budget the native instance reports, so consumers can size work to the real context window instead of hardcoding a char cap (the exact bypass — reaching past the SDK to `globalThis.LanguageModel` — that this avoids):

--- a/apps/site/src/content/docs/guides/prompt.mdx
+++ b/apps/site/src/content/docs/guides/prompt.mdx
@@ -148,7 +148,7 @@ const plan = await session.send("Based on that, suggest an outfit.");
 
 ## Prefill and message arrays
 
-`Session.send` / `sendStreaming` accept either a single string turn or a full `LanguageModelMessage[]`. Passing an array lets you supply multi-message context, control roles per turn, and — most usefully — **prefill** the assistant's reply: set `prefix: true` on the trailing `assistant` message and the model treats its `content` as the start of its own answer rather than a turn to respond to.
+`Session.send` / `sendStreaming` accept either a single string turn or a full `LanguageModelMessage[]`. Passing an array lets you supply multi-message context, control roles per turn, and, most usefully, **prefill** the assistant's reply: set `prefix: true` on the trailing `assistant` message and the model treats its `content` as the start of its own answer rather than a turn to respond to.
 
 ```ts
 const session = createSession({ systemPrompt });
@@ -168,14 +168,14 @@ const json = await session.send([
 // model completes: feline"}  ->  you parse {"thought":"feline"}
 ```
 
-**Prefill vs `responseConstraint`** — both shape output, different trade-offs:
+**Prefill vs `responseConstraint`**: both shape output, different trade-offs:
 
-- **Prefill** (`prefix: true`): cheaper per turn (no schema inlined into context), weaker guarantee — the model may drift off the prefixed format. Good for cheap nudges and structured-output hints that you parse defensively.
+- **Prefill** (`prefix: true`): cheaper per turn (no schema inlined into context), weaker guarantee; the model may drift off the prefixed format. Good for cheap nudges and structured-output hints that you parse defensively.
 - **`responseConstraint`**: enforced JSON Schema (the runtime validates against it), higher per-turn token cost when the schema is large. Use `omitResponseConstraintInput: true` to drop the inlined schema and keep only the enforced constraint.
 
 They compose: prefill the opening brace, set `responseConstraint` for the full shape.
 
-**Spec rule:** `prefix: true` is only valid on the **trailing** `assistant` message. Anywhere else (a non-final message, a non-assistant role) the browser throws a `"SyntaxError"` `DOMException` — the SDK does **not** catch this, so it propagates to your `send` / `sendStreaming` caller.
+**Spec rule:** `prefix: true` is only valid on the **trailing** `assistant` message. Anywhere else (a non-final message, a non-assistant role) the browser throws a `"SyntaxError"` `DOMException`. The SDK does **not** catch this, so it propagates to your `send` / `sendStreaming` caller.
 
 > **Note on `content`:** `LanguageModelMessage.content` is currently `string` only. Multimodal `ContentPart[]` content (images, audio) is tracked as a future enhancement; no timeline is promised.
 

--- a/apps/site/src/content/docs/packages/prompt.md
+++ b/apps/site/src/content/docs/packages/prompt.md
@@ -204,8 +204,8 @@ interface Session {
   readonly destroyed: boolean;
   readonly contextWindow?: number; // context window in tokens; undefined pre-creation
   readonly contextUsage?: number;  // tokens used so far; undefined pre-creation
-  send(input: string, options?: SessionSendOptions): Promise<string | null>;
-  sendStreaming(input: string, options?: SessionSendOptions): AsyncIterable<string>;
+  send(input: string | LanguageModelMessage[], options?: SessionSendOptions): Promise<string | null>;
+  sendStreaming(input: string | LanguageModelMessage[], options?: SessionSendOptions): AsyncIterable<string>;
   abort(): void;
   clone(options?: { signal?: AbortSignal }): Promise<Session>;
   append(messages: LanguageModelMessage[], options?: { signal?: AbortSignal }): Promise<void>; // context without a turn
@@ -284,6 +284,39 @@ const plan = await session.send("Based on that, suggest an outfit.");
 ```
 
 `append()` throws `SessionDestroyedError` if the session is destroyed and `PromptUnavailableError` if the browser instance doesn't support `append()`. Aborts reject with `PromptAbortError`.
+
+### Prefill and message arrays
+
+`Session.send` / `sendStreaming` accept either a single string turn or a full `LanguageModelMessage[]`. Passing an array lets you supply multi-message context, control roles per turn, and — most usefully — **prefill** the assistant's reply: set `prefix: true` on the trailing `assistant` message and the model treats its `content` as the start of its own answer rather than a turn to respond to.
+
+```ts
+const session = createSession({ systemPrompt });
+
+// Multi-message turn: full conversation context, roles per message.
+const reply = await session.send([
+  { role: "user", content: "What is RAG?" },
+  { role: "assistant", content: "Retrieval-Augmented Generation." },
+  { role: "user", content: "Give me the three-step recipe." },
+]);
+
+// Prefill: bias the model toward JSON without a full schema.
+const json = await session.send([
+  { role: "user", content: "Describe a cat in one word of JSON." },
+  { role: "assistant", content: '{"thought":"', prefix: true },
+]);
+// model completes: feline"}  ->  you parse {"thought":"feline"}
+```
+
+**Prefill vs `responseConstraint`** — both shape output, different trade-offs:
+
+- **Prefill** (`prefix: true`): cheaper per turn (no schema inlined into context), weaker guarantee — the model may drift off the prefixed format. Good for cheap nudges and structured-output hints that you parse defensively.
+- **`responseConstraint`**: enforced JSON Schema (the runtime validates against it), higher per-turn token cost when the schema is large. Use `omitResponseConstraintInput: true` to drop the inlined schema and keep only the enforced constraint.
+
+They compose: prefill the opening brace, set `responseConstraint` for the full shape.
+
+**Spec rule:** `prefix: true` is only valid on the **trailing** `assistant` message. Anywhere else (a non-final message, a non-assistant role) the browser throws a `"SyntaxError"` `DOMException` — the SDK does **not** catch this, so it propagates to your `send` / `sendStreaming` caller.
+
+> **Note on `content`:** `LanguageModelMessage.content` is currently `string` only. Multimodal `ContentPart[]` content (images, audio) is tracked as a future enhancement; no timeline is promised.
 
 ### Context-window introspection
 

--- a/apps/site/src/content/docs/packages/prompt.md
+++ b/apps/site/src/content/docs/packages/prompt.md
@@ -287,7 +287,7 @@ const plan = await session.send("Based on that, suggest an outfit.");
 
 ### Prefill and message arrays
 
-`Session.send` / `sendStreaming` accept either a single string turn or a full `LanguageModelMessage[]`. Passing an array lets you supply multi-message context, control roles per turn, and — most usefully — **prefill** the assistant's reply: set `prefix: true` on the trailing `assistant` message and the model treats its `content` as the start of its own answer rather than a turn to respond to.
+`Session.send` / `sendStreaming` accept either a single string turn or a full `LanguageModelMessage[]`. Passing an array lets you supply multi-message context, control roles per turn, and, most usefully, **prefill** the assistant's reply: set `prefix: true` on the trailing `assistant` message and the model treats its `content` as the start of its own answer rather than a turn to respond to.
 
 ```ts
 const session = createSession({ systemPrompt });
@@ -307,14 +307,14 @@ const json = await session.send([
 // model completes: feline"}  ->  you parse {"thought":"feline"}
 ```
 
-**Prefill vs `responseConstraint`** — both shape output, different trade-offs:
+**Prefill vs `responseConstraint`**: both shape output, different trade-offs:
 
-- **Prefill** (`prefix: true`): cheaper per turn (no schema inlined into context), weaker guarantee — the model may drift off the prefixed format. Good for cheap nudges and structured-output hints that you parse defensively.
+- **Prefill** (`prefix: true`): cheaper per turn (no schema inlined into context), weaker guarantee; the model may drift off the prefixed format. Good for cheap nudges and structured-output hints that you parse defensively.
 - **`responseConstraint`**: enforced JSON Schema (the runtime validates against it), higher per-turn token cost when the schema is large. Use `omitResponseConstraintInput: true` to drop the inlined schema and keep only the enforced constraint.
 
 They compose: prefill the opening brace, set `responseConstraint` for the full shape.
 
-**Spec rule:** `prefix: true` is only valid on the **trailing** `assistant` message. Anywhere else (a non-final message, a non-assistant role) the browser throws a `"SyntaxError"` `DOMException` — the SDK does **not** catch this, so it propagates to your `send` / `sendStreaming` caller.
+**Spec rule:** `prefix: true` is only valid on the **trailing** `assistant` message. Anywhere else (a non-final message, a non-assistant role) the browser throws a `"SyntaxError"` `DOMException`. The SDK does **not** catch this, so it propagates to your `send` / `sendStreaming` caller.
 
 > **Note on `content`:** `LanguageModelMessage.content` is currently `string` only. Multimodal `ContentPart[]` content (images, audio) is tracked as a future enhancement; no timeline is promised.
 

--- a/packages/prompt/README.md
+++ b/packages/prompt/README.md
@@ -197,8 +197,8 @@ interface Session {
   readonly destroyed: boolean;
   readonly contextWindow?: number; // context window in tokens; undefined pre-creation
   readonly contextUsage?: number;  // tokens used so far; undefined pre-creation
-  send(input: string, options?: SessionSendOptions): Promise<string | null>;
-  sendStreaming(input: string, options?: SessionSendOptions): AsyncIterable<string>;
+  send(input: string | LanguageModelMessage[], options?: SessionSendOptions): Promise<string | null>;
+  sendStreaming(input: string | LanguageModelMessage[], options?: SessionSendOptions): AsyncIterable<string>;
   abort(): void;
   clone(options?: { signal?: AbortSignal }): Promise<Session>;
   append(messages: LanguageModelMessage[], options?: { signal?: AbortSignal }): Promise<void>; // context without a turn
@@ -277,6 +277,39 @@ const plan = await session.send("Based on that, suggest an outfit.");
 ```
 
 `append()` throws `SessionDestroyedError` if the session is destroyed and `PromptUnavailableError` if the browser instance doesn't support `append()`. Aborts reject with `PromptAbortError`.
+
+### Prefill and message arrays
+
+`Session.send` / `sendStreaming` accept either a single string turn or a full `LanguageModelMessage[]`. Passing an array lets you supply multi-message context, control roles per turn, and — most usefully — **prefill** the assistant's reply: set `prefix: true` on the trailing `assistant` message and the model treats its `content` as the start of its own answer rather than a turn to respond to.
+
+```ts
+const session = createSession({ systemPrompt });
+
+// Multi-message turn: full conversation context, roles per message.
+const reply = await session.send([
+  { role: "user", content: "What is RAG?" },
+  { role: "assistant", content: "Retrieval-Augmented Generation." },
+  { role: "user", content: "Give me the three-step recipe." },
+]);
+
+// Prefill: bias the model toward JSON without a full schema.
+const json = await session.send([
+  { role: "user", content: "Describe a cat in one word of JSON." },
+  { role: "assistant", content: '{"thought":"', prefix: true },
+]);
+// model completes: feline"}  ->  you parse {"thought":"feline"}
+```
+
+**Prefill vs `responseConstraint`** — both shape output, different trade-offs:
+
+- **Prefill** (`prefix: true`): cheaper per turn (no schema inlined into context), weaker guarantee — the model may drift off the prefixed format. Good for cheap nudges and structured-output hints that you parse defensively.
+- **`responseConstraint`**: enforced JSON Schema (the runtime validates against it), higher per-turn token cost when the schema is large. Use `omitResponseConstraintInput: true` to drop the inlined schema and keep only the enforced constraint.
+
+They compose: prefill the opening brace, set `responseConstraint` for the full shape.
+
+**Spec rule:** `prefix: true` is only valid on the **trailing** `assistant` message. Anywhere else (a non-final message, a non-assistant role) the browser throws a `"SyntaxError"` `DOMException` — the SDK does **not** catch this, so it propagates to your `send` / `sendStreaming` caller.
+
+> **Note on `content`:** `LanguageModelMessage.content` is currently `string` only. Multimodal `ContentPart[]` content (images, audio) is tracked as a future enhancement; no timeline is promised.
 
 ### Context-window introspection
 

--- a/packages/prompt/README.md
+++ b/packages/prompt/README.md
@@ -280,7 +280,7 @@ const plan = await session.send("Based on that, suggest an outfit.");
 
 ### Prefill and message arrays
 
-`Session.send` / `sendStreaming` accept either a single string turn or a full `LanguageModelMessage[]`. Passing an array lets you supply multi-message context, control roles per turn, and — most usefully — **prefill** the assistant's reply: set `prefix: true` on the trailing `assistant` message and the model treats its `content` as the start of its own answer rather than a turn to respond to.
+`Session.send` / `sendStreaming` accept either a single string turn or a full `LanguageModelMessage[]`. Passing an array lets you supply multi-message context, control roles per turn, and, most usefully, **prefill** the assistant's reply: set `prefix: true` on the trailing `assistant` message and the model treats its `content` as the start of its own answer rather than a turn to respond to.
 
 ```ts
 const session = createSession({ systemPrompt });
@@ -300,14 +300,14 @@ const json = await session.send([
 // model completes: feline"}  ->  you parse {"thought":"feline"}
 ```
 
-**Prefill vs `responseConstraint`** — both shape output, different trade-offs:
+**Prefill vs `responseConstraint`**: both shape output, different trade-offs:
 
-- **Prefill** (`prefix: true`): cheaper per turn (no schema inlined into context), weaker guarantee — the model may drift off the prefixed format. Good for cheap nudges and structured-output hints that you parse defensively.
+- **Prefill** (`prefix: true`): cheaper per turn (no schema inlined into context), weaker guarantee; the model may drift off the prefixed format. Good for cheap nudges and structured-output hints that you parse defensively.
 - **`responseConstraint`**: enforced JSON Schema (the runtime validates against it), higher per-turn token cost when the schema is large. Use `omitResponseConstraintInput: true` to drop the inlined schema and keep only the enforced constraint.
 
 They compose: prefill the opening brace, set `responseConstraint` for the full shape.
 
-**Spec rule:** `prefix: true` is only valid on the **trailing** `assistant` message. Anywhere else (a non-final message, a non-assistant role) the browser throws a `"SyntaxError"` `DOMException` — the SDK does **not** catch this, so it propagates to your `send` / `sendStreaming` caller.
+**Spec rule:** `prefix: true` is only valid on the **trailing** `assistant` message. Anywhere else (a non-final message, a non-assistant role) the browser throws a `"SyntaxError"` `DOMException`. The SDK does **not** catch this, so it propagates to your `send` / `sendStreaming` caller.
 
 > **Note on `content`:** `LanguageModelMessage.content` is currently `string` only. Multimodal `ContentPart[]` content (images, audio) is tracked as a future enhancement; no timeline is promised.
 

--- a/packages/prompt/src/api.ts
+++ b/packages/prompt/src/api.ts
@@ -11,6 +11,15 @@ export type LanguageModelRole = "system" | "user" | "assistant";
 export interface LanguageModelMessage {
   role: LanguageModelRole;
   content: string;
+  /**
+   * When `true` on the trailing `assistant` message, the model treats
+   * `content` as a prefix to complete rather than a turn to respond to.
+   * Spec: only valid on the final `assistant`-role message; the browser
+   * throws a `"SyntaxError"` `DOMException` if used elsewhere. Use it to
+   * bias structured output (e.g. prefill `{"thought":"` for JSON) without
+   * inlining a full `responseConstraint` schema into context every turn.
+   */
+  prefix?: boolean;
 }
 
 export interface LanguageModelExpectedInput {

--- a/packages/prompt/src/index.test.ts
+++ b/packages/prompt/src/index.test.ts
@@ -1028,6 +1028,113 @@ describe("createSession", () => {
   });
 });
 
+describe("Session.send with message arrays", () => {
+  it("forwards a message array unchanged, preserving prefix:true on the trailing assistant message", async () => {
+    const fake = installFakeLanguageModel({ response: "ok" });
+    const session = createSession();
+    const messages = [
+      { role: "user" as const, content: "Return JSON." },
+      {
+        role: "assistant" as const,
+        content: '{"thought":"',
+        prefix: true,
+      },
+    ];
+    await session.send(messages);
+    expect(fake.promptSpy).toHaveBeenCalledTimes(1);
+    expect(fake.promptSpy.mock.calls[0]?.[0]).toEqual(messages);
+    session.destroy();
+  });
+
+  it("forwards a multi-message turn array as-is", async () => {
+    const fake = installFakeLanguageModel({ response: "ok" });
+    const session = createSession();
+    const messages = [
+      { role: "user" as const, content: "a" },
+      { role: "assistant" as const, content: "b" },
+      { role: "user" as const, content: "c" },
+    ];
+    await session.send(messages);
+    expect(fake.promptSpy.mock.calls[0]?.[0]).toEqual(messages);
+    session.destroy();
+  });
+
+  it("still accepts a plain string (regression)", async () => {
+    const fake = installFakeLanguageModel({ response: "ok" });
+    const session = createSession();
+    await session.send("ping");
+    expect(fake.promptSpy.mock.calls[0]?.[0]).toBe("ping");
+    session.destroy();
+  });
+
+  it("short-circuits an empty array without calling the model", async () => {
+    const fake = installFakeLanguageModel({ response: "ok" });
+    const session = createSession();
+    const result = await session.send([]);
+    expect(result).toBeNull();
+    expect(fake.promptSpy).not.toHaveBeenCalled();
+    session.destroy();
+  });
+
+  it("short-circuits an all-empty-content array without calling the model", async () => {
+    const fake = installFakeLanguageModel({ response: "ok" });
+    const session = createSession();
+    const result = await session.send([{ role: "user", content: "   " }]);
+    expect(result).toBeNull();
+    expect(fake.promptSpy).not.toHaveBeenCalled();
+    session.destroy();
+  });
+
+  it("sendStreaming forwards a prefill array and yields chunks", async () => {
+    const fake = installFakeLanguageModel({ chunks: ['"hi"', "}"] });
+    const session = createSession();
+    const messages = [
+      { role: "user" as const, content: "Return JSON." },
+      {
+        role: "assistant" as const,
+        content: '{"thought":"',
+        prefix: true,
+      },
+    ];
+    const deltas: string[] = [];
+    for await (const d of session.sendStreaming(messages)) {
+      deltas.push(d);
+    }
+    expect(deltas).toEqual(['"hi"', "}"]);
+    expect(fake.streamingSpy).not.toBeNull();
+    expect(fake.streamingSpy?.mock.calls[0]?.[0]).toEqual(messages);
+    session.destroy();
+  });
+
+  it("forwards a prefill array from a clone()d session", async () => {
+    const childPrompt = vi.fn(async (_input: unknown) => "child reply");
+    const cloneSpy = vi.fn(async () => ({
+      prompt: childPrompt,
+      destroy: vi.fn(),
+    }));
+    installFakeLanguageModel({
+      sessionFactory: () => ({
+        prompt: vi.fn(async () => "parent reply"),
+        destroy: vi.fn(),
+        clone: cloneSpy,
+      }),
+    });
+    const base = createSession({ systemPrompt: "S" });
+    await base.send("warm");
+    const turn = await base.clone();
+    const messages = [
+      { role: "user" as const, content: "go" },
+      { role: "assistant" as const, content: "{", prefix: true },
+    ];
+    const result = await turn.send(messages);
+    expect(result).toBe("child reply");
+    expect(childPrompt).toHaveBeenCalledTimes(1);
+    expect(childPrompt.mock.calls[0]?.[0]).toEqual(messages);
+    turn.destroy();
+    base.destroy();
+  });
+});
+
 describe("Session.clone", () => {
   it("forks via the native instance.clone() and the clone works independently", async () => {
     const parentDestroy = vi.fn();

--- a/packages/prompt/src/session.ts
+++ b/packages/prompt/src/session.ts
@@ -204,14 +204,23 @@ export interface SessionSendOptions {
 export interface Session {
   /** Whether `destroy()` has been called. After destroy, sends throw `SessionDestroyedError`. */
   readonly destroyed: boolean;
-  /** Run a turn. Returns the cleaned final text, or `null` if nothing meaningful remains. */
-  send(input: string, options?: SessionSendOptions): Promise<string | null>;
+  /**
+   * Run a turn. Accepts a single string turn or a `LanguageModelMessage[]`
+   * (multi-message context, role-per-turn control, assistant prefill via
+   * `prefix: true`). Returns the cleaned final text, or `null` if nothing
+   * meaningful remains.
+   */
+  send(
+    input: string | LanguageModelMessage[],
+    options?: SessionSendOptions,
+  ): Promise<string | null>;
   /**
    * Run a turn and yield **delta** chunks (each chunk is the *new* text since
-   * the last yield, never cumulative).
+   * the last yield, never cumulative). Accepts the same `string |
+   * LanguageModelMessage[]` input as {@link send}.
    */
   sendStreaming(
-    input: string,
+    input: string | LanguageModelMessage[],
     options?: SessionSendOptions,
   ): AsyncIterable<string>;
   /** Abort the most recent in-flight `send` / `sendStreaming`. No-op when idle. */
@@ -378,11 +387,15 @@ const wrapInstance = (
   };
 
   const send = async (
-    input: string,
+    input: string | LanguageModelMessage[],
     options?: SessionSendOptions,
   ): Promise<string | null> => {
     ensureLive();
-    if (!input.trim()) return null;
+    const isEmpty =
+      typeof input === "string"
+        ? !input.trim()
+        : input.length === 0 || input.every((m) => !m.content?.trim());
+    if (isEmpty) return null;
     const { instance } = await ready;
     ensureLive();
 
@@ -414,12 +427,16 @@ const wrapInstance = (
   };
 
   const sendStreaming = (
-    input: string,
+    input: string | LanguageModelMessage[],
     options?: SessionSendOptions,
   ): AsyncIterable<string> => ({
     [Symbol.asyncIterator]: async function* () {
       ensureLive();
-      if (!input.trim()) return;
+      const isEmpty =
+        typeof input === "string"
+          ? !input.trim()
+          : input.length === 0 || input.every((m) => !m.content?.trim());
+      if (isEmpty) return;
       const { instance } = await ready;
       ensureLive();
 


### PR DESCRIPTION
## What

Forward message arrays (multi-message context, role-per-turn control, assistant prefill) to the native `LanguageModel` API, which already accepts `string | LanguageModelMessage[]` but was only ever handed strings by the wrapper.

- Add optional `prefix?: boolean` to `LanguageModelMessage` (spec-canonical on the **trailing** `assistant` message).
- Widen `Session.send` / `sendStreaming` input from `string` to `string | LanguageModelMessage[]`.
- Replace the string-only empty-input guard with a shape-aware check (empty string, empty array, and all-empty-content array all short-circuit to `null` without hitting the model).

## Why

The native `instance.prompt` already accepts message arrays, but `Session.send` only forwarded strings. Every consumer wanting multi-message turns, role-per-turn control, or assistant prefill had to bypass the wrapper and lose its sanitization, abort composition, and typed-error behavior.

The highest-leverage reason to close the gap is **assistant prefill** (`{ role: "assistant", content: '{"thought":"', prefix: true }`): it biases output shape without the per-turn token cost of a large `responseConstraint` schema inlined into context. Prefill and `responseConstraint` compose — prefill the opening brace, set `responseConstraint` for the full shape.

**Prefill vs `responseConstraint`:**
- **Prefill**: cheaper per turn (no schema inlined), weaker guarantee — the model may drift off the prefixed format.
- **`responseConstraint`**: enforced JSON Schema (runtime-validated), higher per-turn token cost when the schema is large (`omitResponseConstraintInput: true` drops the inlined schema).

**Spec rule:** `prefix: true` is only valid on the trailing `assistant` message; elsewhere the browser throws a `"SyntaxError"` `DOMException`, which the SDK does **not** catch (let it propagate so consumers debugging prefill see the real error).

## Backward compatibility

Additive widening. Existing string `send("...")` calls and the React `useSession` hook are unchanged — `packages/prompt/src/react/index.ts` was not edited (typecheck confirms backward compatibility).

## Scope

| File | Change |
| --- | --- |
| `packages/prompt/src/api.ts` | `prefix?: boolean` on `LanguageModelMessage` + JSDoc |
| `packages/prompt/src/session.ts` | widen `send`/`sendStreaming` interface + impls; shape-aware guard |
| `packages/prompt/src/index.test.ts` | +7 tests (prefill, multi-message, string regression, empty-array & all-empty-content short-circuits, streaming array, clone prefill) |
| `packages/prompt/README.md` | signature widening + "Prefill and message arrays" section |
| `apps/site/src/content/docs/packages/prompt.md` | mirrored section |
| `apps/site/src/content/docs/guides/prompt.mdx` | mirrored section |
| `.changeset/prefill-message-arrays.md` | minor bump for `@web-ai-sdk/prompt` |

**Not touched:** `packages/prompt/src/cache.ts` (one-shot `ask()` cache), `packages/prompt/src/react/index.ts` (hook). `content` stays `string`; multimodal `ContentPart[]` content is a separate future enhancement.

## Verification

```
pnpm gate → exit 0
packages/prompt test: 82 → 89 (+7)
```

The 7 new tests are falsifiable: the short-circuit tests assert `promptSpy` is **not** called (they would fail if the guard regressed), and the prefill test asserts `prefix: true` survives forwarding via deep-equal.