### PR TITLE
fix(prompt): make initial instruction precedence observable

### DIFF
--- a/.changeset/beige-seals-poke.md
+++ b/.changeset/beige-seals-poke.md
@@ -1,0 +1,5 @@
+---
+"@web-ai-sdk/prompt": patch
+---
+
+Warn once when createOptions.initialPrompts overrides systemPrompt, and document eager session creation and readiness.

--- a/apps/site/src/content/docs/guides/prompt.mdx
+++ b/apps/site/src/content/docs/guides/prompt.mdx
@@ -109,6 +109,8 @@ The wrapper is intentionally thin. It handles cross-browser smoothing every cons
 
 `createSession()` never touches the `ask()` session cache. Two sessions with identical options get two independent instances with isolated history, system prompt, sampling, and lifecycle — `abort()` / `destroy()` on one session never touch another. Concurrent `send` / `sendStreaming` calls on the **same** session are NOT queued — the underlying `LanguageModel` is sequential per instance and will reject the overlapping call with `InvalidStateError`. Either `await` the previous send or call `session.abort()` before issuing a new turn.
 
+Calling `createSession()` starts `LanguageModel.create()` immediately. The first `send`, `sendStreaming`, or `clone` only awaits that already-started creation, so creating a base as soon as the user's intent is clear is a valid prewarming primitive. Finalize the initial instructions at that point; the native session is already being created when the synchronous wrapper returns.
+
 **Concurrency note.** Each session is an independent `LanguageModel` instance, but the underlying on-device model is single-instance. Chrome 148 / Edge 138 currently schedule `sendStreaming` calls across sessions FIFO: overlapping sends do not interleave token-by-token — the second send waits for the first to drain. This is a constraint of the runtime, not of the API; code written against `createSession()` becomes faster automatically if a future release exposes parallel inference.
 
 ## Session resilience: base + per-task `clone()`
@@ -116,9 +118,10 @@ The wrapper is intentionally thin. It handles cross-browser smoothing every cons
 For agents and multi-task flows there's a lose-lose with naive session handling: reuse one long-lived session and history accumulates (later runs start echoing earlier ones, and you eventually hit `QuotaExceededError`); recreate a session per task and you pay the cold start and can trip Chrome's single-instance degradation. Chrome's [session management guidance](https://developer.chrome.com/docs/ai/session-management) recommends a third way: keep one warm **base** session (system prompt only) and `clone()` it per task. The clone inherits the system prompt and history without re-parsing instructions or paying another `create()`, then gets its own independent history and lifecycle.
 
 ```ts
-const base = createSession({ systemPrompt }); // create once; keep warm
+// As soon as the workflow is chosen, begin native creation with final instructions.
+const base = createSession({ systemPrompt }); // eager prewarm; keep this base
 // per task / run:
-const turn = await base.clone();              // fresh history, no re-parse
+const turn = await base.clone();              // awaits base readiness, then fresh history
 try {
   for await (const delta of turn.sendStreaming(input)) render(delta);
 } finally {
@@ -186,11 +189,11 @@ They compose: prefill the opening brace, set `responseConstraint` for the full s
 - `session.contextWindow` — max input tokens for the session (the context window).
 - `session.contextUsage` — input tokens used so far. On a fresh base-clone this reflects the inherited history (≈ the system prompt), the right baseline to budget a turn against.
 
-These mirror the Prompt API's [`contextWindow` / `contextUsage`](https://developer.chrome.com/docs/ai/prompt-api#session_management) (the renamed successors of `inputQuota` / `inputUsage`); the wrapper reads the new names and falls back to the deprecated ones on older Chrome builds. Both are `undefined` until the underlying instance exists. The instance is created lazily on the first `send` / `sendStreaming`, so read them after a `send` or — cleaner — on a session from `clone()`, whose instance is live the moment `clone()` resolves.
+These mirror the Prompt API's [`contextWindow` / `contextUsage`](https://developer.chrome.com/docs/ai/prompt-api#session_management) (the renamed successors of `inputQuota` / `inputUsage`); the wrapper reads the new names and falls back to the deprecated ones on older Chrome builds. Calling `createSession()` starts native creation eagerly, but the wrapper returns synchronously, so both getters remain `undefined` while that promise is in flight. The first `send` awaits the already-started creation; alternatively, read the getters on a session from `clone()`, whose native instance is live the moment `clone()` resolves. React's `useSession` similarly stays `"loading"` until creation resolves.
 
 ```ts
-const base = createSession({ systemPrompt }); // keep warm
-const turn = await base.clone();               // instance is live here
+const base = createSession({ systemPrompt }); // native creation starts here
+const turn = await base.clone();               // awaits readiness; clone is live here
 const quota = turn.contextWindow;              // e.g. 4096 / 6144 tokens
 const used = turn.contextUsage ?? 0;           // ≈ system prompt
 if (quota) {
@@ -226,6 +229,8 @@ The two cache-shaped items above are *ergonomic defaults scoped to `ask()`*, not
 ## System prompt + sampling
 
 `systemPrompt` is folded into the session's `initialPrompts` as a `system` role. Prefer `samplingMode` for output variety: the browser maps the semantic mode to model-appropriate sampling parameters. Legacy `temperature` and `topK` are still passed through where browsers expose them, but they are mutually exclusive with `samplingMode`.
+
+For `createSession`, use either the `systemPrompt` shorthand or `createOptions.initialPrompts` for restored multi-turn context. If both are provided, the advanced `initialPrompts` value is authoritative and the SDK warns once per loaded module instance that `systemPrompt` was ignored.
 
 ```ts
 ask({
@@ -347,4 +352,4 @@ try {
 }
 ```
 
-`createSession()` returns a `Session` synchronously even when creation fails; the error surfaces on the first `send` / `sendStreaming`.
+`createSession()` starts native creation immediately and returns a `Session` wrapper synchronously. If creation fails, the error surfaces when the first `send`, `sendStreaming`, or `clone` awaits that already-started work.

--- a/apps/site/src/content/docs/packages/prompt.md
+++ b/apps/site/src/content/docs/packages/prompt.md
@@ -67,6 +67,8 @@ session.destroy();
 
 Every `createSession()` call returns an independent `LanguageModelInstance` with its own history, system prompt, sampling, and lifecycle — `abort()` / `destroy()` on one session never touch another. Concurrent `send` / `sendStreaming` calls on the **same** session are NOT queued — the underlying `LanguageModel` is sequential per instance and will reject the overlapping call with `InvalidStateError`. Either `await` the previous send or call `session.abort()` before issuing a new turn. Multi-turn conversation context is tracked by the native instance itself; UI message lists are your data model.
 
+Calling `createSession()` starts `LanguageModel.create()` immediately. The first `send`, `sendStreaming`, or `clone` only awaits that already-started creation, so creating a base session as soon as the user's intent is clear is a valid prewarming primitive. The synchronous `Session` wrapper is returned before native creation necessarily resolves; see [Context-window introspection](#context-window-introspection) for the resulting getter-readiness distinction.
+
 **Concurrency note.** Each session is an independent `LanguageModel` instance: independent history, system prompt, sampling, and lifecycle. The underlying on-device model is single-instance, so the browser currently schedules `sendStreaming` calls across sessions FIFO. Overlapping sends do not interleave token-by-token in Chrome 148 / Edge 138 — the second send waits for the first to drain. This is a constraint of the runtime, not of the API; code written against `createSession()` becomes faster automatically if a future release exposes parallel inference.
 
 ## React
@@ -173,8 +175,6 @@ interface AskResult {
 
 `onUpdate` receives the cumulative text so far, not deltas. For delta-shaped streaming use `createSession().sendStreaming()`.
 
-If `systemPrompt` is passed alongside `createOptions.initialPrompts`, the SDK emits a one-shot `console.warn` because `initialPrompts` overrides the synthesized system prompt and the persona is silently lost.
-
 ### `createSession(options?): Session`
 
 ```ts
@@ -203,8 +203,8 @@ interface SessionSendOptions {
 
 interface Session {
   readonly destroyed: boolean;
-  readonly contextWindow?: number; // context window in tokens; undefined pre-creation
-  readonly contextUsage?: number;  // tokens used so far; undefined pre-creation
+  readonly contextWindow?: number; // context window in tokens; undefined until eager creation resolves
+  readonly contextUsage?: number;  // tokens used so far; undefined until eager creation resolves
   send(input: string | LanguageModelMessage[], options?: SessionSendOptions): Promise<string | null>;
   sendStreaming(input: string | LanguageModelMessage[], options?: SessionSendOptions): AsyncIterable<string>;
   abort(): void;
@@ -214,6 +214,8 @@ interface Session {
   destroy(): void;
 }
 ```
+
+`createOptions` is merged last for advanced native control. If both `systemPrompt` and `createOptions.initialPrompts` are provided, `createOptions.initialPrompts` remains authoritative and the SDK emits a clear `console.warn` once per loaded module instance. Use one instruction surface: `systemPrompt` for the shorthand, or `initialPrompts` when restoring richer context.
 
 `Session.sendStreaming()` yields **deltas** (each chunk is the new text since the last yield, never cumulative). The wrapper does no extra bookkeeping: no history tracking, no concurrent-send queue, no usage telemetry. Always destroy sessions you no longer need.
 
@@ -256,9 +258,10 @@ To declare the native tool modalities, pass them through the advanced `expectedI
 For agents and multi-task flows, reusing one long-lived session lets history accumulate (later runs "echo" earlier ones, and you eventually hit `QuotaExceededError`), while recreating a session per task pays the cold start and can hit Chrome's single-instance degradation. The spec's [recommended pattern](https://developer.chrome.com/docs/ai/session-management) is to keep one warm **base** session (system prompt only) and `clone()` it per task: the clone inherits the system prompt and history without re-parsing or another `create()`, then gets independent history and lifecycle.
 
 ```ts
-const base = createSession({ systemPrompt }); // once; keep warm
+// As soon as the workflow is chosen, begin native creation with final instructions.
+const base = createSession({ systemPrompt }); // eager prewarm; keep this base
 // per task / run:
-const turn = await base.clone();              // fresh history, no re-parse
+const turn = await base.clone();              // awaits base readiness, then fresh history
 try {
   for await (const delta of turn.sendStreaming(input)) render(delta);
 } finally {
@@ -321,7 +324,7 @@ They compose: prefill the opening brace, set `responseConstraint` for the full s
 
 ### Context-window introspection
 
-`Session` surfaces the live token budget the native instance reports, so consumers can size work to the actual context window instead of hardcoding a char cap. Both are `undefined` until the underlying instance exists — the instance is created lazily on the first `send` / `sendStreaming`, so read them after a `send` or (cleaner) on a session from `clone()`, whose instance is live the moment `clone()` resolves.
+`Session` surfaces the live token budget the native instance reports, so consumers can size work to the actual context window instead of hardcoding a char cap. Calling `createSession()` starts native creation eagerly, but the wrapper returns synchronously: both getters remain `undefined` while that creation promise is in flight. The first `send` awaits the already-started creation; alternatively, read the getters on a session from `clone()`, whose instance is live the moment `clone()` resolves. In React, `useSession` does not report `"ready"` until the same native creation has resolved.
 
 - `session.contextWindow` — max input tokens for the session (the context window).
 - `session.contextUsage` — input tokens used so far. On a fresh base-clone this reflects the inherited history (≈ the system prompt), the right baseline to budget a turn against.
@@ -329,8 +332,8 @@ They compose: prefill the opening brace, set `responseConstraint` for the full s
 These mirror the Prompt API's `contextWindow` / `contextUsage` (the renamed successors of `inputQuota` / `inputUsage`); the wrapper reads the new names and falls back to the deprecated ones on older Chrome builds.
 
 ```ts
-const base = createSession({ systemPrompt }); // keep warm
-const turn = await base.clone();               // instance is live here
+const base = createSession({ systemPrompt }); // native creation starts here
+const turn = await base.clone();               // awaits readiness; clone is live here
 const quota = turn.contextWindow;              // e.g. 4096 / 6144 tokens
 const used = turn.contextUsage ?? 0;           // ≈ system prompt
 if (quota) {
@@ -397,7 +400,7 @@ ask({ input: "hi", cache: myMap, cacheKey: "greeting" });
 
 The vanilla `ask()` throws `PromptUnavailableError` when the API is missing or reports `availability: "unavailable"`. The React hook absorbs this and returns `status: "unavailable"` instead.
 
-`createSession()` returns a `Session` synchronously even if the underlying `create()` rejects; the error surfaces on the first `send` / `sendStreaming`. In React, `useSession()` waits for native creation before reporting `"ready"` and reports `"unavailable"` with `error` if creation fails.
+`createSession()` starts native creation immediately and returns a `Session` wrapper synchronously. If the underlying `create()` rejects, the error surfaces when the first `send`, `sendStreaming`, or `clone` awaits that already-started work. In React, `useSession()` waits for native creation before reporting `"ready"` and reports `"unavailable"` with `error` if creation fails.
 
 `AbortSignal` is supported on every surface. Aborting mid-stream resolves cleanly; the result cache is not written for aborted runs. Aborts reject with `PromptAbortError` (exported; `instanceof PromptAbortError` works, and its `name` is `"AbortError"`), thrown by both `ask()` and sessions.
 

--- a/apps/site/src/content/docs/react/use-session.mdx
+++ b/apps/site/src/content/docs/react/use-session.mdx
@@ -7,6 +7,8 @@ Lifecycle-only React adapter for the chat-shaped [`createSession()`](/docs/guide
 
 For ask-and-display flows (embeds, widgets, single-question UIs) prefer [`usePrompt`](/docs/react/use-prompt/); it uses isolated one-shot prompts and may keep a warm base session for same-shape calls.
 
+When enabled, mounting `useSession` starts `LanguageModel.create()` in the hook's lifecycle effect; it does not wait for a call to `send`. This makes mounting an intent-driven workflow a valid prewarm. The hook stays `"loading"` and keeps `session` null until that eagerly started native creation resolves.
+
 ## Usage
 
 ```tsx
@@ -81,7 +83,8 @@ const { session } = useSession({ systemPrompt });
 
 const runTask = async (input: string) => {
   if (!session) return;
-  const turn = await session.clone(); // fresh history, base stays warm
+  // Native base creation started when the hook mounted; clone from the ready base.
+  const turn = await session.clone();
   try {
     for await (const delta of turn.sendStreaming(input)) render(delta);
   } finally {
@@ -130,7 +133,6 @@ Pass `createOptions.initialPrompts` to restore a prior conversation:
 
 ```tsx
 const { status, session } = useSession({
-  systemPrompt: "You are a helpful assistant.",
   createOptions: {
     initialPrompts: [
       { role: "system", content: "You are a helpful assistant." },
@@ -143,7 +145,7 @@ const { status, session } = useSession({
 if (status !== "ready" || !session) return null;
 ```
 
-The seeded turns become real context for the model. UI history lives in your own component state.
+The seeded turns become real context for the model. UI history lives in your own component state. Use either the `systemPrompt` shorthand or `createOptions.initialPrompts`, without duplicating the instruction. If both are supplied, `initialPrompts` is authoritative and the SDK warns once per loaded module instance that `systemPrompt` was ignored.
 
 ## Reference
 

--- a/packages/prompt/README.md
+++ b/packages/prompt/README.md
@@ -60,6 +60,8 @@ session.destroy();
 
 Every `createSession()` call returns an independent `LanguageModelInstance` with its own history, system prompt, sampling, and lifecycle — `abort()` / `destroy()` on one session never touch another. Concurrent `send` / `sendStreaming` calls on the **same** session are NOT queued — the underlying `LanguageModel` is sequential per instance and will reject the overlapping call with `InvalidStateError`. Either `await` the previous send or call `session.abort()` before issuing a new turn. Multi-turn conversation context is tracked by the native instance itself; UI message lists are your data model.
 
+Calling `createSession()` starts `LanguageModel.create()` immediately. The first `send`, `sendStreaming`, or `clone` only awaits that already-started creation, so creating a base session as soon as the user's intent is clear is a valid prewarming primitive. The synchronous `Session` wrapper is returned before native creation necessarily resolves; see [Context-window introspection](#context-window-introspection) for the resulting getter-readiness distinction.
+
 **Concurrency note.** Each session is an independent `LanguageModel` instance: independent history, system prompt, sampling, and lifecycle. The underlying on-device model is single-instance, so the browser currently schedules `sendStreaming` calls across sessions FIFO. Overlapping sends do not interleave token-by-token in Chrome 148 / Edge 138 — the second send waits for the first to drain. This is a constraint of the runtime, not of the API; code written against `createSession()` becomes faster automatically if a future release exposes parallel inference.
 
 ## React
@@ -166,8 +168,6 @@ interface AskResult {
 
 `onUpdate` receives the cumulative text so far, not deltas. For delta-shaped streaming use `createSession().sendStreaming()`.
 
-If `systemPrompt` is passed alongside `createOptions.initialPrompts`, the SDK emits a one-shot `console.warn` because `initialPrompts` overrides the synthesized system prompt and the persona is silently lost.
-
 ### `createSession(options?): Session`
 
 ```ts
@@ -196,8 +196,8 @@ interface SessionSendOptions {
 
 interface Session {
   readonly destroyed: boolean;
-  readonly contextWindow?: number; // context window in tokens; undefined pre-creation
-  readonly contextUsage?: number;  // tokens used so far; undefined pre-creation
+  readonly contextWindow?: number; // context window in tokens; undefined until eager creation resolves
+  readonly contextUsage?: number;  // tokens used so far; undefined until eager creation resolves
   send(input: string | LanguageModelMessage[], options?: SessionSendOptions): Promise<string | null>;
   sendStreaming(input: string | LanguageModelMessage[], options?: SessionSendOptions): AsyncIterable<string>;
   abort(): void;
@@ -207,6 +207,8 @@ interface Session {
   destroy(): void;
 }
 ```
+
+`createOptions` is merged last for advanced native control. If both `systemPrompt` and `createOptions.initialPrompts` are provided, `createOptions.initialPrompts` remains authoritative and the SDK emits a clear `console.warn` once per loaded module instance. Use one instruction surface: `systemPrompt` for the shorthand, or `initialPrompts` when restoring richer context.
 
 `Session.sendStreaming()` yields **deltas** (each chunk is the new text since the last yield, never cumulative). The wrapper does no extra bookkeeping: no history tracking, no concurrent-send queue, no usage telemetry. Always destroy sessions you no longer need.
 
@@ -249,9 +251,10 @@ To declare the native tool modalities, pass them through the advanced `expectedI
 For agents and multi-task flows, reusing one long-lived session lets history accumulate (later runs "echo" earlier ones, and you eventually hit `QuotaExceededError`), while recreating a session per task pays the cold start and can hit Chrome's single-instance degradation. The spec's [recommended pattern](https://developer.chrome.com/docs/ai/session-management) is to keep one warm **base** session (system prompt only) and `clone()` it per task: the clone inherits the system prompt and history without re-parsing or another `create()`, then gets independent history and lifecycle.
 
 ```ts
-const base = createSession({ systemPrompt }); // once; keep warm
+// As soon as the workflow is chosen, begin native creation with final instructions.
+const base = createSession({ systemPrompt }); // eager prewarm; keep this base
 // per task / run:
-const turn = await base.clone();              // fresh history, no re-parse
+const turn = await base.clone();              // awaits base readiness, then fresh history
 try {
   for await (const delta of turn.sendStreaming(input)) render(delta);
 } finally {
@@ -314,7 +317,7 @@ They compose: prefill the opening brace, set `responseConstraint` for the full s
 
 ### Context-window introspection
 
-`Session` surfaces the live token budget the native instance reports, so consumers can size work to the actual context window instead of hardcoding a char cap. Both are `undefined` until the underlying instance exists — the instance is created lazily on the first `send` / `sendStreaming`, so read them after a `send` or (cleaner) on a session from `clone()`, whose instance is live the moment `clone()` resolves.
+`Session` surfaces the live token budget the native instance reports, so consumers can size work to the actual context window instead of hardcoding a char cap. Calling `createSession()` starts native creation eagerly, but the wrapper returns synchronously: both getters remain `undefined` while that creation promise is in flight. The first `send` awaits the already-started creation; alternatively, read the getters on a session from `clone()`, whose instance is live the moment `clone()` resolves. In React, `useSession` does not report `"ready"` until the same native creation has resolved.
 
 - `session.contextWindow` — max input tokens for the session (the context window).
 - `session.contextUsage` — input tokens used so far. On a fresh base-clone this reflects the inherited history (≈ the system prompt), the right baseline to budget a turn against.
@@ -322,8 +325,8 @@ They compose: prefill the opening brace, set `responseConstraint` for the full s
 These mirror the Prompt API's `contextWindow` / `contextUsage` (the renamed successors of `inputQuota` / `inputUsage`); the wrapper reads the new names and falls back to the deprecated ones on older Chrome builds.
 
 ```ts
-const base = createSession({ systemPrompt }); // keep warm
-const turn = await base.clone();               // instance is live here
+const base = createSession({ systemPrompt }); // native creation starts here
+const turn = await base.clone();               // awaits readiness; clone is live here
 const quota = turn.contextWindow;              // e.g. 4096 / 6144 tokens
 const used = turn.contextUsage ?? 0;           // ≈ system prompt
 if (quota) {
@@ -390,7 +393,7 @@ ask({ input: "hi", cache: myMap, cacheKey: "greeting" });
 
 The vanilla `ask()` throws `PromptUnavailableError` when the API is missing or reports `availability: "unavailable"`. The React hook absorbs this and returns `status: "unavailable"` instead.
 
-`createSession()` returns a `Session` synchronously even if the underlying `create()` rejects; the error surfaces on the first `send` / `sendStreaming`. In React, `useSession()` waits for native creation before reporting `"ready"` and reports `"unavailable"` with `error` if creation fails.
+`createSession()` starts native creation immediately and returns a `Session` wrapper synchronously. If the underlying `create()` rejects, the error surfaces when the first `send`, `sendStreaming`, or `clone` awaits that already-started work. In React, `useSession()` waits for native creation before reporting `"ready"` and reports `"unavailable"` with `error` if creation fails.
 
 `AbortSignal` is supported on every surface. Aborting mid-stream resolves cleanly; the result cache is not written for aborted runs. Aborts reject with `PromptAbortError` (exported; `instanceof PromptAbortError` works, and its `name` is `"AbortError"`), thrown by both `ask()` and sessions.
 

--- a/packages/prompt/src/index.test.ts
+++ b/packages/prompt/src/index.test.ts
@@ -793,14 +793,59 @@ describe("ask", () => {
 });
 
 describe("createSession", () => {
+  it("keeps createOptions.initialPrompts authoritative and warns once about conflicts", () => {
+    const fake = installFakeLanguageModel();
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const advancedPrompts = [
+      { role: "system" as const, content: "Use the restored persona." },
+      { role: "user" as const, content: "A restored turn." },
+    ];
+
+    const systemOnly = createSession({ systemPrompt: "Use the shorthand." });
+    const advancedOnly = createSession({
+      createOptions: { initialPrompts: advancedPrompts },
+    });
+
+    expect(warn).not.toHaveBeenCalled();
+    expect(fake.create.mock.calls[0]?.[0]).toMatchObject({
+      initialPrompts: [{ role: "system", content: "Use the shorthand." }],
+    });
+    expect(fake.create.mock.calls[1]?.[0]).toMatchObject({
+      initialPrompts: advancedPrompts,
+    });
+
+    const firstConflict = createSession({
+      systemPrompt: "This must be ignored.",
+      createOptions: { initialPrompts: advancedPrompts },
+    });
+    const repeatedConflict = createSession({
+      systemPrompt: "This must also be ignored.",
+      createOptions: { initialPrompts: advancedPrompts },
+    });
+
+    expect(fake.create.mock.calls[2]?.[0]).toMatchObject({
+      initialPrompts: advancedPrompts,
+    });
+    expect(fake.create.mock.calls[3]?.[0]).toMatchObject({
+      initialPrompts: advancedPrompts,
+    });
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn).toHaveBeenCalledWith(
+      "[@web-ai-sdk/prompt] `systemPrompt` was ignored because `createOptions.initialPrompts` was also provided; `createOptions.initialPrompts` takes precedence.",
+    );
+
+    systemOnly.destroy();
+    advancedOnly.destroy();
+    firstConflict.destroy();
+    repeatedConflict.destroy();
+    warn.mockRestore();
+  });
+
   it("never shares an instance across calls (parallel chats stream concurrently)", async () => {
     const fake = installFakeLanguageModel();
     const a = createSession({ systemPrompt: "X" });
     const b = createSession({ systemPrompt: "X" });
-    // Trigger creation by issuing an empty send (returns null without
-    // touching the model, but awaits the underlying create()).
-    await Promise.resolve();
-    await Promise.resolve();
+    // Creation starts eagerly; no send is needed to trigger it.
     expect(fake.create).toHaveBeenCalledTimes(2);
     a.destroy();
     b.destroy();
@@ -1297,7 +1342,7 @@ describe("Session.append", () => {
 });
 
 describe("Session context introspection", () => {
-  it("contextWindow / contextUsage are undefined before the instance is created", () => {
+  it("contextWindow / contextUsage are undefined while eager creation is in flight", () => {
     installFakeLanguageModel({ response: "ok" });
     const session = createSession({ systemPrompt: "S" });
     expect(session.contextWindow).toBeUndefined();
@@ -1395,7 +1440,7 @@ describe("Session.onContextOverflow", () => {
       }),
     });
     const session = createSession({ systemPrompt: "S" });
-    await session.send("warm"); // force create() so the listener attaches
+    await session.send("warm"); // await eager creation before attaching
     const onOverflow = vi.fn();
     const stop = session.onContextOverflow(onOverflow);
     await Promise.resolve();
@@ -1413,7 +1458,7 @@ describe("Session.onContextOverflow", () => {
     session.destroy();
   });
 
-  it("never attaches when cleanup runs before the instance is created", async () => {
+  it("never attaches when cleanup runs before eager creation resolves", async () => {
     const emitter = makeEmitter();
     installFakeLanguageModel({
       sessionFactory: () => ({
@@ -1425,7 +1470,7 @@ describe("Session.onContextOverflow", () => {
     });
     const session = createSession({ systemPrompt: "S" });
     const stop = session.onContextOverflow(vi.fn());
-    stop(); // before any send → instance not created yet
+    stop(); // synchronously, while eager creation is still in flight
     await session.send("warm");
     await Promise.resolve();
     expect(emitter.addEventListener).not.toHaveBeenCalled();

--- a/packages/prompt/src/react/index.test.tsx
+++ b/packages/prompt/src/react/index.test.tsx
@@ -238,6 +238,27 @@ describe("useSession", () => {
     expect(api.create).toHaveBeenCalledTimes(2);
   });
 
+  it("does not repeat the initial-prompt conflict warning across recreations", () => {
+    const api = installFakeLanguageModel();
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const createOptions = {
+      initialPrompts: [
+        { role: "system" as const, content: "Use restored instructions." },
+      ],
+    };
+    const { rerender } = renderHook(
+      ({ p }: { p: string }) => useSession({ systemPrompt: p, createOptions }),
+      { initialProps: { p: "Ignored A" } },
+    );
+
+    expect(api.create).toHaveBeenCalledTimes(1);
+    expect(warn).toHaveBeenCalledTimes(1);
+    rerender({ p: "Ignored B" });
+    expect(api.create).toHaveBeenCalledTimes(2);
+    expect(warn).toHaveBeenCalledTimes(1);
+    warn.mockRestore();
+  });
+
   it("recreates the session when samplingMode changes", () => {
     const api = installFakeLanguageModel();
     type SamplingModeProps = { samplingMode: "predictable" | "creative" };

--- a/packages/prompt/src/session.ts
+++ b/packages/prompt/src/session.ts
@@ -190,7 +190,9 @@ export interface CreateSessionOptions {
   /**
    * Override `LanguageModel.create()` options entirely. Merged on top of
    * defaults. Pass `initialPrompts` here to seed multi-turn context (e.g.
-   * restoring a conversation from storage).
+   * restoring a conversation from storage). When both `systemPrompt` and
+   * `createOptions.initialPrompts` are provided, `initialPrompts` wins and
+   * the SDK warns once per module instance.
    */
   createOptions?: Partial<LanguageModelCreateOptions>;
 }
@@ -262,10 +264,10 @@ export interface Session {
   /**
    * Max input tokens for this session (the context window), as reported by
    * the underlying instance — mirrors the native `contextWindow`. `undefined`
-   * until the instance is created — the instance is created lazily on the
-   * first `send` / `sendStreaming`, so read it after a `send` or (preferably)
-   * on a session from `clone()`, whose instance is live the moment `clone()`
-   * resolves.
+   * until the eager native creation started by `createSession()` resolves.
+   * The synchronous wrapper has no readiness event, so read it after a `send`
+   * or (preferably) on a session from `clone()`, whose instance is live the
+   * moment `clone()` resolves.
    */
   readonly contextWindow?: number;
   /**
@@ -295,10 +297,32 @@ export interface SessionWithReady {
   ready: Promise<void>;
 }
 
+let didWarnAboutInitialPromptConflict = false;
+
+const warnAboutInitialPromptConflict = (
+  options: CreateSessionOptions,
+): void => {
+  if (
+    didWarnAboutInitialPromptConflict ||
+    options.systemPrompt === undefined ||
+    options.createOptions?.initialPrompts === undefined
+  ) {
+    return;
+  }
+
+  didWarnAboutInitialPromptConflict = true;
+  if (typeof console !== "undefined") {
+    console.warn(
+      "[@web-ai-sdk/prompt] `systemPrompt` was ignored because `createOptions.initialPrompts` was also provided; `createOptions.initialPrompts` takes precedence.",
+    );
+  }
+};
+
 const buildCreateOptions = (
   options: CreateSessionOptions,
 ): LanguageModelCreateOptions => {
   assertValidSamplingOptions(options);
+  warnAboutInitialPromptConflict(options);
   const initialPrompts = options.systemPrompt
     ? [{ role: "system" as const, content: options.systemPrompt }]
     : [];
@@ -345,7 +369,7 @@ const wrapInstance = (
   // Synchronous handle on the live instance so the `inputQuota` / `inputUsage`
   // getters can read it without awaiting. Seeded eagerly for clones (whose
   // instance already exists when `clone()` resolves) and otherwise populated
-  // once the lazy `create()` settles.
+  // once the eagerly started `create()` settles.
   let liveInstance: LanguageModelInstance | null = resolvedInstance ?? null;
 
   // Wrap the create-failure promise once so awaiters get the typed error.
@@ -500,8 +524,8 @@ const wrapInstance = (
   const onContextOverflow = (listener: () => void): (() => void) => {
     let cancelled = false;
     let detach: (() => void) | null = null;
-    // The instance may not exist yet (lazy create), so wait for `ready` and
-    // attach then — unless cleanup ran first.
+    // Eager creation may still be in flight, so wait for `ready` and attach
+    // then — unless cleanup ran first.
     ready
       .then(({ instance }) => {
         if (cancelled) return;
@@ -637,9 +661,11 @@ const wrapInstance = (
  * reject the second call with an `InvalidStateError`. Either `await` the
  * previous call or `session.abort()` before issuing a new turn.
  *
- * The returned `Session` is usable synchronously; the first `send` /
- * `sendStreaming` awaits the underlying `LanguageModel.create()` internally
- * and surfaces creation errors as `PromptUnavailableError`.
+ * Calling `createSession()` starts `LanguageModel.create()` immediately, so it
+ * can intentionally prewarm a session as soon as user intent is known. The
+ * returned `Session` wrapper is available synchronously; its first `send` /
+ * `sendStreaming` only awaits the already-started creation and surfaces
+ * creation errors as `PromptUnavailableError`.
  */
 export const createSession = (options: CreateSessionOptions = {}): Session => {
   return createSessionWithReady(options).session;


### PR DESCRIPTION
## Summary

- Warn once per loaded module when `systemPrompt` conflicts with `createOptions.initialPrompts`.
- Preserve `createOptions.initialPrompts` precedence with vanilla and React regression coverage.
- Document eager session creation, intent-driven prewarming, and synchronous getter readiness.
- Remove examples that duplicate system instructions across both configuration surfaces.
- Add a patch changeset for `@web-ai-sdk/prompt`.

## Root cause

`createOptions.initialPrompts` already overrode the synthesized system prompt, but the documented warning was never implemented. Related docs also described session creation as lazy even though `createSession()` starts `LanguageModel.create()` immediately.

## Validation

- `pnpm --filter @web-ai-sdk/prompt test` — 94 tests passed
- `pnpm --filter @web-ai-sdk-apps/site typecheck`
- `pnpm gate`

## Manual testing

- [ ] Confirm the conflict warning appears once in a supported browser.
- [ ] Verify eager base-session prewarming and per-task cloning.
- [ ] Verify clone cleanup and context-window getter readiness.

Fixes #150
