### PR TITLE
fix(playground): continue mixed-tool requests after eager fetches

### DIFF
--- a/apps/site/src/features/playground/experimental/agent/loop.test.ts
+++ b/apps/site/src/features/playground/experimental/agent/loop.test.ts
@@ -45,7 +45,7 @@ describe("buildNativePrompt", () => {
 });
 
 describe("createAgentLoop", () => {
-  it("continues a mixed request after eager URL fetches until clock_now executes", async () => {
+  it("continues a mixed request until a prefixed clock_now call executes", async () => {
     const fixture = createSessionFixture([
       "Both URLs were fetched successfully.",
       "```tool_code\nclock_now()\n```",
@@ -60,7 +60,7 @@ describe("createAgentLoop", () => {
     const agent = createAgentLoop({ tools });
 
     const result = await agent.run(
-      "Fetch https://one.test and https://two.test, then call clock_now to give me the current time.",
+      "Fetch https://one.test and https://two.test, then default_api.clock_now().",
     );
     agent.destroy();
 

--- a/apps/site/src/features/playground/experimental/agent/loop.test.ts
+++ b/apps/site/src/features/playground/experimental/agent/loop.test.ts
@@ -1,5 +1,32 @@
-import { describe, expect, it } from "vitest";
-import { buildNativePrompt } from "./loop.js";
+import type { Session } from "@web-ai-sdk/prompt";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { buildNativePrompt, createAgentLoop } from "./loop.js";
+import type { AgentTool } from "./types.js";
+
+const { createSessionMock } = vi.hoisted(() => ({
+  createSessionMock: vi.fn(),
+}));
+
+vi.mock("@web-ai-sdk/prompt", () => {
+  class PromptAbortError extends Error {
+    override readonly name = "AbortError";
+  }
+
+  class PromptUnavailableError extends Error {
+    override readonly name = "PromptUnavailableError";
+  }
+
+  return {
+    createSession: createSessionMock,
+    isAvailable: () => true,
+    PromptAbortError,
+    PromptUnavailableError,
+  };
+});
+
+beforeEach(() => {
+  createSessionMock.mockReset();
+});
 
 describe("buildNativePrompt", () => {
   it("requires direct, evidence-calibrated answers from every agent", () => {
@@ -16,3 +43,190 @@ describe("buildNativePrompt", () => {
     expect(prompt).toContain("Never say the user is correct");
   });
 });
+
+describe("createAgentLoop", () => {
+  it("continues a mixed request after eager URL fetches until clock_now executes", async () => {
+    const fixture = createSessionFixture([
+      "Both URLs were fetched successfully.",
+      "```tool_code\nclock_now()\n```",
+      "Both pages are available, and the current time is 12:34.",
+    ]);
+    createSessionMock.mockReturnValue(fixture.base);
+    const calls: string[] = [];
+    const tools: AgentTool[] = [
+      createFetchFixtureTool(calls),
+      createClockFixtureTool(calls),
+    ];
+    const agent = createAgentLoop({ tools });
+
+    const result = await agent.run(
+      "Fetch https://one.test and https://two.test, then call clock_now to give me the current time.",
+    );
+    agent.destroy();
+
+    expect(calls).toEqual(["fetch_url", "fetch_url", "clock_now"]);
+    expect(result.stopReason).toBe("done");
+    expect(result.text).toContain("12:34");
+  });
+
+  it("keeps fetch-only requests on the existing single-answer path", async () => {
+    const fixture = createSessionFixture(["Fetch-only answer."]);
+    createSessionMock.mockReturnValue(fixture.base);
+    const calls: string[] = [];
+    const agent = createAgentLoop({
+      tools: [createFetchFixtureTool(calls), createClockFixtureTool(calls)],
+    });
+
+    const result = await agent.run("Fetch https://one.test and summarize it.");
+    agent.destroy();
+
+    expect(calls).toEqual(["fetch_url"]);
+    expect(fixture.inputs).toHaveLength(1);
+    expect(result).toMatchObject({
+      stopReason: "done",
+      text: "Fetch-only answer.",
+    });
+  });
+
+  it("reports explicitly requested tool work that remains uncalled", async () => {
+    const fixture = createSessionFixture([
+      "The URLs are done.",
+      "Here is the final answer.",
+    ]);
+    createSessionMock.mockReturnValue(fixture.base);
+    const calls: string[] = [];
+    const agent = createAgentLoop({
+      tools: [createFetchFixtureTool(calls), createClockFixtureTool(calls)],
+    });
+
+    const result = await agent.run(
+      "Fetch https://one.test, then call clock_now for the current time.",
+    );
+    agent.destroy();
+
+    expect(calls).toEqual(["fetch_url"]);
+    expect(fixture.inputs).toHaveLength(2);
+    expect(result.stopReason).toBe("done");
+    expect(result.text).toContain("clock_now was not called");
+  });
+
+  it("reports explicitly requested tool work that fails", async () => {
+    const fixture = createSessionFixture([
+      "```tool_code\nclock_now()\n```",
+      "Everything completed.",
+    ]);
+    createSessionMock.mockReturnValue(fixture.base);
+    const calls: string[] = [];
+    const agent = createAgentLoop({
+      tools: [
+        createFetchFixtureTool(calls),
+        createClockFixtureTool(calls, new Error("Clock unavailable")),
+      ],
+    });
+
+    const result = await agent.run(
+      "Fetch https://one.test, then call clock_now for the current time.",
+    );
+    agent.destroy();
+
+    expect(calls).toEqual(["fetch_url", "clock_now"]);
+    expect(result.stopReason).toBe("done");
+    expect(result.text).toContain("clock_now failed: Clock unavailable");
+  });
+
+  it("uses the existing step budget for the remaining-tool correction", async () => {
+    const fixture = createSessionFixture(["The URLs are done."]);
+    createSessionMock.mockReturnValue(fixture.base);
+    const calls: string[] = [];
+    const agent = createAgentLoop({
+      tools: [createFetchFixtureTool(calls), createClockFixtureTool(calls)],
+      maxSteps: 2,
+    });
+
+    const result = await agent.run(
+      "Fetch https://one.test, then call clock_now for the current time.",
+    );
+    agent.destroy();
+
+    expect(fixture.inputs).toHaveLength(1);
+    expect(result.stopReason).toBe("budget_exhausted");
+    expect(result.text).toContain("clock_now was not called");
+    expect(result.failure?.name).toBe("AgentIncompleteToolRequestError");
+  });
+});
+
+function createFetchFixtureTool(
+  calls: string[],
+): AgentTool<{ url: string }, { status: number; url: string; text: string }> {
+  return {
+    name: "fetch_url",
+    description: "Fetch a URL.",
+    inputSchema: {
+      type: "object",
+      properties: { url: { type: "string" } },
+      required: ["url"],
+    },
+    async execute({ url }) {
+      calls.push("fetch_url");
+      return { status: 200, url, text: `Content from ${url}` };
+    },
+  };
+}
+
+function createClockFixtureTool(
+  calls: string[],
+  failure?: Error,
+): AgentTool<Record<string, never>, { formatted: string }> {
+  return {
+    name: "clock_now",
+    description: "Return the current time.",
+    inputSchema: { type: "object" },
+    async execute() {
+      calls.push("clock_now");
+      if (failure) throw failure;
+      return { formatted: "12:34" };
+    },
+  };
+}
+
+function createSessionFixture(replies: readonly string[]): {
+  base: Session;
+  inputs: string[];
+} {
+  let replyIndex = 0;
+  const inputs: string[] = [];
+
+  const create = (): Session => {
+    let destroyed = false;
+    return {
+      get destroyed() {
+        return destroyed;
+      },
+      async send(input) {
+        inputs.push(String(input));
+        return replies[replyIndex++] ?? null;
+      },
+      async *sendStreaming(input) {
+        inputs.push(String(input));
+        const reply = replies[replyIndex++];
+        if (reply === undefined) {
+          throw new Error("Fixture ran out of model replies.");
+        }
+        yield reply;
+      },
+      abort() {},
+      async clone() {
+        return create();
+      },
+      async append() {},
+      onContextOverflow() {
+        return () => {};
+      },
+      destroy() {
+        destroyed = true;
+      },
+    };
+  };
+
+  return { base: create(), inputs };
+}

--- a/apps/site/src/features/playground/experimental/agent/loop.ts
+++ b/apps/site/src/features/playground/experimental/agent/loop.ts
@@ -245,6 +245,11 @@ export function createAgentLoop(options: CreateAgentOptions = {}): Agent {
     const inputUrls = resolveContextualUrls(input, [...knownFetchUrls]);
     const userUrls = new Set(inputUrls.map(normUrl));
     const fetchTool = urlFetchingTool;
+    const explicitlyRequestedToolNames = collectExplicitToolRequests(
+      input,
+      tools,
+      fetchTool,
+    );
 
     let session: Session;
     try {
@@ -304,6 +309,7 @@ export function createAgentLoop(options: CreateAgentOptions = {}): Agent {
     // skipped (it often fetches only the first of several) and flag failures.
     const fetchedOk = new Set<string>();
     const fetchTried = new Set<string>();
+    const toolCallRecords: AgentToolCallRecord[] = [];
     /** Extracted bodies from successful fetches - provenance for summarize_text. */
     const fetchedSources: string[] = [];
     const runCtx: AgentRunContext = {
@@ -315,6 +321,9 @@ export function createAgentLoop(options: CreateAgentOptions = {}): Agent {
     let autoFetchDone = false;
     // Guards the one-time "answer directly, no tools" self-heal below.
     let directRetryDone = false;
+    // Guards the one-time correction when eager fetches are followed by a
+    // premature final answer that skips explicitly requested tool work.
+    let remainingToolRetryDone = false;
     const recordFetches = (records: AgentToolCallRecord[]) => {
       for (const r of records) {
         const src = extractFetchSourceText(r);
@@ -333,6 +342,21 @@ export function createAgentLoop(options: CreateAgentOptions = {}): Agent {
         }
       }
     };
+    const recordToolResults = (records: AgentToolCallRecord[]) => {
+      toolCallRecords.push(...records);
+      recordFetches(records);
+    };
+    const uncompletedRequestedTools = () =>
+      explicitlyRequestedToolNames.filter(
+        (name) =>
+          !toolCallRecords.some(
+            (record) => record.name === name && !record.error,
+          ),
+      );
+    const unattemptedRequestedTools = () =>
+      explicitlyRequestedToolNames.filter(
+        (name) => !toolCallRecords.some((record) => record.name === name),
+      );
 
     let stepIndex = 0;
     try {
@@ -366,14 +390,16 @@ export function createAgentLoop(options: CreateAgentOptions = {}): Agent {
           toolCalls: records,
         });
         yield { type: "step_end", index: stepIndex };
-        recordFetches(records);
+        recordToolResults(records);
         // The URLs are already fetched; don't let the reactive backstop
         // re-fetch (a CORS failure here would just fail again).
         autoFetchDone = true;
-        const closer =
+        const closer = [
           inputUrls.length > 1
-            ? "Answer the user's request now in ONE reply that covers every URL."
-            : "Answer the user's request now.";
+            ? "Continue the user's request now and cover every URL in ONE reply."
+            : "Continue the user's request now.",
+          "The URL fetches are complete, but call any other tools needed for the remaining requested work before answering. Only answer after every requested task is completed or reported as unavailable.",
+        ].join(" ");
         // Fold the user's original message INTO this turn. Because we fetched
         // eagerly we skipped the model's planning turn - which means the user's
         // message was never sent on its own. Without it here, the model only
@@ -463,10 +489,29 @@ export function createAgentLoop(options: CreateAgentOptions = {}): Agent {
               toolCalls: records,
             });
             yield { type: "step_end", index: stepIndex };
-            recordFetches(records);
+            recordToolResults(records);
             const noun =
               missing.length === 1 ? "the URL" : `${missing.length} URLs`;
             turnInput = `${buildToolResultTurn(records, perResultMaxChars)}\n\nYou had not fetched ${noun} the user asked about; the real content is above. Address EACH one in your answer - don't drop any.`;
+            continue;
+          }
+
+          // Eager URL fetching skips the model's initial planning turn. A
+          // small model can therefore treat the fetch results as the entire
+          // task and finalize before an explicitly requested second tool
+          // (for example `clock_now`) has run. Reject that premature answer
+          // once and make the outstanding call requirement unambiguous. The
+          // retry still consumes a normal loop iteration, preserving
+          // `maxSteps`; a second miss falls through to deterministic
+          // incomplete-work reporting below.
+          const unattempted = unattemptedRequestedTools();
+          if (unattempted.length > 0 && !remainingToolRetryDone) {
+            remainingToolRetryDone = true;
+            if (streamedAnswerText) {
+              yield { type: "step_reset", index: stepIndex };
+            }
+            yield { type: "step_end", index: stepIndex };
+            turnInput = buildRemainingToolTurn(unattempted);
             continue;
           }
 
@@ -505,12 +550,16 @@ export function createAgentLoop(options: CreateAgentOptions = {}): Agent {
           const unfetched = fetchTool
             ? inputUrls.filter((u) => !fetchedOk.has(normUrl(u)))
             : [];
-          finalText = maybeFlagUnverifiedUrl(answer, {
-            hasFetchTool: !!fetchTool,
-            totalUrls: inputUrls.length,
-            unfetched,
-            anyTried: fetchTried.size > 0,
-          });
+          finalText = maybeReportIncompleteToolRequests(
+            maybeFlagUnverifiedUrl(answer, {
+              hasFetchTool: !!fetchTool,
+              totalUrls: inputUrls.length,
+              unfetched,
+              anyTried: fetchTried.size > 0,
+            }),
+            explicitlyRequestedToolNames,
+            toolCallRecords,
+          );
           yield {
             type: "plan",
             index: stepIndex,
@@ -557,6 +606,7 @@ export function createAgentLoop(options: CreateAgentOptions = {}): Agent {
           stepIndex,
           signal,
         });
+        recordToolResults(records);
 
         // Summarizer returned `{ summary: "" }` (availability race). The next
         // model turn will summarize in prose - drop the empty tool card so the
@@ -581,7 +631,7 @@ export function createAgentLoop(options: CreateAgentOptions = {}): Agent {
           tools,
           runCtx,
         );
-        if (directText !== null) {
+        if (directText !== null && uncompletedRequestedTools().length === 0) {
           finalText = directText;
           steps.push({
             index: stepIndex,
@@ -600,7 +650,6 @@ export function createAgentLoop(options: CreateAgentOptions = {}): Agent {
             plan: { final: true, message: finalText },
           };
           yield { type: "step_end", index: stepIndex };
-          recordFetches(records);
           stopReason = "done";
           yield { type: "message", text: finalText };
           break;
@@ -611,9 +660,6 @@ export function createAgentLoop(options: CreateAgentOptions = {}): Agent {
           toolCalls: records,
         });
         yield { type: "step_end", index: stepIndex };
-
-        // Track which URLs the model actually fetched (per-URL).
-        recordFetches(records);
 
         const fatal = records.find((r) => r.error);
         if (fatal && onToolError !== "report") {
@@ -630,7 +676,22 @@ export function createAgentLoop(options: CreateAgentOptions = {}): Agent {
         turnInput = buildToolResultTurn(records, perResultMaxChars);
       }
 
-      if (stopReason === null) stopReason = "budget_exhausted";
+      if (stopReason === null) {
+        stopReason = "budget_exhausted";
+        const incomplete = uncompletedRequestedTools();
+        if (incomplete.length > 0) {
+          finalText = maybeReportIncompleteToolRequests(
+            "",
+            explicitlyRequestedToolNames,
+            toolCallRecords,
+          );
+          failure = {
+            name: "AgentIncompleteToolRequestError",
+            message: `The run ended before completing: ${incomplete.join(", ")}.`,
+          };
+          yield { type: "message", text: finalText };
+        }
+      }
     } finally {
       if (currentController === controller) currentController = null;
       if (sessionMode === "run-isolated") {
@@ -946,6 +1007,87 @@ function buildToolResultTurn(
     // they fit the small context together.
     "Use these results to answer. If the user mentioned other URLs you haven't fetched yet, fetch those first; once you have them all, write ONE reply that covers every one of them.",
   ].join("\n");
+}
+
+/**
+ * Find tool work the user requested by exact name. This is deliberately
+ * narrower than natural-language intent detection: the model still decides
+ * which tools a normal request needs, while the loop can deterministically
+ * enforce explicit instructions such as "then call clock_now".
+ *
+ * The URL-fetching tool is excluded because eager fetching and its failure
+ * notices already have dedicated per-URL handling.
+ */
+function collectExplicitToolRequests(
+  input: string,
+  tools: readonly AgentTool[],
+  fetchTool: AgentTool | undefined,
+): string[] {
+  return tools
+    .filter((tool) => tool.name !== fetchTool?.name)
+    .filter((tool) => {
+      const name = escapeRegExp(tool.name);
+      const exactCall = new RegExp(`(^|[^\\w.])${name}\\s*\\(`, "i").test(
+        input,
+      );
+      const imperative = new RegExp(
+        `\\b(?:call|run|use|invoke|execute)\\b[^.!?\\n]{0,64}(?:^|[^\\w])${name}(?=$|[^\\w])`,
+        "i",
+      ).test(input);
+      const namedInstrument = new RegExp(
+        `\\b(?:with|via)\\s+[\`'"]?${name}(?=$|[^\\w])`,
+        "i",
+      ).test(input);
+      return exactCall || imperative || namedInstrument;
+    })
+    .map((tool) => tool.name);
+}
+
+function buildRemainingToolTurn(names: readonly string[]): string {
+  const formatted = names.map((name) => `\`${name}\``).join(", ");
+  const noun = names.length === 1 ? "tool has" : "tools have";
+  return [
+    `The user explicitly requested ${formatted}, but the ${noun} not been called yet.`,
+    "Emit ONLY a tool_code block that calls the remaining tool work now.",
+    "Do not answer the user until that work has completed; if a call fails, report the failure instead of silently skipping it.",
+  ].join(" ");
+}
+
+function maybeReportIncompleteToolRequests(
+  answer: string,
+  requestedNames: readonly string[],
+  records: readonly AgentToolCallRecord[],
+): string {
+  const missing = requestedNames.filter(
+    (name) => !records.some((record) => record.name === name),
+  );
+  const failed = requestedNames.filter((name) => {
+    const attempts = records.filter((record) => record.name === name);
+    return (
+      attempts.length > 0 && attempts.every((record) => Boolean(record.error))
+    );
+  });
+  if (missing.length === 0 && failed.length === 0) return answer;
+
+  const details: string[] = [];
+  if (missing.length > 0) {
+    details.push(
+      `${missing.join(", ")} ${missing.length === 1 ? "was" : "were"} not called`,
+    );
+  }
+  for (const name of failed) {
+    const lastError = records.filter((record) => record.name === name).at(-1)
+      ?.error?.message;
+    details.push(
+      lastError
+        ? `${name} failed: ${truncate(lastError, 300)}`
+        : `${name} failed`,
+    );
+  }
+
+  const notice = `> ⚠ I couldn't complete all requested tool work: ${details.join("; ")}.`;
+  const trimmed = answer.trim();
+  return trimmed ? `${notice}\n\n${trimmed}` : notice;
 }
 
 /**

--- a/apps/site/src/features/playground/experimental/agent/loop.ts
+++ b/apps/site/src/features/playground/experimental/agent/loop.ts
@@ -1027,9 +1027,10 @@ function collectExplicitToolRequests(
     .filter((tool) => tool.name !== fetchTool?.name)
     .filter((tool) => {
       const name = escapeRegExp(tool.name);
-      const exactCall = new RegExp(`(^|[^\\w.])${name}\\s*\\(`, "i").test(
-        input,
-      );
+      const exactCall = new RegExp(
+        `(^|[^\\w.])(?:[A-Za-z_]\\w*\\.)?${name}\\s*\\(`,
+        "i",
+      ).test(input);
       const imperative = new RegExp(
         `\\b(?:call|run|use|invoke|execute)\\b[^.!?\\n]{0,64}(?:^|[^\\w])${name}(?=$|[^\\w])`,
         "i",


### PR DESCRIPTION
## Summary

- continue mixed fetch-and-tool requests after eager URL fetches
- report explicitly requested tool work that remains uncalled or fails
- preserve fetch-only behavior and existing iteration limits
- add deterministic regression coverage for the two-URL plus `clock_now` flow

## Root cause

The eager-fetch path prompted the model to answer immediately and accepted plain text as final without checking whether explicitly requested non-fetch tool work remained.

## Validation

- `pnpm gate`

## Manual testing

- [ ] Verify the mixed two-URL plus `clock_now` flow in the playground

Closes #160
