### PR TITLE
docs(readme): sync roadmap with shipped/moved items and pnpm version

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ git clone https://github.com/obetomuniz/web-ai-sdk.git
 cd web-ai-sdk
 
 # Node 24 (or any version-manager that respects .nvmrc) + Corepack picks up
-# pnpm 9.15.0 automatically from package.json's "packageManager" field.
+# pnpm 10.34.3 automatically from package.json's "packageManager" field.
 pnpm install
 pnpm build:packages  # build packages so workspace consumers can resolve them
 pnpm dev             # site at http://localhost:5173/, docs at /docs/
@@ -137,17 +137,15 @@ For the AI APIs to actually run, open a supporting browser. On Chrome, Summarize
 | Build Pages artifact            | `pnpm pages:build`    |
 | Preview combined Pages locally  | `pnpm pages:preview`  |
 
-Toolchain: Node 24 (pinned in `.nvmrc`) + pnpm 9.15.0 (pinned via `package.json#packageManager` and provisioned automatically by Corepack on Node 16.13+).
+Toolchain: Node 24 (pinned in `.nvmrc`) + pnpm 10.34.3 (pinned via `package.json#packageManager` and provisioned automatically by Corepack on Node 16.13+).
 
 ## Roadmap
 
 Directional, not a commitment. The bias is toward owning only the lifecycle and ergonomics the raw APIs leave rough, and thinning out as the Web AI APIs stabilize.
 
-- Native tool calling for the Prompt API
-- Session resilience (auto-retry on session loss)
-- IndexedDB cache backend for result caches
 - Cloud / custom-provider fallback for unsupported browsers
 - More browser compatibility helpers
+- Broader browser adoption of the Writer / Rewriter / Proofreader APIs as they ship
 
 ## Contributing
 


### PR DESCRIPTION
## What

Close the remaining SEO/brand checklist and sync the root roadmap.

## Why

The root `README.md` roadmap still listed shipped and moved items as future SDK work, sending mixed signals to humans and crawlers and mis-scoping the SDK vs the `web-ai-kit` sibling.

## Changes (`README.md` only, +3 −5)

**Roadmap sync** — removed 3 stale/moved bullets:
- `Native tool calling for the Prompt API` → shipped as experimental passthrough (`tools` option, `packages/prompt/src/index.ts:109`)
- `Session resilience (auto-retry on session loss)` → shipped via `clone()`-based recovery (`packages/prompt/src/index.ts:311-317`)
- `IndexedDB cache backend for result caches` → moved to `web-ai-kit/.ideas/cache-backends.md` (plan 009) as a cross-cutting kit concern

Kept the 2 valid future items and added 1 (broader Writer/Rewriter/Proofreader browser adoption as those APIs ship).

**Adjacent drift** — aligned the pnpm version in two places (`README.md:92`, `README.md:140`): `pnpm 9.15.0` → `pnpm 10.34.3` to match `package.json#packageManager`.

## Step 1 (SEO checklist) — verified, no fixes needed

All 12 checklist items pass on the live homepage, closed as side effects of plans 019 (Organization entity + `sameAs` in the JSON-LD `@graph`) and 028 (`the Web AI surface` umbrella-term sweep). npm `description` fields across all 9 packages already follow a consistent pattern.

## Verification

- ```rg "Session resilience|Native tool calling|IndexedDB cache backend|@web-ai-sdk/stream|pnpm 9\.15" README.md``` → no matches
- `pnpm gate` → exit 0