### PR TITLE
fix(webmcp): make registerTool async-safe per WebMCP spec update

### DIFF
--- a/.changeset/webmcp-async-registration.md
+++ b/.changeset/webmcp-async-registration.md
@@ -1,0 +1,5 @@
+---
+"@web-ai-sdk/webmcp": patch
+---
+
+Adapt `registerTool` to the WebMCP spec update that makes `document.modelContext.registerTool()` return a Promise (cross-origin iframe tool sharing made registration asynchronous). The wrapper normalizes both the legacy synchronous-throw and the new async-promise shapes into one async pipeline; the public `registerTool(tool): () => void` signature is unchanged. As a forced side-effect, a first-call non-duplicate failure that previously threw synchronously now logs via `console.error` and gives up — matching the package's "feature detect, never throw" contract and the retry path's existing posture (the throw became uncatchable once registration went async).

--- a/apps/site/src/content/docs/packages/webmcp.md
+++ b/apps/site/src/content/docs/packages/webmcp.md
@@ -15,7 +15,7 @@ An ergonomic, framework-agnostic adapter over the native browser API, with safe 
 
 ## Status
 
-WebMCP shipped as an early preview in Chrome 146+ behind `chrome://flags/#enable-webmcp-testing`; a public [origin trial](https://developer.chrome.com/docs/ai/webmcp) opens in Chrome 149. Edge added support in 147+ behind the matching `edge://flags/` toggle. On any browser that doesn't expose `document.modelContext` (or the legacy `navigator.modelContext`), this library is a no-op. Your app stays callable, and no tools get registered.
+WebMCP shipped as an early preview in Chrome 146+ behind `chrome://flags/#enable-webmcp-testing`; a public [origin trial](https://developer.chrome.com/docs/ai/webmcp) opens in Chrome 149. Edge added support in 147+ behind the matching `edge://flags/` toggle. On any browser that doesn't expose `document.modelContext` (or the legacy `navigator.modelContext`), this library is a no-op. Your app stays callable, and no tools get registered. A WebMCP spec update changed `registerTool` to return a Promise (cross-origin iframe tool sharing made registration asynchronous); this adapter normalizes both the legacy synchronous shape and the async shape, so consumer code is unchanged.
 
 ## Install
 
@@ -111,6 +111,8 @@ The hook registers on mount, unregisters on unmount, and re-registers when the a
 ### `registerTool(tool): () => void`
 
 Register a single tool. Returns a cleanup function. No-op on unsupported browsers.
+
+Registration is asynchronous under the hood (per the current spec); the returned cleanup is synchronous and safe to call before registration settles — it aborts the in-flight registration cleanly.
 
 To register many at once, map and combine:
 

--- a/packages/webmcp/README.md
+++ b/packages/webmcp/README.md
@@ -8,7 +8,7 @@ An ergonomic, framework-agnostic adapter over the native browser API, with safe 
 
 ## Status
 
-WebMCP shipped as an early preview in Chrome 146+ behind `chrome://flags/#enable-webmcp-testing`; a public [origin trial](https://developer.chrome.com/docs/ai/webmcp) opens in Chrome 149. Edge added support in 147+ behind the matching `edge://flags/` toggle. On any browser that doesn't expose `document.modelContext` (or the legacy `navigator.modelContext`), this library is a no-op. Your app stays callable, and no tools get registered.
+WebMCP shipped as an early preview in Chrome 146+ behind `chrome://flags/#enable-webmcp-testing`; a public [origin trial](https://developer.chrome.com/docs/ai/webmcp) opens in Chrome 149. Edge added support in 147+ behind the matching `edge://flags/` toggle. On any browser that doesn't expose `document.modelContext` (or the legacy `navigator.modelContext`), this library is a no-op. Your app stays callable, and no tools get registered. A WebMCP spec update changed `registerTool` to return a Promise (cross-origin iframe tool sharing made registration asynchronous); this adapter normalizes both the legacy synchronous shape and the async shape, so consumer code is unchanged.
 
 ## Install
 
@@ -104,6 +104,8 @@ The hook registers on mount, unregisters on unmount, and re-registers when the a
 ### `registerTool(tool): () => void`
 
 Register a single tool. Returns a cleanup function. No-op on unsupported browsers.
+
+Registration is asynchronous under the hood (per the current spec); the returned cleanup is synchronous and safe to call before registration settles — it aborts the in-flight registration cleanly.
 
 To register many at once, map and combine:
 

--- a/packages/webmcp/src/index.test.ts
+++ b/packages/webmcp/src/index.test.ts
@@ -29,24 +29,53 @@ const setModelContext = (host: Host, value: unknown) => {
   );
 };
 
+/** Flush all pending microtasks (the async register pipeline chains several). */
+const flush = () => new Promise<void>((resolve) => setTimeout(resolve, 0));
+
 /**
  * Mirror the native WebMCP shape: a single `registerTool(def, { signal? })`
  * method. There is no `unregisterTool`; cleanup happens by aborting the signal
  * that was passed at registration. Installs on `navigator` by default; pass
  * `host: "document"` to mount on `document.modelContext` instead.
+ *
+ * By default mirrors the spec-current async shape: `registerTool` returns a
+ * `Promise<void>`. The promise executor runs synchronously (so
+ * `registered.set(...)` is visible in the same tick), but the settle
+ * (resolve/reject) is observed on a later microtask. Pass `{ sync: true }`
+ * for the legacy synchronous shape (throws synchronously, returns
+ * `undefined`).
  */
-const installFakeModelContext = (host: Host = "navigator") => {
+const installFakeModelContext = (
+  host: Host = "navigator",
+  { sync = false }: { sync?: boolean } = {},
+) => {
   const registered = new Map<string, RegisteredCall>();
+  const dup = () =>
+    new Error(
+      "Failed to execute 'registerTool' on 'ModelContext': Duplicate tool name",
+    );
+  const apply = (def: RegisteredCall, options?: RegisterOptions) => {
+    if (registered.has(def.name)) throw dup();
+    registered.set(def.name, def);
+    options?.signal?.addEventListener("abort", () => {
+      registered.delete(def.name);
+    });
+  };
   const registerTool = vi.fn(
     (def: RegisteredCall, options?: RegisterOptions) => {
-      if (registered.has(def.name)) {
-        throw new Error(
-          "Failed to execute 'registerTool' on 'ModelContext': Duplicate tool name",
-        );
+      if (sync) {
+        apply(def, options); // legacy: throws synchronously, returns undefined
+        return undefined;
       }
-      registered.set(def.name, def);
-      options?.signal?.addEventListener("abort", () => {
-        registered.delete(def.name);
+      // Spec-current shape: returns a Promise. Executor is sync (mutations
+      // visible same tick), but settle is observed on a later microtask.
+      return new Promise<void>((resolve, reject) => {
+        try {
+          apply(def, options);
+          resolve();
+        } catch (err) {
+          reject(err);
+        }
       });
     },
   );
@@ -216,13 +245,15 @@ describe("registerTool", () => {
     expect(() => cleanup()).not.toThrow();
   });
 
-  it("evicts a prior live registration for the same name (last writer wins)", () => {
+  it("evicts a prior live registration for the same name (last writer wins)", async () => {
     const { registered } = installFakeModelContext();
     const cleanupA = registerTool({
       name: "shared",
       description: "first",
       execute: () => ({ which: "A" }),
     });
+    // Let A's registration settle so its ownership is tracked before B runs.
+    await flush();
     expect(registered.get("shared")?.description).toBe("first");
 
     // Fresh call for the same name. The prior controller should be aborted
@@ -232,6 +263,7 @@ describe("registerTool", () => {
       description: "second",
       execute: () => ({ which: "B" }),
     });
+    await flush();
     expect(registered.get("shared")?.description).toBe("second");
 
     // The first caller's cleanup is a no-op now (its controller was already
@@ -242,6 +274,34 @@ describe("registerTool", () => {
     // The second caller's cleanup removes the tool.
     cleanupB();
     expect(registered.has("shared")).toBe(false);
+  });
+
+  it("same-tick double-register of one name degrades to warn-and-skip (first wins)", async () => {
+    const { registered } = installFakeModelContext();
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    // No flush between the two calls: neither registration has settled, so
+    // neither sees the other in ownedControllers and no eviction happens.
+    registerTool({
+      name: "tick",
+      description: "first",
+      execute: async () => ({}),
+    });
+    registerTool({
+      name: "tick",
+      description: "second",
+      execute: async () => ({}),
+    });
+    await flush();
+
+    expect(registered.get("tick")?.description).toBe("first");
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringMatching(/already registered by another caller/),
+    );
+    expect(errorSpy).not.toHaveBeenCalled();
+    warnSpy.mockRestore();
+    errorSpy.mockRestore();
   });
 
   it("warns and skips when the name is owned outside the wrapper (no throw)", async () => {
@@ -260,7 +320,7 @@ describe("registerTool", () => {
       execute: async () => ({}),
     });
     // The wrapper retries on a microtask before giving up; flush it.
-    await Promise.resolve();
+    await flush();
     expect(warnSpy).toHaveBeenCalledWith(
       expect.stringMatching(/already registered/i),
     );
@@ -308,7 +368,7 @@ describe("registerTool", () => {
 
     registerTool({ name: "t", description: "d", execute: async () => ({}) });
     expect(map.has("t")).toBe(false); // not yet; retry is queued
-    await Promise.resolve(); // flush microtask
+    await flush(); // flush the async register pipeline
     expect(map.has("t")).toBe(true); // retry landed it
     expect(registerTool_).toHaveBeenCalledTimes(2);
   });
@@ -337,7 +397,7 @@ describe("registerTool", () => {
     expect(() =>
       registerTool({ name: "t", description: "d", execute: async () => ({}) }),
     ).not.toThrow();
-    await Promise.resolve(); // flush microtask; if the throw survived it would surface here
+    await flush(); // flush the async register pipeline; if the throw survived it would surface here
 
     expect(errorSpy).toHaveBeenCalledWith(
       expect.stringMatching(/could not be registered after retry/),
@@ -345,6 +405,76 @@ describe("registerTool", () => {
     expect(warnSpy).not.toHaveBeenCalled();
     errorSpy.mockRestore();
     warnSpy.mockRestore();
+  });
+
+  it("logs and gives up (no throw) when the FIRST call fails with a non-duplicate error", async () => {
+    const registerTool_ = vi.fn(() =>
+      Promise.reject(new Error("InvalidStateError: sandbox unavailable")),
+    );
+    Object.defineProperty(navigator, "modelContext", {
+      value: { registerTool: registerTool_ },
+      configurable: true,
+    });
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    expect(() =>
+      registerTool({ name: "t", description: "d", execute: async () => ({}) }),
+    ).not.toThrow();
+    await flush();
+
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringMatching(/could not be registered:/),
+    );
+    expect(warnSpy).not.toHaveBeenCalled();
+    errorSpy.mockRestore();
+    warnSpy.mockRestore();
+  });
+
+  it("treats abort-during-pending registration as a clean cancellation (no error/warn)", async () => {
+    const registerTool_ = vi.fn(
+      (_def: RegisteredCall, options?: RegisterOptions) =>
+        new Promise<void>((_resolve, reject) => {
+          // Never resolves on its own; only rejects when aborted.
+          options?.signal?.addEventListener("abort", () => {
+            reject(
+              new DOMException("The user aborted a request.", "AbortError"),
+            );
+          });
+        }),
+    );
+    Object.defineProperty(navigator, "modelContext", {
+      value: { registerTool: registerTool_ },
+      configurable: true,
+    });
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    const cleanup = registerTool({
+      name: "x",
+      description: "x",
+      execute: async () => ({}),
+    });
+    cleanup(); // abort before the pending registration settles
+    await flush();
+
+    expect(errorSpy).not.toHaveBeenCalled();
+    expect(warnSpy).not.toHaveBeenCalled();
+    errorSpy.mockRestore();
+    warnSpy.mockRestore();
+  });
+
+  it("handles the legacy synchronous-throw shape (callRegister normalizes it)", async () => {
+    const { registered } = installFakeModelContext("navigator", {
+      sync: true,
+    });
+    registerTool({
+      name: "sync",
+      description: "old chrome",
+      execute: async () => ({}),
+    });
+    await flush();
+    expect(registered.has("sync")).toBe(true);
   });
 });
 

--- a/packages/webmcp/src/index.ts
+++ b/packages/webmcp/src/index.ts
@@ -190,7 +190,10 @@ interface RegisterToolOptions {
 }
 
 interface ModelContext {
-  registerTool: (def: RegisteredTool, options?: RegisterToolOptions) => void;
+  registerTool: (
+    def: RegisteredTool,
+    options?: RegisterToolOptions,
+  ) => Promise<void> | void;
 }
 
 interface HostWithModelContext {
@@ -257,55 +260,99 @@ const trackOwnership = (controller: AbortController, name: string): void => {
 };
 
 /**
- * Returns `true` if registration succeeded synchronously with `controller`,
- * `false` if a transient duplicate was hit and we scheduled a microtask
- * retry (the registration will land asynchronously), or if another caller
- * permanently owns the name.
+ * Normalize the native `registerTool` call into a `Promise<void>`, supporting
+ * both the legacy synchronous shape (returns `undefined`, throws on duplicate)
+ * and the spec-current asynchronous shape (returns `Promise<void>`, rejects on
+ * duplicate). Cross-origin iframe tool sharing made registration inherently
+ * asynchronous — see WebMCP spec issue #175 / PR #228.
  */
-const registerOne = (
+const callRegister = (
   mc: ModelContext,
   registered: RegisteredTool,
   controller: AbortController,
-): boolean => {
+): Promise<void> => {
+  try {
+    return Promise.resolve(
+      mc.registerTool(registered, { signal: controller.signal }),
+    );
+  } catch (err) {
+    return Promise.reject(err);
+  }
+};
+
+/**
+ * Register a single tool against the host modelContext, async-safe.
+ *
+ * Must be **total**: it never rejects. Every failure path logs and resolves
+ * `false`. That invariant is what lets `registerTool` fire-and-forget the
+ * returned promise without an unhandled-rejection guard.
+ *
+ * Returns `true` if registration succeeded (ownership tracked), `false`
+ * otherwise. The return value is unused by the caller today; kept for symmetry.
+ *
+ * Error posture follows the package's "feature detect, never throw" contract:
+ * a first-call non-duplicate failure used to `throw` to the caller (catchable
+ * only while registration was synchronous); the spec's async registration
+ * update makes that throw uncatchable, so it is now logged — matching the
+ * retry path.
+ */
+const registerOne = async (
+  mc: ModelContext,
+  registered: RegisteredTool,
+  controller: AbortController,
+): Promise<boolean> => {
   // If we still hold a live controller for this name, evict it before the
-  // native register call so Chrome doesn't throw InvalidStateError.
+  // native register call so Chrome doesn't reject with InvalidStateError.
   const prior = ownedControllers.get(registered.name);
   if (prior && prior !== controller && !prior.signal.aborted) {
     prior.abort();
   }
+
   try {
-    mc.registerTool(registered, { signal: controller.signal });
+    await callRegister(mc, registered, controller);
   } catch (err) {
-    if (!isDuplicateNameError(err)) throw err;
-    // Chrome's AbortSignal-driven unregistration isn't guaranteed to
-    // propagate to the registry in the same tick as `.abort()`. A fresh
-    // re-register fired immediately after an abort (e.g. React effect
-    // cleanup → mount cycle, or a hook re-running on dep change) can land
-    // before Chrome processes the queued removal. Yield to a microtask and
-    // retry once. If the retry also fails, log and give up.
-    queueMicrotask(() => {
-      if (controller.signal.aborted) return;
-      try {
-        mc.registerTool(registered, { signal: controller.signal });
-        trackOwnership(controller, registered.name);
-      } catch (retryErr) {
-        if (isDuplicateNameError(retryErr)) {
-          if (typeof console !== "undefined") {
-            console.warn(
-              `[@web-ai-sdk/webmcp] tool "${registered.name}" is already registered by another caller; skipping. This is usually a transient race. If you see it in production, ensure only one caller registers each name.`,
-            );
-          }
-          return;
-        }
+    // If our own controller was aborted (a later caller evicted us, or our
+    // cleanup fired, while registration was still pending), treat it as a
+    // clean cancellation — no log, no retry.
+    if (controller.signal.aborted) return false;
+
+    if (!isDuplicateNameError(err)) {
+      // Unrecoverable first-call failure: log and give up (no throw).
+      if (typeof console !== "undefined") {
+        console.error(
+          `[@web-ai-sdk/webmcp] tool "${registered.name}" could not be registered: ${(err as Error)?.message ?? String(err)}`,
+        );
+      }
+      return false;
+    }
+
+    // Duplicate: Chrome's AbortSignal-driven unregistration isn't guaranteed
+    // to have drained by the time our (now async) rejection landed. A fresh
+    // re-register fired right after an abort can still race the queued
+    // removal. Yield once and retry. If the retry also fails, log and give up.
+    await Promise.resolve();
+    if (controller.signal.aborted) return false;
+    try {
+      await callRegister(mc, registered, controller);
+    } catch (retryErr) {
+      if (controller.signal.aborted) return false;
+      if (isDuplicateNameError(retryErr)) {
         if (typeof console !== "undefined") {
-          console.error(
-            `[@web-ai-sdk/webmcp] tool "${registered.name}" could not be registered after retry: ${(retryErr as Error)?.message ?? String(retryErr)}`,
+          console.warn(
+            `[@web-ai-sdk/webmcp] tool "${registered.name}" is already registered by another caller; skipping. This is usually a transient race. If you see it in production, ensure only one caller registers each name.`,
           );
         }
+        return false;
       }
-    });
-    return false;
+      if (typeof console !== "undefined") {
+        console.error(
+          `[@web-ai-sdk/webmcp] tool "${registered.name}" could not be registered after retry: ${(retryErr as Error)?.message ?? String(retryErr)}`,
+        );
+      }
+      return false;
+    }
   }
+
   trackOwnership(controller, registered.name);
   return true;
 };
@@ -327,7 +374,11 @@ export const registerTool = <TInput, TOutput>(
 
   const registered = toRegistered(tool as Tool);
   const controller = new AbortController();
-  registerOne(mc, registered, controller);
+  // Fire-and-forget: registerOne is total (never rejects — see its contract),
+  // so there is no unhandled-rejection risk. The sync cleanup below aborts the
+  // controller; if registration is still pending, the abort propagates to the
+  // host and registerOne treats it as a clean cancellation.
+  void registerOne(mc, registered, controller);
 
   let disposed = false;
   return () => {


### PR DESCRIPTION
A WebMCP spec update makes `document.modelContext.registerTool()` return a Promise — cross-origin iframe tool sharing made registration inherently asynchronous. The wrapper's duplicate detection relied on synchronous throws, so under the new shape it silently stopped working and every registration became an unhandled-rejection risk.

## What changed

- New `callRegister` normalizer folds both native shapes (legacy sync-throw, spec-current async-reject) into one `Promise<void>` pipeline.
- `registerOne` is now async and total — every failure path logs and resolves, never rejects — which lets `registerTool` fire-and-forget it safely. Aborting mid-registration is treated as a clean cancellation (no log).
- The public API is unchanged: `registerTool(tool)` still returns a synchronous `() => void` cleanup, safe to call before registration settles.
- Forced side-effect: a first-call non-duplicate failure that previously threw now logs via `console.error`, matching the package's "feature detect, never throw" contract (the throw became uncatchable once registration went async).
- Known narrow behavior change: two same-tick registrations of one name degrade to first-wins + `console.warn` instead of last-writer-wins (neither has settled, so neither can evict the other). Documented and tested.

## Tests

27 → 32 (first-call failure logging, abort-during-pending cancellation, legacy sync-throw shape, same-tick degradation; React adapter passes unchanged). Full gate green.