### PR TITLE
feat(site): include conceptual docs in llms-full.txt

### DIFF
--- a/apps/site/scripts/build-llms.mjs
+++ b/apps/site/scripts/build-llms.mjs
@@ -4,7 +4,7 @@
 //
 // Inputs:
 //   - packages/*/README.md             (source of truth for llms content)
-//   - apps/site/src/content/docs/** (route enumeration for sitemap)
+//   - apps/site/src/content/docs/** (route enumeration for sitemap; JSX-free conceptual docs feed llms-full.txt)
 // Outputs:
 //   - apps/site/dist/llms.txt
 //   - apps/site/dist/llms-full.txt
@@ -12,7 +12,8 @@
 //
 // llms.txt format follows https://llmstxt.org — H1 title, blockquote
 // summary, per-section bullet list of links. llms-full.txt concatenates the
-// full README bodies so an LLM can ingest everything in one fetch.
+// full README bodies plus the JSX-free conceptual docs so an LLM can ingest
+// everything in one fetch.
 
 import { readFileSync, readdirSync, statSync, writeFileSync } from "node:fs";
 import { dirname, relative, resolve } from "node:path";

--- a/apps/site/scripts/build-llms.mjs
+++ b/apps/site/scripts/build-llms.mjs
@@ -47,8 +47,26 @@ const PACKAGES = [
 
 const readmeUrl = (dir) => `${REPO_URL}/tree/main/packages/${dir}#readme`;
 
+// Cross-cutting conceptual docs (plain Markdown, no JSX) appended to
+// llms-full.txt so a coding agent gets the mental model + browser matrix in one
+// fetch. Keep this list to JSX-free docs; guides/react docs stay out.
+const CONCEPTUAL_DOCS = [
+  { file: "browser-support.mdx", route: "/docs/browser-support/" },
+  { file: "architecture.mdx", route: "/docs/architecture/" },
+  { file: "why-web-ai-sdk.mdx", route: "/docs/why-web-ai-sdk/" },
+];
+
 function readReadme(dir) {
   return readFileSync(resolve(PACKAGES_DIR, dir, "README.md"), "utf8");
+}
+
+// Read a content doc and strip its leading YAML frontmatter block so only the
+// Markdown body is concatenated into llms-full.txt.
+function readDocBody(absPath) {
+  const raw = readFileSync(absPath, "utf8");
+  // Frontmatter is a leading `---` line, content, then a closing `---` line.
+  const fm = /^---\r?\n[\s\S]*?\r?\n---\r?\n?/;
+  return raw.replace(fm, "").trim();
 }
 
 function summary(md) {
@@ -167,6 +185,19 @@ function buildLlmsFull() {
     parts.push(`<!-- Source: ${readmeUrl(p.dir)} -->`);
     parts.push("");
     parts.push(md.trimEnd());
+    parts.push("");
+  }
+  parts.push("---");
+  parts.push("");
+  parts.push("# Conceptual guides");
+  parts.push("");
+  for (const d of CONCEPTUAL_DOCS) {
+    const body = readDocBody(resolve(DOCS_CONTENT_DIR, d.file));
+    parts.push("---");
+    parts.push("");
+    parts.push(`<!-- Source: ${SITE_URL}${d.route} -->`);
+    parts.push("");
+    parts.push(body);
     parts.push("");
   }
   return parts.join("\n");


### PR DESCRIPTION
## What
Appends the three cross-cutting conceptual docs (browser-support, architecture, why-web-ai-sdk) to the generated `/llms-full.txt` so a coding agent gets the full project brief in one fetch.

## Why
`/llms-full.txt` serves the one use case these files actually have in 2026: coding agents (Claude Code, Cursor) pulling a project's docs into context. Today it only concatenates the package READMEs, which cover the API surface but omit the cross-cutting context a README can't carry — the per-package browser/flag matrix, the "thin shim, gets thinner" mental model, and the positioning vs provider SDKs.

## How
- Add `readDocBody()` frontmatter-stripping helper (regex, zero deps, matches existing `summary()`/`readReadme()` style).
- Add `CONCEPTUAL_DOCS` list of the three JSX-free docs.
- Append a `# Conceptual guides` section to `buildLlmsFull()`.

The three docs are plain Markdown with YAML frontmatter only (architecture.mdx imports live inside code fences); frontmatter stripping alone yields clean text.

## Verification
- `pnpm --filter @web-ai-sdk-apps/site build` exits 0
- output has exactly one `# Conceptual guides` header
- no leaked frontmatter (`^title:` = 0)
- 9 package source-comment lines intact
- `pnpm gate` exits 0