### PR TITLE
docs: define capability adoption policy

### DIFF
--- a/.agents/agents.md
+++ b/.agents/agents.md
@@ -144,12 +144,23 @@ All workflow commands are pnpm scripts in `package.json`.
 - **No relative imports across package boundaries.** Each package is self-contained; cross-package usage goes through `@web-ai-sdk/*` published exports.
 - **Subpath imports inside a package** use `.js` suffix (`from "../index.js"`); required by ESM resolution under `moduleResolution: "Bundler"` for the published shape.
 
+### Capability adoption gate
+
+Before scaffolding a wrapper, classify it as Tracked, Preview, Trial, Stable, or Retired using [`CONTRIBUTING.md` § Capability adoption policy](../CONTRIBUTING.md#capability-adoption-policy).
+
+- Tracked capabilities stay as issues. Only Preview, Trial, or Stable capabilities may become packages.
+- Preview requires an authoritative public source, public instructions sufficient to run and document the implementation, a cohesive capability boundary, material lifecycle value beyond types, zero runtime dependencies, deterministic tests, and deliberate unsupported-browser behavior.
+- Published issues, PRs, READMEs, docs, demos, changelogs, and release notes must rely entirely on public sources. Never link, quote, paraphrase, or disclose versions, flags, behavior, or timelines learned only from confidential, restricted, or private-preview material. If the public evidence is insufficient, keep the capability Tracked.
+- Record the stage and exact public setup requirements in the package README and browser-support docs. Preview and Trial packages remain `0.x`; Stable browser support does not automatically make the package `1.0`.
+- Do not copy capability-specific conveniences mechanically. Session reuse must be safe and clearable; rejected creation promises must be evicted. Result caching requires a complete key, lossless serialization, and semantically valid reuse, including a compatibility discriminator when outputs depend on one. Preserve structured native results when their metadata matters.
+- When a capability is withdrawn or replaced, deprecate it with migration guidance instead of silently repurposing the package.
+
 ### Core package contract
 
 These rules apply to the API-wrapper packages (`@web-ai-sdk/prompt`, `webmcp`, `summarizer`, `translator`, `detector`, `writer`, `rewriter`, `proofreader`). Future packages with a different role (UI primitives, polyfills, etc.) sit at different layers and get their own rules.
 
 - **No UI components in the core wrappers.** A core package may never render DOM. The React adapter is a hook, not a component. UI primitives would ship as a separate `@web-ai-sdk/ui` package, not bolted into a wrapper.
-- **Feature detect, never throw.** If the underlying browser API is missing, the package is a no-op (return a no-op cleanup, return `undefined`, etc.) so consumers can ship the same code to all browsers.
+- **Feature-detection helpers never throw.** `isAvailable()` returns `false` and `checkAvailability()` returns `null` when the native API cannot be used. High-level vanilla execution may throw a package-specific typed unavailability error; React hooks absorb it into an `"unavailable"` state. Registration-style APIs may instead return an idempotent no-op cleanup when that preserves their natural call shape.
 - **Configurable selectors / roots.** Don't hardcode page-specific assumptions; every selector or root element an SDK helper accepts must be overridable via the API.
 - **Cleanup must be idempotent.** Returning a cleanup function from `register*` / `start*` is the universal lifecycle. Calling it twice must not throw.
 
@@ -193,14 +204,15 @@ The marketing site uses **Tailwind CSS v4**. Full guardrails: [`apps/site/README
 
 ### Add a new tool / wrapper package
 
-1. `cp -r packages/<closest-template> packages/<new>` and rename in `package.json`, `tsup.config.ts`, `tsconfig.json`.
-2. Replace `src/index.ts` / `src/api.ts` / `src/react/index.ts` with the real wrapper. Keep the core package contract (§ 5).
-3. Add Vitest tests next to each source file.
-4. Write `README.md` matching the existing structure (status / install / vanilla / React / API / errors / license).
-5. Add the new package's docs MDX pages under `apps/site/src/content/docs/guides/<name>.mdx` and `apps/site/src/content/docs/react/use-<name>.mdx`, plus a docs demo component under `apps/site/src/features/docs/components/`, plus a sidebar entry in `apps/site/astro.config.mjs`. Add a corresponding static row and React demo island to `apps/site/src/pages/index.astro`.
-6. `pnpm install` at the repo root (picks up the new workspace package).
-7. `pnpm changeset` to record the new package for the next release.
-8. `pnpm gate` to verify everything is wired up.
+1. Confirm the capability has reached Preview, Trial, or Stable under the capability adoption gate. Keep Tracked capabilities as issues.
+2. `cp -r packages/<closest-template> packages/<new>` and rename in `package.json`, `tsup.config.ts`, `tsconfig.json`.
+3. Replace `src/index.ts` / `src/api.ts` / `src/react/index.ts` with the real wrapper. Keep the core package contract (§ 5).
+4. Add Vitest tests next to each source file.
+5. Write `README.md` matching the existing structure (status / install / vanilla / React / API / errors / license).
+6. Add the new package's docs MDX pages under `apps/site/src/content/docs/guides/<name>.mdx` and `apps/site/src/content/docs/react/use-<name>.mdx`, plus a docs demo component under `apps/site/src/features/docs/components/`, plus a sidebar entry in `apps/site/astro.config.mjs`. Add a corresponding static row and React demo island to `apps/site/src/pages/index.astro`.
+7. `pnpm install` at the repo root (picks up the new workspace package).
+8. `pnpm changeset` to record the new package for the next release.
+9. `pnpm gate` to verify everything is wired up.
 
 Note: a brand-new package's **first** publish must be done locally; CI can't create it. See [Cut a release](#cut-a-release).
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,14 +44,65 @@ These rules define what belongs in `@web-ai-sdk/*` and what doesn't. They're the
 
 For the time being these rules are enforced by review, not by CI. If you open a PR that adds `dependencies` or non-`react` `peerDependencies` to a `@web-ai-sdk/*` wrapper, expect to be asked to remove them or to land the work in the future kit instead. Shared infrastructure across packages (feature detection, stream normalization, error classes) will live in a private `@web-ai-sdk/internal` package the first time it's actually needed; until then, copy small helpers between packages rather than designing the shared layer upfront.
 
+## Capability adoption policy
+
+New browser capabilities enter the SDK according to evidence, not a target date. Classify a proposal before scaffolding a package:
+
+| Stage | Evidence | Repository treatment |
+| --- | --- | --- |
+| **Tracked** | An authoritative public proposal exists, but there is no publicly documentable implementation or the API shape is too incomplete to wrap responsibly. | Track the capability in an issue. Do not scaffold or publish a package. |
+| **Preview** | Maintainers can run the capability from public instructions, the execution and lifecycle shape is coherent, and a wrapper adds material value. Flags and preview browsers are acceptable. | An experimental `0.x` package may ship with a prominent status notice and exact public setup requirements. |
+| **Trial** | The capability is available through a public developer or origin trial. | Keep the package `0.x`, expand real-browser coverage and demos, and document trial constraints. |
+| **Stable** | At least one stable browser exposes the capability without an opt-in flag or trial token. | Mark browser support stable. A `1.0` package release remains a separate decision based on the wrapper's own API stability. |
+| **Retired** | The proposal is withdrawn, replaced, or no longer implementable. | Deprecate instead of silently repurposing the package, and publish migration guidance when a successor exists. |
+
+### Admission gates
+
+A capability must satisfy every gate before it moves from Tracked to Preview:
+
+1. **Public evidence:** an authoritative explainer, specification, or browser-vendor document describes the capability, and public instructions are sufficient to test and document it.
+2. **Cohesive boundary:** it maps to one browser capability and fits the one-package rule.
+3. **Material wrapper value:** the package owns a real lifecycle or ergonomics gap such as feature detection, availability, session reuse, cleanup, abort handling, error normalization, or stream normalization. Types alone are not enough.
+4. **Contract fit:** it can remain framework-agnostic, zero-runtime-dependency, testable without the real browser implementation, and independently usable without importing another SDK package.
+5. **Progressive enhancement:** unsupported environments have a deliberate, documented behavior.
+6. **Honest scope:** result caching, persistence, DOM traversal, cross-capability composition, and helper algorithms are included only when they independently satisfy the SDK's scope rules.
+
+Published artifacts must stand entirely on public sources. Confidential, restricted, or private-preview material may inform an internal go/no-go discussion, but it must never be linked, quoted, paraphrased, or used to disclose non-public versions, flags, behavior, or timelines in issues, PRs, READMEs, docs, demos, changelogs, or release notes. If public evidence is insufficient, the capability remains Tracked.
+
+### Integration contract
+
+An admitted wrapper normally includes:
+
+- `src/api.ts`: native types, global lookup, `isAvailable()`, `checkAvailability()`, and native instance ownership.
+- `src/index.ts`: the vanilla high-level operation, public result types, and package-specific errors.
+- `src/react/index.ts`: a thin hook over the vanilla operation with honest effect dependencies.
+- Vanilla and React lifecycle tests, a package README, site guides and demo, browser-support documentation, meta-package exports, and a changeset.
+
+Unavailability behavior is consistent by entry-point role:
+
+- Detection and probe helpers do not throw: `isAvailable()` returns `false`, and `checkAvailability()` returns `null`, when the native API cannot be used.
+- High-level vanilla execution may throw a package-specific typed unavailability error so callers can branch explicitly.
+- React hooks absorb that error and expose an `"unavailable"` state.
+- Registration-style APIs may instead return an idempotent no-op cleanup when that preserves their natural call shape.
+
+Capability-specific ergonomics are not copied mechanically from the nearest package:
+
+- Cache native sessions only when reuse is safe. Bound or explicitly clear the cache, destroy evicted instances, and remove rejected creation promises so later calls can retry.
+- Add result caching only when every output-shaping input can be keyed, the output has a lossless serialization, and serving a stored result remains semantically valid. Include a version or compatibility discriminator when the capability's outputs depend on one.
+- Preserve structured native results when their metadata carries compatibility or lifecycle meaning.
+- Add download monitoring, streaming, or abort forwarding only when the native capability supports it or the wrapper can describe its weaker semantics precisely.
+
+Promotion between stages is a documentation and support decision, not automatically a breaking release. Breaking wrapper changes still follow Changesets and the package's current semantic-versioning contract.
+
 ## Adding a new package
 
-1. Copy an existing package whose shape matches what you need (`prompt` if you want streaming + session cache + opt-in result cache, `webmcp` if you want an AbortSignal registry, `translator` if you want DOM-walking).
-2. Mirror the file layout: `src/api.ts` (adapter over the global, feature-detected), `src/index.ts` (public API + typed unavailability error), `src/react/index.ts` (thin hook adapter), `src/*.test.ts` (vanilla tests), `src/react/index.test.tsx` (React hook tests). Optional: `src/cache.ts` if the package has a result cache.
-3. Add the package to the Pages docs (`apps/site/src/content/docs/guides/<name>.mdx`, `apps/site/src/content/docs/react/use-<name>.mdx`, plus a demo component) and to the home page's package row.
-4. Add a changeset.
-5. Run `pnpm gate`.
-6. **Publish the first version locally.** A brand-new package can't be created by CI (OIDC Trusted Publishing needs the package to already exist, and a CI token can't create new `@web-ai-sdk` packages — npm returns a masked `404`). Do the initial publish by hand: `npm login`, `pnpm build:packages`, then `cd packages/<new> && npm publish --access public --provenance=false`. After that, set up a Trusted Publisher for it on npm and CI handles every later version.
+1. Confirm the capability has reached Preview, Trial, or Stable under the adoption policy above. A Tracked capability stays as an issue.
+2. Copy an existing package whose shape matches what you need (`prompt` if you want streaming + session cache + opt-in result cache, `webmcp` if you want an AbortSignal registry, `translator` if you want DOM-walking).
+3. Mirror the file layout: `src/api.ts` (adapter over the global, feature-detected), `src/index.ts` (public API + typed unavailability error), `src/react/index.ts` (thin hook adapter), `src/*.test.ts` (vanilla tests), `src/react/index.test.tsx` (React hook tests). Optional: `src/cache.ts` only when the capability meets the result-cache gate above.
+4. Add the package to the Pages docs (`apps/site/src/content/docs/guides/<name>.mdx`, `apps/site/src/content/docs/react/use-<name>.mdx`, plus a demo component) and to the home page's package row.
+5. Add a changeset.
+6. Run `pnpm gate`.
+7. **Publish the first version locally.** A brand-new package can't be created by CI (OIDC Trusted Publishing needs the package to already exist, and a CI token can't create new `@web-ai-sdk` packages — npm returns a masked `404`). Do the initial publish by hand: `npm login`, `pnpm build:packages`, then `cd packages/<new> && npm publish --access public --provenance=false`. After that, set up a Trusted Publisher for it on npm and CI handles every later version.
 
 See [`.agents/agents.md` § "Add a new tool / wrapper package"](./.agents/agents.md#add-a-new-tool--wrapper-package) and [§ "Cut a release"](./.agents/agents.md#cut-a-release) for the full conventions.
 

--- a/apps/site/src/content/docs/architecture.mdx
+++ b/apps/site/src/content/docs/architecture.mdx
@@ -29,6 +29,30 @@ This is forced by shape, not just taste. The specialized built-ins carry option 
 
 No SDK package imports from another published SDK package. Composition across capabilities (running a Prompt session over a tool registered with WebMCP, for example) is something you write in your application code.
 
+## When a capability enters the SDK
+
+Capabilities enter the SDK according to public evidence and wrapper value, not a calendar date:
+
+| Stage | SDK treatment |
+| --- | --- |
+| **Tracked** | An authoritative proposal exists, but the capability cannot yet be responsibly implemented and documented from public information. Track it in an issue; do not publish a package. |
+| **Preview** | Public instructions expose a runnable, coherent capability with a material lifecycle or ergonomics gap. An experimental `0.x` package may ship, even when a preview browser or flag is required. |
+| **Trial** | A public developer or origin trial is available. Keep the package `0.x` while expanding browser coverage and demos. |
+| **Stable** | A stable browser exposes the capability without a flag or trial token. Mark support stable; package `1.0` is a separate API-stability decision. |
+| **Retired** | The proposal is withdrawn or replaced. Deprecate the package and document migration rather than repurposing it. |
+
+Moving from Tracked to Preview requires all of the following:
+
+- an authoritative public explainer, specification, or browser-vendor document and enough public information to test the capability;
+- one cohesive package boundary;
+- meaningful lifecycle value beyond types, such as feature detection, availability, session reuse, cleanup, abort handling, or stream normalization;
+- zero runtime dependencies, deterministic tests, and a deliberate unsupported-browser behavior;
+- a narrow surface that does not pull persistence, cross-capability composition, or unrelated algorithms into the wrapper.
+
+Public packages and their issues, PRs, docs, demos, changelogs, and release notes must be supportable entirely from public sources. Confidential or restricted preview material is never published or used to reveal non-public versions, flags, behavior, or timelines. When public evidence is insufficient, the capability stays Tracked.
+
+Preview and Trial describe browser maturity, not lower quality expectations. Experimental packages still ship the standard vanilla API, React adapter, tests, status documentation, and meta-package integration. The complete contributor checklist lives in [CONTRIBUTING.md](https://github.com/obetomuniz/web-ai-sdk/blob/main/CONTRIBUTING.md#capability-adoption-policy).
+
 ## Zero-dependency policy
 
 Every `@web-ai-sdk/*` package ships with **no runtime dependencies and no peer dependencies**. The one exception is `react`, which is declared as an *optional* peer for the `/react` subpath adapter only.


### PR DESCRIPTION
## Summary

- define lifecycle stages for tracked, preview, trial, stable, and retired capabilities
- add objective admission criteria for new wrapper packages
- standardize the required integration surface and capability-specific exceptions
- document the policy for contributors, agents, and SDK consumers

## Why

The existing governance defines how packages must be structured, but not when an emerging browser capability is mature enough to enter the SDK. This leaves adoption decisions dependent on precedent rather than an explicit, reusable policy.

## Scope

Documentation and governance only. This does not add or modify any runtime package.

## Validation

- `pnpm gate`