### PR TITLE
fix(site): remove homepage subsection heading counters

### DIFF
--- a/apps/site/src/pages/index.astro
+++ b/apps/site/src/pages/index.astro
@@ -523,7 +523,7 @@ const browserColumns = [
           </div>
           <div class={`${ui.twoCol} ${ui.reveal}`} data-reveal>
             <div>
-              <h3 class={ui.philosophyTitle}><span class={ui.philosophyNum}>01</span> One model surface.</h3>
+              <h3 class={ui.philosophyTitle}>One model surface.</h3>
               <p class={ui.philosophyText}>
                 A single text-generation model abstraction reaches exactly one of these built-ins, <code>LanguageModel</code> (Prompt). Useful, but one surface, not the whole product.
               </p>
@@ -533,7 +533,7 @@ const browserColumns = [
               </ul>
             </div>
             <div>
-              <h3 class={ui.philosophyTitle}><span class={ui.philosophyNum}>02</span> Seven surfaces beyond it.</h3>
+              <h3 class={ui.philosophyTitle}>Seven surfaces beyond it.</h3>
               <p class={ui.philosophyText}>
                 The rest carry options a text-out contract cannot hold, so each gets its own thin package.
               </p>
@@ -696,7 +696,7 @@ const browserColumns = [
           </div>
           <div class={`${ui.twoCol} ${ui.reveal}`} data-reveal>
             <div>
-              <h3 class={ui.philosophyTitle}><span class={ui.philosophyNum}>01</span> We handle the rough edges.</h3>
+              <h3 class={ui.philosophyTitle}>We handle the rough edges.</h3>
               <p class={ui.philosophyText}>
                 The Web AI surface is young. Capability checks, model downloads, abortable streams, session lifetimes, and DOM-rebuild safety are all things you would otherwise re-implement in every component.
               </p>
@@ -709,7 +709,7 @@ const browserColumns = [
               </ul>
             </div>
             <div>
-              <h3 class={ui.philosophyTitle}><span class={ui.philosophyNum}>02</span> You compose the stack.</h3>
+              <h3 class={ui.philosophyTitle}>You compose the stack.</h3>
               <p class={ui.philosophyText}>
                 We ship the lifecycle layer: state machines, streams, abort signals. Framework adapters, polyfills, and UI primitives stay optional so they do not constrain the design system.
               </p>

--- a/apps/site/src/shared/ui.ts
+++ b/apps/site/src/shared/ui.ts
@@ -337,8 +337,6 @@ export const whyRawText =
 export const philosophyTitle =
   "mb-3 font-sans text-[25px] leading-[1.3] tracking-[-0.03em] text-fg max-[640px]:text-[20px]";
 
-export const philosophyNum = "mr-2.5 font-mono text-sm text-accent";
-
 export const philosophyText =
   "text-[16.5px] leading-[1.8] text-fg-2 max-[640px]:text-[15.5px]";
 


### PR DESCRIPTION
## Summary
- Remove numeric counters from homepage subsection headings.
- Delete the now-unused `philosophyNum` shared UI class.

## Validation
- `pnpm --filter @web-ai-sdk-apps/site typecheck`
- Live checked the homepage with `pnpm dev:site` at `http://localhost:5173/`