### PR TITLE
fix(site): treat streamed model output as untrusted

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ import { ask } from "@web-ai-sdk/prompt";
 const { output } = await ask({ input: "Summarize this page in one sentence." });
 ```
 
-A small, focused monorepo of framework-agnostic packages that smooth over the gnarly bits of the new `document.modelContext`, `Translator`, `Summarizer`, `LanguageModel`, `LanguageDetector`, `Writer`, `Rewriter`, and `Proofreader` browser APIs (feature detection, session caching, streaming, lifecycle, safe DOM rebuild) without bringing any UI along.
+A small, focused monorepo of framework-agnostic packages that smooth over the gnarly bits of the new `document.modelContext`, `Translator`, `Summarizer`, `LanguageModel`, `LanguageDetector`, `Writer`, `Rewriter`, and `Proofreader` browser APIs (feature detection, session caching, streaming, lifecycle, and control-character cleanup) without bringing any UI along.
 
 > If you're exploring AI in the browser, a [star on GitHub](https://github.com/obetomuniz/web-ai-sdk) helps others find web-ai-sdk.
 
@@ -23,6 +23,8 @@ The SDK is per-capability because the Web ships more than one AI surface. Six sp
 ## What it is
 
 **`web-ai-sdk`** ships one package per browser capability. Zero runtime dependencies. Written in TypeScript. That's it. The SDK tracks a moving browser spec and intentionally stays out of the way of *how* you build an app.
+
+All model output is untrusted. The SDK strips selected non-printing control characters; that cleanup does **not** make HTML or Markdown safe. Use React interpolation or `textContent` for plain text. If you convert model Markdown or HTML into rendered HTML, keep raw HTML disabled and sanitize the complete accumulated output before inserting it into the DOM—never sanitize and concatenate individual stream chunks, because malicious syntax can span updates.
 
 Compositions that bond multiple primitives (block-level DOM translation,
 article-aware summarization, detect-then-summarize chains) are

--- a/apps/site/src/content/docs/guides/prompt.mdx
+++ b/apps/site/src/content/docs/guides/prompt.mdx
@@ -12,19 +12,28 @@ The package's [README](https://github.com/obetomuniz/web-ai-sdk/tree/main/packag
 ```ts
 import { ask } from "@web-ai-sdk/prompt";
 
+const outputElement = document.querySelector<HTMLElement>("#prompt-output");
 const result = await ask({
   input: "Summarize this in one sentence: WebMCP lets pages expose tools to agents.",
   systemPrompt: "You are concise. Reply with a single sentence.",
   samplingMode: "predictable",
-  onUpdate: (text) => render(text),
+  onUpdate: (text) => {
+    if (outputElement) outputElement.textContent = text;
+  },
 });
 
 console.log(result.output, result.cached);
 ```
 
-Pass `onUpdate` to render partial text as it streams. `result.output` is the final cleaned text; `result.cached` tells you whether the response came back without invoking the model.
+Pass `onUpdate` to render partial text as it streams. `result.output` is the final control-character-cleaned text; `result.cached` tells you whether the response came back without invoking the model.
 
 `onUpdate` receives the **cumulative** buffer, not deltas. For delta-shaped streaming use `createSession().sendStreaming()`.
+
+### Treat model output as untrusted
+
+The Prompt wrapper removes selected non-printing control characters from model responses. This is control-character cleanup, **not** HTML or Markdown sanitization. Treat every final response and streaming update as untrusted.
+
+React interpolation and DOM `textContent`, as shown above, are appropriate for plain text. If you convert model Markdown or HTML into rendered HTML, keep raw HTML disabled and sanitize the complete accumulated buffer before DOM insertion. Do not sanitize and concatenate individual deltas: a malicious construct can be split across stream updates.
 
 ## Options
 
@@ -105,7 +114,7 @@ const text = await session.send("And what about the Prompt API?");
 session.destroy();
 ```
 
-The wrapper is intentionally thin. It handles cross-browser smoothing every consumer would otherwise reimplement (delta-vs-cumulative chunk detection, output sanitization, abort wiring, typed unavailability) and forwards everything else to the native instance. It does **not** track conversation history or queue concurrent sends; those are your data model and UI concerns. It does surface `clone()`, since forking a warm base session is the spec's recommended way to start a fresh task (see [Session resilience](#session-resilience-base--per-task-clone) below).
+The wrapper is intentionally thin. It handles cross-browser smoothing every consumer would otherwise reimplement (delta-vs-cumulative chunk detection, control-character cleanup, abort wiring, typed unavailability) and forwards everything else to the native instance. It does **not** track conversation history or queue concurrent sends; those are your data model and UI concerns. It does surface `clone()`, since forking a warm base session is the spec's recommended way to start a fresh task (see [Session resilience](#session-resilience-base--per-task-clone) below).
 
 `createSession()` never touches the `ask()` session cache. Two sessions with identical options get two independent instances with isolated history, system prompt, sampling, and lifecycle — `abort()` / `destroy()` on one session never touch another. Concurrent `send` / `sendStreaming` calls on the **same** session are NOT queued — the underlying `LanguageModel` is sequential per instance and will reject the overlapping call with `InvalidStateError`. Either `await` the previous send or call `session.abort()` before issuing a new turn.
 
@@ -117,10 +126,15 @@ For agents and multi-task flows there's a lose-lose with naive session handling:
 
 ```ts
 const base = createSession({ systemPrompt }); // create once; keep warm
+const outputElement = document.querySelector<HTMLElement>("#output");
 // per task / run:
 const turn = await base.clone();              // fresh history, no re-parse
+let response = "";
 try {
-  for await (const delta of turn.sendStreaming(input)) render(delta);
+  for await (const delta of turn.sendStreaming(input)) {
+    response += delta;
+    if (outputElement) outputElement.textContent = response;
+  }
 } finally {
   turn.destroy();                             // free the clone, keep the base warm
 }

--- a/apps/site/src/content/docs/guides/rewriter.mdx
+++ b/apps/site/src/content/docs/guides/rewriter.mdx
@@ -14,7 +14,7 @@ const result = await rewrite({
   input: "hey, can u send me that doc when u get a sec? thx",
   tone: "more-formal",
   length: "as-is",
-  onUpdate: (text) => render(text),
+  onUpdate: (text) => console.log("partial", text),
 });
 
 console.log(result.output, result.cached);

--- a/apps/site/src/content/docs/guides/summarizer.mdx
+++ b/apps/site/src/content/docs/guides/summarizer.mdx
@@ -15,7 +15,7 @@ const result = await summarize({
   language: "en",
   type: "key-points",
   length: "short",
-  onUpdate: (text) => render(text),
+  onUpdate: (text) => console.log("partial", text),
 });
 
 console.log(result.output, result.cached);
@@ -180,4 +180,3 @@ try {
 ```
 
 `AbortSignal` is supported. Aborting mid-stream resolves cleanly; an opt-in result cache is not written for aborted runs.
-

--- a/apps/site/src/content/docs/guides/writer.mdx
+++ b/apps/site/src/content/docs/guides/writer.mdx
@@ -15,7 +15,7 @@ const result = await write({
   context: "I'm a longstanding customer.",
   tone: "formal",
   length: "medium",
-  onUpdate: (text) => render(text),
+  onUpdate: (text) => console.log("partial", text),
 });
 
 console.log(result.output, result.cached);

--- a/apps/site/src/content/docs/packages/prompt.md
+++ b/apps/site/src/content/docs/packages/prompt.md
@@ -1,6 +1,6 @@
 ---
 title: "@web-ai-sdk/prompt"
-description: "web-ai-sdk building block for the Web's Built-in Prompt API (LanguageModel). One-shot ask() for embeds and widgets, plus a thin createSession() primitive (and React useSession) for chat-shaped apps that need independent per-conversation sessions and delta-shaped streaming. The wrapper smooths cross-browser quirks (delta-vs-cumulative chunks, output sanitization, abort wiring); UI state and conversation history are the consumer's concern."
+description: "web-ai-sdk building block for the Web's Built-in Prompt API (LanguageModel). One-shot ask() for embeds and widgets, plus a thin createSession() primitive (and React useSession) for chat-shaped apps that need independent per-conversation sessions and delta-shaped streaming. The wrapper smooths cross-browser quirks (delta-vs-cumulative chunks, control-character cleanup, abort wiring); UI state and conversation history are the consumer's concern."
 editUrl: https://github.com/obetomuniz/web-ai-sdk/edit/main/packages/prompt/README.md
 ---
 
@@ -8,7 +8,7 @@ editUrl: https://github.com/obetomuniz/web-ai-sdk/edit/main/packages/prompt/READ
 This page is synced from [`packages/prompt/README.md`](https://github.com/obetomuniz/web-ai-sdk/blob/main/packages/prompt/README.md) by `pnpm --filter @web-ai-sdk-apps/site docs:sync`. Edits should go to the README.
 :::
 
-web-ai-sdk building block for the Web's Built-in [Prompt API](https://developer.chrome.com/docs/extensions/ai/prompt-api) (`LanguageModel`). One-shot `ask()` for embeds and widgets, plus a thin `createSession()` primitive (and React `useSession`) for chat-shaped apps that need independent per-conversation sessions and delta-shaped streaming. The wrapper smooths cross-browser quirks (delta-vs-cumulative chunks, output sanitization, abort wiring); UI state and conversation history are the consumer's concern.
+web-ai-sdk building block for the Web's Built-in [Prompt API](https://developer.chrome.com/docs/extensions/ai/prompt-api) (`LanguageModel`). One-shot `ask()` for embeds and widgets, plus a thin `createSession()` primitive (and React `useSession`) for chat-shaped apps that need independent per-conversation sessions and delta-shaped streaming. The wrapper smooths cross-browser quirks (delta-vs-cumulative chunks, control-character cleanup, abort wiring); UI state and conversation history are the consumer's concern.
 
 
 ## Status
@@ -173,6 +173,12 @@ interface AskResult {
 
 `onUpdate` receives the cumulative text so far, not deltas. For delta-shaped streaming use `createSession().sendStreaming()`.
 
+### Treat model output as untrusted
+
+The Prompt wrapper removes selected non-printing control characters from model responses. This is control-character cleanup, **not** HTML or Markdown sanitization. Treat every final response and streaming update as untrusted.
+
+React interpolation (`<p>{output}</p>`) and DOM `textContent` are appropriate for plain text. If you convert model Markdown or HTML into rendered HTML, keep raw HTML disabled and sanitize the complete accumulated buffer before DOM insertion. Do not sanitize and concatenate individual deltas: a malicious construct can be split across stream updates.
+
 If `systemPrompt` is passed alongside `createOptions.initialPrompts`, the SDK emits a one-shot `console.warn` because `initialPrompts` overrides the synthesized system prompt and the persona is silently lost.
 
 ### `createSession(options?): Session`
@@ -257,10 +263,15 @@ For agents and multi-task flows, reusing one long-lived session lets history acc
 
 ```ts
 const base = createSession({ systemPrompt }); // once; keep warm
+const outputElement = document.querySelector<HTMLElement>("#output");
 // per task / run:
 const turn = await base.clone();              // fresh history, no re-parse
+let response = "";
 try {
-  for await (const delta of turn.sendStreaming(input)) render(delta);
+  for await (const delta of turn.sendStreaming(input)) {
+    response += delta;
+    if (outputElement) outputElement.textContent = response;
+  }
 } finally {
   turn.destroy();                             // free the clone, keep base
 }

--- a/apps/site/src/content/docs/packages/summarizer.md
+++ b/apps/site/src/content/docs/packages/summarizer.md
@@ -34,7 +34,7 @@ const result = await summarize({
   language: "en",
   type: "key-points",
   length: "short",
-  onUpdate: (text) => render(text),
+  onUpdate: (text) => console.log("partial", text),
 });
 
 console.log(result.output, result.cached);

--- a/apps/site/src/content/docs/react/use-session.mdx
+++ b/apps/site/src/content/docs/react/use-session.mdx
@@ -78,16 +78,23 @@ function ChatPane({ agent }: { agent: Agent }) {
 
 ```tsx
 const { session } = useSession({ systemPrompt });
+const [response, setResponse] = useState("");
 
 const runTask = async (input: string) => {
   if (!session) return;
   const turn = await session.clone(); // fresh history, base stays warm
+  let nextResponse = "";
   try {
-    for await (const delta of turn.sendStreaming(input)) render(delta);
+    for await (const delta of turn.sendStreaming(input)) {
+      nextResponse += delta;
+      setResponse(nextResponse);
+    }
   } finally {
     turn.destroy();
   }
 };
+
+return <p>{response}</p>;
 ```
 
 Destroying a clone never affects the base session. The hook still owns the base session's lifecycle (destroyed on unmount / option change); clones you create are yours to destroy.

--- a/apps/site/src/features/home/components/shared.tsx
+++ b/apps/site/src/features/home/components/shared.tsx
@@ -1,9 +1,9 @@
-import { marked } from "marked";
-import { type ReactNode, useCallback, useMemo, useRef, useState } from "react";
+import { type ReactNode, useCallback, useRef, useState } from "react";
 import {
   detectBrowser,
   isDesktopWebAIBrowser,
 } from "../../../shared/browser.js";
+import { ModelMarkdown } from "../../../shared/components/ModelMarkdown.js";
 import {
   caret,
   markdownProse,
@@ -205,8 +205,6 @@ export const Output = ({
   </div>
 );
 
-marked.use({ gfm: true, breaks: true });
-
 const normalizeBullets = (text: string): string => {
   if (!/^[*-]\s/.test(text)) return text;
   return text.replace(/([^\n])\s+[*-]\s+/g, "$1\n* ");
@@ -223,11 +221,6 @@ export const MarkdownOutput = ({
   placeholder: string;
   className?: string;
 }) => {
-  const html = useMemo(() => {
-    if (!text) return "";
-    return marked.parse(normalizeBullets(text)) as string;
-  }, [text]);
-
   const cursor = streaming ? <span className={`${caret} ml-[0.15em]`} /> : null;
 
   if (!text) {
@@ -242,10 +235,10 @@ export const MarkdownOutput = ({
   }
   return (
     <div className={`${outputBase} ${markdownProse} ${className}`}>
-      <div
+      <ModelMarkdown
+        content={normalizeBullets(text)}
+        streaming={streaming}
         className="whitespace-normal"
-        // biome-ignore lint/security/noDangerouslySetInnerHtml: model output, demo only
-        dangerouslySetInnerHTML={{ __html: html }}
       />
       {cursor}
     </div>

--- a/apps/site/src/features/playground/components/MessageContent.tsx
+++ b/apps/site/src/features/playground/components/MessageContent.tsx
@@ -1,7 +1,5 @@
 import { memo } from "react";
-import ReactMarkdown, { type Components } from "react-markdown";
-import remarkGfm from "remark-gfm";
-import remend from "remend";
+import { ModelMarkdown } from "../../../shared/components/ModelMarkdown.js";
 import { playground as ui } from "../../../shared/ui.js";
 import { ThinkingIndicator } from "./ThinkingIndicator.js";
 
@@ -10,88 +8,18 @@ interface Props {
   streaming?: boolean;
 }
 
-const components: Components = {
-  a: ({ href, children, node: _node, ...rest }) => (
-    <a href={href} target="_blank" rel="noreferrer noopener" {...rest}>
-      {children}
-    </a>
-  ),
-  code: ({ className, children, node: _node, ...rest }) => {
-    const isBlock = /\blanguage-/.test(className ?? "");
-    if (isBlock) {
-      return (
-        <code className={className} {...rest}>
-          {children}
-        </code>
-      );
-    }
-    return (
-      <code className={ui.markdownInlineCode} {...rest}>
-        {children}
-      </code>
-    );
-  },
-};
-
-const trailingMarkdownSyntax = /(?:^|\n)(?:\s|[-+*>#_~`[\]()])+$/;
-const listMarkerWithExtraSpacing = /^(\s*(?:[-+*]|\d+[.)]))[ \t]{2,}(?=\S)/;
-const fencedCodeBoundary = /^\s*(`{3,}|~{3,})/;
-
-function normalizeListMarkerSpacing(content: string): string {
-  let fence: { character: string; length: number } | undefined;
-
-  return content
-    .split("\n")
-    .map((line) => {
-      const boundary = line.match(fencedCodeBoundary)?.[1];
-      if (boundary) {
-        if (!fence) {
-          fence = { character: boundary[0] ?? "", length: boundary.length };
-        } else if (
-          boundary[0] === fence.character &&
-          boundary.length >= fence.length
-        ) {
-          fence = undefined;
-        }
-        return line;
-      }
-
-      return fence ? line : line.replace(listMarkerWithExtraSpacing, "$1 ");
-    })
-    .join("\n");
-}
-
-function stabilizeMarkdown(content: string): string {
-  // A streamed list item or emphasis marker can briefly look like a thematic
-  // break (`***`) or an empty block. Keep syntax-only tails out of the parser
-  // until the model provides semantic content.
-  const stableContent = trailingMarkdownSyntax.test(content)
-    ? content.replace(trailingMarkdownSyntax, "")
-    : content;
-
-  // Complete unterminated inline syntax so the same semantic element remains
-  // mounted as its text grows instead of changing from plain text to Markdown.
-  // Persisted responses bypass this repair step because they already contain
-  // complete Markdown, and repairing valid nested lists can change their tree.
-  return remend(normalizeListMarkerSpacing(stableContent), {
-    linkMode: "text-only",
-  });
-}
-
 function MessageContentImpl({ content, streaming }: Props) {
   if (!content) {
     return streaming ? <ThinkingIndicator /> : null;
   }
-  const renderedContent = streaming
-    ? stabilizeMarkdown(content)
-    : normalizeListMarkerSpacing(content);
 
   return (
-    <div className={ui.answerMarkdown}>
-      <ReactMarkdown remarkPlugins={[remarkGfm]} components={components}>
-        {renderedContent}
-      </ReactMarkdown>
-    </div>
+    <ModelMarkdown
+      content={content}
+      streaming={streaming}
+      className={ui.answerMarkdown}
+      inlineCodeClassName={ui.markdownInlineCode}
+    />
   );
 }
 

--- a/apps/site/src/shared/components/ModelMarkdown.test.tsx
+++ b/apps/site/src/shared/components/ModelMarkdown.test.tsx
@@ -72,6 +72,19 @@ describe("ModelMarkdown", () => {
     }
   });
 
+  it("drops remote images and task-list form controls", () => {
+    const container = render(
+      [
+        "![tracking pixel](https://tracker.example/pixel.gif)",
+        "- [ ] Keep the task text",
+      ].join("\n\n"),
+    );
+
+    expect(container.querySelector("img")).toBeNull();
+    expect(container.querySelector("input")).toBeNull();
+    expect(container.textContent).toContain("Keep the task text");
+  });
+
   it("stabilizes partial fences, lists, links, and emphasis", () => {
     let container = render("**important", true);
     expect(container.querySelector("strong")?.textContent).toBe("important");

--- a/apps/site/src/shared/components/ModelMarkdown.test.tsx
+++ b/apps/site/src/shared/components/ModelMarkdown.test.tsx
@@ -1,0 +1,115 @@
+// @vitest-environment happy-dom
+
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, describe, expect, it } from "vitest";
+import { ModelMarkdown } from "./ModelMarkdown.js";
+
+(
+  globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+let root: Root | undefined;
+
+const render = (content: string, streaming = false): HTMLElement => {
+  let container = document.querySelector<HTMLElement>("[data-test-root]");
+  if (!container) {
+    container = document.createElement("div");
+    container.dataset.testRoot = "";
+    document.body.append(container);
+    root = createRoot(container);
+  }
+
+  act(() => {
+    root?.render(<ModelMarkdown content={content} streaming={streaming} />);
+  });
+  return container;
+};
+
+afterEach(() => {
+  act(() => root?.unmount());
+  root = undefined;
+  document.body.replaceChildren();
+});
+
+describe("ModelMarkdown", () => {
+  it("ignores raw script elements and event-handler attributes", () => {
+    const container = render(
+      'Before<script>globalThis.modelXss = true</script><img src="x" onerror="globalThis.modelXss = true">After',
+    );
+
+    expect(container.querySelector("script")).toBeNull();
+    expect(container.querySelector("img")).toBeNull();
+    expect(container.querySelector("[onerror]")).toBeNull();
+    expect(
+      (globalThis as typeof globalThis & { modelXss?: boolean }).modelXss,
+    ).toBeUndefined();
+  });
+
+  it("keeps safe links hardened and removes unsafe protocols", () => {
+    const container = render(
+      [
+        "[Web](https://example.com)",
+        "[Docs](/docs/)",
+        "[Email](mailto:hello@example.com)",
+        "[Script](javascript:alert(1))",
+        "[Data](data:text/html;base64,PHNjcmlwdD4=)",
+      ].join(" "),
+    );
+    const links = [...container.querySelectorAll("a")];
+
+    expect(links).toHaveLength(5);
+    expect(links.map((link) => link.getAttribute("href"))).toEqual([
+      "https://example.com",
+      "/docs/",
+      "mailto:hello@example.com",
+      null,
+      null,
+    ]);
+    for (const link of links) {
+      expect(link.getAttribute("target")).toBe("_blank");
+      expect(link.getAttribute("rel")).toBe("noreferrer noopener");
+    }
+  });
+
+  it("stabilizes partial fences, lists, links, and emphasis", () => {
+    let container = render("**important", true);
+    expect(container.querySelector("strong")?.textContent).toBe("important");
+
+    container = render("* first item", true);
+    expect(container.querySelector("li")?.textContent).toBe("first item");
+
+    container = render("[Docs](https://example.com", true);
+    expect(container.textContent).toContain("Docs");
+    expect(container.querySelector("a")).toBeNull();
+
+    container = render("[Docs](https://example.com)", true);
+    expect(container.querySelector("a")?.textContent).toBe("Docs");
+    expect(container.querySelector("a")?.getAttribute("href")).toBe(
+      "https://example.com",
+    );
+
+    container = render("```ts\nconst answer = 42;", true);
+    expect(container.querySelector("pre code.language-ts")?.textContent).toBe(
+      "const answer = 42;\n",
+    );
+  });
+
+  it("re-evaluates malicious constructs split across stream updates", () => {
+    let container = render('<img src="x" one', true);
+    expect(container.querySelector("img")).toBeNull();
+
+    container = render(
+      '<img src="x" onerror="globalThis.modelXss = true">',
+      true,
+    );
+    expect(container.querySelector("img")).toBeNull();
+    expect(container.querySelector("[onerror]")).toBeNull();
+
+    container = render("[Run](java", true);
+    expect(container.querySelector('a[href^="java"]')).toBeNull();
+
+    container = render("[Run](javascript:alert(1))", true);
+    expect(container.querySelector("a")?.getAttribute("href")).toBeNull();
+  });
+});

--- a/apps/site/src/shared/components/ModelMarkdown.tsx
+++ b/apps/site/src/shared/components/ModelMarkdown.tsx
@@ -15,6 +15,32 @@ const listMarkerWithExtraSpacing = /^(\s*(?:[-+*]|\d+[.)]))[ \t]{2,}(?=\S)/;
 const fencedCodeBoundary = /^\s*(`{3,}|~{3,})/;
 const safeLinkProtocols = new Set(["http:", "https:", "mailto:"]);
 const linkUrlBase = "https://model-output.invalid";
+// Keep this default-deny set aligned with `safeMarkdownTags` in
+// `features/playground/PlaygroundFallback.astro`.
+const allowedModelMarkdownElements = [
+  "a",
+  "blockquote",
+  "br",
+  "code",
+  "del",
+  "em",
+  "h1",
+  "h2",
+  "h3",
+  "hr",
+  "li",
+  "ol",
+  "p",
+  "pre",
+  "strong",
+  "table",
+  "tbody",
+  "td",
+  "th",
+  "thead",
+  "tr",
+  "ul",
+] as const;
 
 function normalizeListMarkerSpacing(content: string): string {
   let fence: { character: string; length: number } | undefined;
@@ -122,6 +148,7 @@ export function ModelMarkdown({
       <ReactMarkdown
         remarkPlugins={[remarkGfm]}
         components={components}
+        allowedElements={allowedModelMarkdownElements}
         skipHtml
         urlTransform={secureModelUrl}
       >

--- a/apps/site/src/shared/components/ModelMarkdown.tsx
+++ b/apps/site/src/shared/components/ModelMarkdown.tsx
@@ -1,0 +1,132 @@
+import { useMemo } from "react";
+import ReactMarkdown, { type Components } from "react-markdown";
+import remarkGfm from "remark-gfm";
+import remend from "remend";
+
+interface ModelMarkdownProps {
+  content: string;
+  streaming?: boolean;
+  className?: string;
+  inlineCodeClassName?: string;
+}
+
+const trailingMarkdownSyntax = /(?:^|\n)(?:\s|[-+*>#_~`[\]()])+$/;
+const listMarkerWithExtraSpacing = /^(\s*(?:[-+*]|\d+[.)]))[ \t]{2,}(?=\S)/;
+const fencedCodeBoundary = /^\s*(`{3,}|~{3,})/;
+const safeLinkProtocols = new Set(["http:", "https:", "mailto:"]);
+const linkUrlBase = "https://model-output.invalid";
+
+function normalizeListMarkerSpacing(content: string): string {
+  let fence: { character: string; length: number } | undefined;
+
+  return content
+    .split("\n")
+    .map((line) => {
+      const boundary = line.match(fencedCodeBoundary)?.[1];
+      if (boundary) {
+        if (!fence) {
+          fence = { character: boundary[0] ?? "", length: boundary.length };
+        } else if (
+          boundary[0] === fence.character &&
+          boundary.length >= fence.length
+        ) {
+          fence = undefined;
+        }
+        return line;
+      }
+
+      return fence ? line : line.replace(listMarkerWithExtraSpacing, "$1 ");
+    })
+    .join("\n");
+}
+
+function stabilizeMarkdown(content: string): string {
+  // A streamed list item or emphasis marker can briefly look like a thematic
+  // break (`***`) or an empty block. Keep syntax-only tails out of the parser
+  // until the model provides semantic content.
+  const stableContent = trailingMarkdownSyntax.test(content)
+    ? content.replace(trailingMarkdownSyntax, "")
+    : content;
+
+  // Complete unterminated inline syntax so the same semantic element remains
+  // mounted as its text grows instead of changing from plain text to Markdown.
+  // Persisted responses bypass this repair step because they already contain
+  // complete Markdown, and repairing valid nested lists can change their tree.
+  return remend(normalizeListMarkerSpacing(stableContent), {
+    linkMode: "text-only",
+  });
+}
+
+/**
+ * Model-authored links are untrusted. Resolve against an HTTPS base so relative
+ * URLs stay useful, then allow only the same protocols as the static fallback
+ * renderer. Returning an empty string leaves unsafe Markdown links without an
+ * executable `href`.
+ */
+export function secureModelUrl(url: string): string {
+  try {
+    const resolved = new URL(url, linkUrlBase);
+    return safeLinkProtocols.has(resolved.protocol) ? url : "";
+  } catch {
+    return "";
+  }
+}
+
+/**
+ * Render untrusted model Markdown as a React tree. Raw HTML stays disabled;
+ * callers must pass the complete accumulated stream buffer on every update so
+ * split Markdown constructs are stabilized and re-evaluated together.
+ */
+export function ModelMarkdown({
+  content,
+  streaming = false,
+  className,
+  inlineCodeClassName,
+}: ModelMarkdownProps) {
+  const components = useMemo<Components>(
+    () => ({
+      a: ({ href, children, node: _node, ...rest }) => (
+        <a
+          {...rest}
+          {...(href ? { href } : {})}
+          target="_blank"
+          rel="noreferrer noopener"
+        >
+          {children}
+        </a>
+      ),
+      code: ({ className: codeClassName, children, node: _node, ...rest }) => {
+        const isBlock = /\blanguage-/.test(codeClassName ?? "");
+        if (isBlock || !inlineCodeClassName) {
+          return (
+            <code className={codeClassName} {...rest}>
+              {children}
+            </code>
+          );
+        }
+        return (
+          <code className={inlineCodeClassName} {...rest}>
+            {children}
+          </code>
+        );
+      },
+    }),
+    [inlineCodeClassName],
+  );
+  const renderedContent = streaming
+    ? stabilizeMarkdown(content)
+    : normalizeListMarkerSpacing(content);
+
+  return (
+    <div className={className}>
+      <ReactMarkdown
+        remarkPlugins={[remarkGfm]}
+        components={components}
+        skipHtml
+        urlTransform={secureModelUrl}
+      >
+        {renderedContent}
+      </ReactMarkdown>
+    </div>
+  );
+}

--- a/packages/prompt/README.md
+++ b/packages/prompt/README.md
@@ -1,6 +1,6 @@
 # @web-ai-sdk/prompt
 
-web-ai-sdk building block for the Web's Built-in [Prompt API](https://developer.chrome.com/docs/extensions/ai/prompt-api) (`LanguageModel`). One-shot `ask()` for embeds and widgets, plus a thin `createSession()` primitive (and React `useSession`) for chat-shaped apps that need independent per-conversation sessions and delta-shaped streaming. The wrapper smooths cross-browser quirks (delta-vs-cumulative chunks, output sanitization, abort wiring); UI state and conversation history are the consumer's concern.
+web-ai-sdk building block for the Web's Built-in [Prompt API](https://developer.chrome.com/docs/extensions/ai/prompt-api) (`LanguageModel`). One-shot `ask()` for embeds and widgets, plus a thin `createSession()` primitive (and React `useSession`) for chat-shaped apps that need independent per-conversation sessions and delta-shaped streaming. The wrapper smooths cross-browser quirks (delta-vs-cumulative chunks, control-character cleanup, abort wiring); UI state and conversation history are the consumer's concern.
 
 **Docs:** <https://web-ai-sdk.dev/docs/guides/prompt/> · **React:** [`usePrompt`](https://web-ai-sdk.dev/docs/react/use-prompt/) · [`useSession`](https://web-ai-sdk.dev/docs/react/use-session/)
 
@@ -166,6 +166,12 @@ interface AskResult {
 
 `onUpdate` receives the cumulative text so far, not deltas. For delta-shaped streaming use `createSession().sendStreaming()`.
 
+### Treat model output as untrusted
+
+The Prompt wrapper removes selected non-printing control characters from model responses. This is control-character cleanup, **not** HTML or Markdown sanitization. Treat every final response and streaming update as untrusted.
+
+React interpolation (`<p>{output}</p>`) and DOM `textContent` are appropriate for plain text. If you convert model Markdown or HTML into rendered HTML, keep raw HTML disabled and sanitize the complete accumulated buffer before DOM insertion. Do not sanitize and concatenate individual deltas: a malicious construct can be split across stream updates.
+
 If `systemPrompt` is passed alongside `createOptions.initialPrompts`, the SDK emits a one-shot `console.warn` because `initialPrompts` overrides the synthesized system prompt and the persona is silently lost.
 
 ### `createSession(options?): Session`
@@ -250,10 +256,15 @@ For agents and multi-task flows, reusing one long-lived session lets history acc
 
 ```ts
 const base = createSession({ systemPrompt }); // once; keep warm
+const outputElement = document.querySelector<HTMLElement>("#output");
 // per task / run:
 const turn = await base.clone();              // fresh history, no re-parse
+let response = "";
 try {
-  for await (const delta of turn.sendStreaming(input)) render(delta);
+  for await (const delta of turn.sendStreaming(input)) {
+    response += delta;
+    if (outputElement) outputElement.textContent = response;
+  }
 } finally {
   turn.destroy();                             // free the clone, keep base
 }

--- a/packages/prompt/src/index.ts
+++ b/packages/prompt/src/index.ts
@@ -40,6 +40,7 @@ import {
   assertValidSamplingOptions,
   buildLangHints,
   type CreateSessionOptions,
+  cleanResponse,
   createSession,
   mergeStreamChunk,
   PromptAbortError,
@@ -47,7 +48,6 @@ import {
   type Session,
   SessionDestroyedError,
   type SessionSendOptions,
-  sanitizeResponse,
 } from "./session.js";
 
 export type {
@@ -341,7 +341,7 @@ export const ask = async (options: AskOptions): Promise<AskResult> => {
       options.onUpdate?.(finalText);
     }
 
-    const cleaned = sanitizeResponse(finalText);
+    const cleaned = cleanResponse(finalText);
     if (cleaned && cache) cache.set(cacheKey, cleaned);
     return { output: cleaned || null, cached: false };
   } catch (err) {

--- a/packages/prompt/src/session.ts
+++ b/packages/prompt/src/session.ts
@@ -8,7 +8,7 @@
  *
  * The wrapper is intentionally thin. It handles cross-browser smoothing that
  * every consumer would otherwise reimplement (delta-vs-cumulative chunk
- * detection, output sanitization, abort composition, typed unavailability)
+ * detection, control-character cleanup, abort composition, typed unavailability)
  * and forwards everything else to the native instance. It does NOT track
  * conversation history or queue concurrent sends; those are the consumer's
  * data model and UI concerns. It does surface `clone()`, since forking a warm
@@ -107,10 +107,10 @@ export const stripNonPrinting = (raw: string): string =>
   raw.replace(NON_PRINTING, "");
 
 /**
- * Full sanitization for a final response: strip non-printing characters and
- * trim leading/trailing whitespace. Apply at the end of a turn, not per delta.
+ * Final response cleanup: strip non-printing characters and trim
+ * leading/trailing whitespace. Apply at the end of a turn, not per delta.
  */
-export const sanitizeResponse = (raw: string): string =>
+export const cleanResponse = (raw: string): string =>
   stripNonPrinting(raw).trim();
 
 /**
@@ -422,7 +422,7 @@ const wrapInstance = (
     try {
       const raw = await instance.prompt(input, promptOpts);
       if (controller.signal.aborted) throw new PromptAbortError();
-      const cleaned = sanitizeResponse(raw);
+      const cleaned = cleanResponse(raw);
       return cleaned || null;
     } catch (err) {
       if ((err as { name?: string })?.name === "AbortError") {
@@ -479,7 +479,7 @@ const wrapInstance = (
         } else {
           const raw = await instance.prompt(input, promptOpts);
           if (controller.signal.aborted) throw new PromptAbortError();
-          const cleaned = sanitizeResponse(raw);
+          const cleaned = cleanResponse(raw);
           if (cleaned) yield cleaned;
         }
       } catch (err) {

--- a/packages/summarizer/README.md
+++ b/packages/summarizer/README.md
@@ -27,7 +27,7 @@ const result = await summarize({
   language: "en",
   type: "key-points",
   length: "short",
-  onUpdate: (text) => render(text),
+  onUpdate: (text) => console.log("partial", text),
 });
 
 console.log(result.output, result.cached);


### PR DESCRIPTION
## Summary

- replace the homepage model-output HTML sink with the shared safe React Markdown pipeline
- disable raw model HTML, reject unsafe link protocols, and stabilize partial streamed Markdown
- add regression coverage for scripts, event handlers, unsafe URLs, and attacks split across updates
- clarify the public trust boundary and use safe streaming examples

## Root cause

The shared homepage renderer parsed model-generated Markdown with `marked` and inserted the result through `dangerouslySetInnerHTML` without full-buffer sanitization.

## Impact

Prompt, Summarizer, Writer, and Rewriter homepage demos no longer route model output into an executable HTML sink. Static repository-authored fixtures remain unchanged.

## Validation

- `pnpm gate`
- site typecheck: 0 errors
- site tests: 42 passed

## Manual validation

- [ ] Test the affected homepage demos before merge

Closes #151
