### PR TITLE
feat(webmcp): align tool registration and output validation

### DIFF
--- a/.changeset/calm-pandas-design.md
+++ b/.changeset/calm-pandas-design.md
@@ -1,0 +1,5 @@
+---
+"@web-ai-sdk/webmcp": minor
+---
+
+Align tool metadata and registration options with the current WebMCP draft, including title, untrustedContentHint, exposedTo, single-tool or conditional React registration, and fresh execute callbacks without registration churn.

--- a/.changeset/eighty-drinks-find.md
+++ b/.changeset/eighty-drinks-find.md
@@ -1,0 +1,5 @@
+---
+"@web-ai-sdk/webmcp": patch
+---
+
+Add Standard Schema output validation to defineTool, including transformed output inference and typed failures.

--- a/apps/site/src/content/docs/guides/webmcp.mdx
+++ b/apps/site/src/content/docs/guides/webmcp.mdx
@@ -38,6 +38,7 @@ const cleanup = () => cleanups.forEach((c) => c());
 ```ts
 interface Tool<TInput = unknown, TOutput = unknown> {
   name: string;
+  title?: string;
   description: string;
   inputSchema?: object;
   readOnly?: boolean;
@@ -52,45 +53,60 @@ interface Tool<TInput = unknown, TOutput = unknown> {
 | Name | Type | Description |
 | --- | --- | --- |
 | `name` <sup>required</sup> | `string` | Tool name. Must be unique within the model context. |
+| `title` | `string` | Human-readable title for host user interfaces. |
 | `description` <sup>required</sup> | `string` | What the tool does. Routed to the agent's tool selector. |
 | `execute` <sup>required</sup> | `(input) => Promise<T> \| T` | The function the agent calls. |
 | `inputSchema` | `object` | JSON Schema describing the input shape. Some hosts validate against it before dispatch. |
 | `readOnly` | `boolean` | Shorthand for `annotations.readOnlyHint = true`. |
-| `destructive` | `boolean` | Shorthand for `annotations.destructiveHint = true`. |
-| `annotations` | `ToolAnnotations` | Raw passthrough (`readOnlyHint`, `destructiveHint`, `idempotentHint`, `openWorldHint`). Merged on top of the shorthand flags. |
+| `destructive` | `boolean` | Compatibility shorthand for `annotations.destructiveHint = true`. |
+| `annotations` | `ToolAnnotations` | Raw passthrough. The current draft defines `readOnlyHint` and `untrustedContentHint`; compatibility fields are described below. |
 
 </div>
 
 ## Returns
 
-`registerTool(tool)` returns a cleanup function: `() => void`. Calling it unregisters the tool. Calling it twice is a no-op. On browsers without `document.modelContext` (or the legacy `navigator.modelContext`), the cleanup is itself a no-op.
+`registerTool(tool, options?)` returns a cleanup function: `() => void`. Calling it unregisters the tool. Calling it twice is a no-op. On browsers without `document.modelContext` (or the legacy `navigator.modelContext`), the cleanup is itself a no-op.
 
 ## How it works
 
-`document.modelContext.registerTool({...}, { signal })` is the spec entry point. (For backward compatibility with the previous shape of the API, this package also reads from `navigator.modelContext`.) The wrapper sits on top with three quality-of-life additions:
+`document.modelContext.registerTool({...}, { signal, exposedTo })` is the spec entry point. (For backward compatibility with the previous shape of the API, this package also reads from `navigator.modelContext`.) The wrapper sits on top with three quality-of-life additions:
 
 - **Feature detection.** On browsers without `document.modelContext` (or the legacy `navigator.modelContext`), every entry point is a no-op so consumer code ships unchanged. `isAvailable()` returns `false`.
 - **Last-writer-wins on duplicate names.** React effect cleanup is asynchronous; a fast re-render can attempt to register `"foo"` before Chrome processed the prior `abort()`. The wrapper detects the resulting duplicate-name error, queues a microtask retry, and tracks ownership so a stale registration can't squat the name.
 - **One AbortController per call.** `registerTool` returns a cleanup function that aborts the underlying controller and unregisters the tool.
 
-## Annotations
+## Cross-document exposure
 
-Annotations communicate intent to the agent. WebMCP exposes shorthand flags (`readOnly`, `destructive`) plus a raw `annotations` passthrough that merges on top:
+By default, the owning document can discover its tool. Pass `exposedTo` when descendant documents at other origins also need access:
 
 ```ts
-registerTool({
-  name: "delete_account",
-  description: "Permanently delete the user account",
-  destructive: true, // → annotations.destructiveHint
-  annotations: {
-    idempotentHint: false,
-    openWorldHint: true,
-  },
-  execute: () => { /* ... */ },
+const cleanup = registerTool(tool, {
+  exposedTo: ["https://agent.example"],
 });
 ```
 
-Shorthand flags map to the spec hints (`readOnlyHint`, `destructiveHint`); pass `annotations` directly when you need `idempotentHint` or `openWorldHint`.
+The SDK forwards the array unchanged alongside its internally owned `AbortSignal`. The browser validates each origin and rejects invalid or untrustworthy values. Those asynchronous failures follow the package's existing non-throwing registration posture: they are logged without creating an unhandled rejection. Grant access only to origins that genuinely need it; `exposedTo` is exposure configuration, not an authorization layer.
+
+## Annotations
+
+Annotations communicate intent to the agent. The current WebMCP draft defines `readOnlyHint` and `untrustedContentHint`. Use the latter when a tool returns external, user-generated, or otherwise untrusted content:
+
+```ts
+registerTool({
+  name: "search_community_posts",
+  title: "Search community posts",
+  description: "Search user-authored community posts.",
+  readOnly: true,
+  annotations: {
+    untrustedContentHint: true,
+  },
+  execute: async () => ({ results: await searchCommunityPosts() }),
+});
+```
+
+`untrustedContentHint` is a trust-boundary signal; it does not validate result shape, truth, freshness, or safety. `readOnly` remains shorthand for the draft's `readOnlyHint`.
+
+For source compatibility, the SDK retains `destructiveHint`, `idempotentHint`, `openWorldHint`, and the `destructive` shorthand as passthroughs for MCP-shaped and earlier WebMCP hosts. They are not defined by the current WebMCP draft, so current-draft browsers may ignore them. Raw `annotations` values merge on top of shorthand values.
 
 ## Tool design
 
@@ -100,7 +116,7 @@ A tool is a semantic interface, not just a function: the agent selects tools by 
 - **Descriptions that say when to use the tool**, not just what it does. Besides the schema, the description is the agent's only routing signal.
 - **Precise `inputSchema`.** Mark `required` fields, describe every property, and use enums for closed sets so hosts can validate before dispatch.
 - **Small, structured outputs.** Return compact objects the agent can act on, and surface failures as structured error objects rather than thrown strings.
-- **Honest annotations.** `readOnly` for inspection tools, `destructive` for anything irreversible or user-impacting — and still confirm destructive actions with the user; an annotation is not authorization, and neither is a tool. Never expose a tool that bypasses your normal authorization checks.
+- **Honest annotations.** Use `readOnly` for inspection tools and `untrustedContentHint` for untrusted results. Compatibility fields such as `destructive` may help older hosts, but no annotation is authorization. Never expose a tool that bypasses your normal authorization checks.
 - **Lifecycle-scoped registration.** Register a tool only while the UI state it acts on exists, and call the cleanup when that state goes away.
 
 ## Errors and unavailability

--- a/apps/site/src/content/docs/packages/webmcp.md
+++ b/apps/site/src/content/docs/packages/webmcp.md
@@ -102,7 +102,7 @@ export function WebMCP({ isSignedIn }: { isSignedIn: boolean }) {
 }
 ```
 
-The hook accepts one tool or a readonly array. It registers on mount, unregisters on unmount, and cleans up immediately when `enabled` changes to `false`. Registration follows discoverable metadata and `exposedTo` values rather than object identity, while `execute` always uses the latest committed callback. Inline tool objects, arrays, and options are safe: changing React state alone does not rebuild the registration, but changing a tool's name, title, description, schema, annotations, or exposure does.
+The hook accepts one tool or a readonly array. It registers on mount, unregisters on unmount, and cleans up immediately when `enabled` changes to `false`. Registration follows discoverable metadata and `exposedTo` values rather than object identity, while `execute` always uses the latest committed callback. Inline tool objects, arrays, and options are safe: changing React state alone does not rebuild the registration, but changing a tool's name, title, description, schema, annotations, or exposure does. Memoize tool arrays and large schemas when practical to avoid rebuilding and comparing their metadata on every render; correctness does not depend on memoization.
 
 ## API
 

--- a/apps/site/src/content/docs/packages/webmcp.md
+++ b/apps/site/src/content/docs/packages/webmcp.md
@@ -34,8 +34,10 @@ import { registerTool } from "@web-ai-sdk/webmcp";
 const tools = [
   {
     name: "list_blog_posts",
+    title: "List blog posts",
     description: "List published blog posts.",
     readOnly: true,
+    annotations: { untrustedContentHint: true },
     execute: async () => {
       const res = await fetch("/api/posts.json");
       return { results: await res.json() };
@@ -75,40 +77,36 @@ const cleanup = () => cleanups.forEach((c) => c());
 cleanup();
 ```
 
-`registerTool(tool)` registers a single tool and returns the cleanup. Re-registering a tool with the same name is safe; the previous registration is dropped first.
+`registerTool(tool, options?)` registers a single tool and returns the cleanup. Re-registering a tool with the same name is safe; the previous registration is dropped first.
 
 ## React
 
 ```tsx
 import { useWebMCP, type Tool } from "@web-ai-sdk/webmcp/react";
-import { useMemo } from "react";
 
-const TOOLS: Tool[] = [
-  {
-    name: "list_blog_posts",
-    description: "List published blog posts.",
-    readOnly: true,
-    execute: async () => {
-      const res = await fetch("/api/posts.json");
-      return { results: await res.json() };
-    },
+const LIST_POSTS: Tool = {
+  name: "list_blog_posts",
+  title: "List blog posts",
+  description: "List published blog posts.",
+  readOnly: true,
+  annotations: { untrustedContentHint: true },
+  execute: async () => {
+    const res = await fetch("/api/posts.json");
+    return { results: await res.json() };
   },
-];
+};
 
-export function WebMCP() {
-  // Stable reference: keep tools outside the component or wrap in useMemo,
-  // otherwise the hook will unregister/re-register on every render.
-  const tools = useMemo(() => TOOLS, []);
-  useWebMCP(tools);
+export function WebMCP({ isSignedIn }: { isSignedIn: boolean }) {
+  useWebMCP(LIST_POSTS, { enabled: isSignedIn });
   return null;
 }
 ```
 
-The hook registers on mount, unregisters on unmount, and re-registers when the array reference changes.
+The hook accepts one tool or a readonly array. It registers on mount, unregisters on unmount, and cleans up immediately when `enabled` changes to `false`. Registration follows discoverable metadata and `exposedTo` values rather than object identity, while `execute` always uses the latest committed callback. Inline tool objects, arrays, and options are safe: changing React state alone does not rebuild the registration, but changing a tool's name, title, description, schema, annotations, or exposure does.
 
 ## API
 
-### `registerTool(tool): () => void`
+### `registerTool(tool, options?): () => void`
 
 Register a single tool. Returns a cleanup function. No-op on unsupported browsers.
 
@@ -121,6 +119,16 @@ const cleanups = tools.map(registerTool);
 const cleanup = () => cleanups.forEach((c) => c());
 ```
 
+Use `exposedTo` to let descendant documents at specific origins discover the tool:
+
+```ts
+const cleanup = registerTool(tool, {
+  exposedTo: ["https://agent.example"],
+});
+```
+
+The SDK forwards the array unchanged alongside its internally owned `AbortSignal`. The browser validates each origin and rejects invalid or untrustworthy values; the wrapper preserves its non-throwing registration posture and logs that failure. Exposure is unnecessary for the owning document and should be limited to origins that genuinely need access.
+
 ### `isAvailable(): boolean`
 
 Feature-detect helper.
@@ -130,6 +138,7 @@ Feature-detect helper.
 ```ts
 interface Tool<TInput = unknown, TOutput = unknown> {
   name: string;
+  title?: string; // human-readable host UI label
   description: string;
   inputSchema?: object; // JSON Schema
   readOnly?: boolean; // shorthand for annotations.readOnlyHint
@@ -139,7 +148,19 @@ interface Tool<TInput = unknown, TOutput = unknown> {
 }
 ```
 
-`description` is consumed by the agent host (Cursor / Claude / Chrome agent / etc.). Write it as an instruction to an LLM about when to call the tool.
+`title` is for human-facing host UI. `description` is consumed by the agent host (Cursor / Claude / Chrome agent / etc.); write it as an instruction to an LLM about when to call the tool.
+
+The current WebMCP draft defines `readOnlyHint` and `untrustedContentHint`. The SDK also retains `destructiveHint`, `idempotentHint`, `openWorldHint`, and the `destructive` shorthand as source-compatible passthroughs for MCP-shaped and earlier WebMCP hosts; current-draft browsers may ignore those compatibility fields.
+
+```ts
+interface ToolAnnotations {
+  readOnlyHint?: boolean;
+  untrustedContentHint?: boolean;
+  destructiveHint?: boolean; // compatibility
+  idempotentHint?: boolean; // compatibility
+  openWorldHint?: boolean; // compatibility
+}
+```
 
 ### `defineTool({...}): Tool` — typed schema adapter (Standard Schema)
 
@@ -149,6 +170,7 @@ import { z } from "zod"; // or valibot, arktype, effect, …
 
 const sendEmail = defineTool({
   name: "send_contact_email",
+  title: "Send contact email",
   description: "Send a contact email on behalf of the visitor.",
   destructive: true,
   // Standard Schema (https://standardschema.dev): used to narrow execute's
@@ -159,6 +181,9 @@ const sendEmail = defineTool({
     subject: z.string().min(1),
     message: z.string().min(1),
   }),
+  // Output schemas validate every resolved result and may transform it.
+  // They stay inside the SDK and are not forwarded to WebMCP.
+  output: z.object({ ok: z.literal(true) }),
   // The host still wants raw JSON Schema for tool dispatch; pass it explicitly.
   // Standard Schema does not emit JSON Schema, so we don't bridge between
   // them — keeping both lets you choose your validator without coupling.
@@ -189,11 +214,17 @@ const sendEmail = defineTool({
 
 `defineTool` accepts any [Standard Schema](https://standardschema.dev) V1 validator (Zod 3.24+, Valibot, ArkType, Effect, …) — no SDK dependency on any specific library. The returned object is a plain `Tool`, so it composes with the rest of the API unchanged.
 
-**Validation:** off by default (`validate: false`). Most WebMCP hosts validate against `inputSchema` themselves; running the Standard Schema validator on top is opt-in via `validate: true`, which throws `ToolValidationError` on bad input. With `validate: false` the schema is type-only.
+**Input validation:** off by default (`validate: false`). Most WebMCP hosts validate against `inputSchema` themselves; running the Standard Schema input validator on top is opt-in via `validate: true`, which throws `ToolValidationError` on bad input. With `validate: false`, `input` is type-only.
+
+**Output validation:** supplying `output` always validates the resolved sync or async `execute` result and returns the schema's parsed value, including transformations. Invalid output throws `ToolOutputValidationError`; its `toolName` and `issues` fields identify the tool and preserve the Standard Schema issues. The output schema is SDK-only because WebMCP has no `outputSchema` field.
+
+Output validation only checks the rules encoded in the schema. It does not prove that a result is fresh, trustworthy, or factually correct.
 
 ## Safety
 
-Mark mutating tools `destructive: true`. The host (browser, agent) is responsible for gating destructive tools on explicit user approval; `@web-ai-sdk/webmcp` only forwards the annotation. For sensitive operations also defend server-side (origin allowlist, rate limit, validation).
+Set `annotations.untrustedContentHint: true` when results contain external, user-generated, or otherwise untrusted content. It is a trust-boundary signal for the host, not validation of the result's shape, truth, freshness, or safety.
+
+The compatibility shorthand `destructive: true` still communicates mutating intent to hosts that understand `destructiveHint`, but an annotation is not authorization. Confirm consequential actions with the user and defend sensitive operations server-side with authentication, authorization, validation, origin controls, and rate limits.
 
 ## Troubleshooting
 

--- a/apps/site/src/content/docs/react/use-web-mcp.mdx
+++ b/apps/site/src/content/docs/react/use-web-mcp.mdx
@@ -11,56 +11,67 @@ React adapter for `@web-ai-sdk/webmcp`. Registers WebMCP tools on mount and unre
 
 <WebMCPDemo client:only="react" />
 
-Toggle the tools on or off, then click "Run agent". On browsers with WebMCP enabled the demo asks Chrome's testing surface (`navigator.modelContextTesting.executeTool`) to dispatch one of the live tools.
+Use the invoke controls below to call a registered tool. On browsers with WebMCP enabled the demo asks Chrome's testing surface (`navigator.modelContextTesting.executeTool`) to dispatch the selected live tool.
 
 ## Usage
 
 ```tsx
-import { useWebMCP } from "@web-ai-sdk/webmcp/react";
-import { useMemo } from "react";
+import { useWebMCP, type Tool } from "@web-ai-sdk/webmcp/react";
 
-export function AgentTools() {
-  const tools = useMemo(
-    () => [
-      {
-        name: "add_to_cart",
-        description: "Add a SKU to the user's cart",
-        execute: async (input) => ({ ok: true, ...input }),
-      },
-    ],
-    [],
-  );
+const ADD_TO_CART: Tool = {
+  name: "add_to_cart",
+  title: "Add to cart",
+  description: "Add a SKU to the user's cart",
+  execute: async (input) => ({ ok: true, ...input }),
+};
 
-  useWebMCP(tools);
+export function AgentTools({ isSignedIn }: { isSignedIn: boolean }) {
+  useWebMCP(ADD_TO_CART, { enabled: isSignedIn });
   return null; // pure logic; render whatever UI you want elsewhere
 }
 ```
 
-The hook re-registers whenever the `tools` array reference changes. Pass a stable reference (memoized or module-level) so the hook doesn't tear down and rebuild on every render.
+The hook accepts a single `Tool` or a readonly array. It registers on mount, cleans up on unmount, and cleans up whenever `enabled` changes to `false`.
+
+Multiple tools can be passed directly:
+
+```tsx
+useWebMCP([listItems, addToCart]);
+```
+
+The hook compares discoverable metadata and `exposedTo` values rather than object identity. Recreating an equivalent tool, tool array, or options object does not tear down its registration. Changing a name, title, description, schema, annotation, exposure value, or `enabled` state does update the registration.
+
+## Cross-document exposure
+
+Pass `exposedTo` through the hook when descendant documents at other origins should discover the tool:
+
+```tsx
+const EXPOSED_TO = ["https://agent.example"] as const;
+
+useWebMCP(ADD_TO_CART, {
+  enabled: isSignedIn,
+  exposedTo: EXPOSED_TO,
+});
+```
+
+The browser validates the origins. The SDK owns the registration's `AbortSignal`; callers cannot replace it.
 
 ## State + reactivity
 
-Tool `execute` closures capture whatever they read at definition time. If your tool needs to read live React state, use a `useRef`:
+The registered tool always delegates to the latest committed `execute` callback, so it can read live props and state without a manual ref bridge:
 
 ```tsx
-const stateRef = useRef(state);
-stateRef.current = state;
-
-const tools = useMemo(
-  () => [
-    {
-      name: "open_settings",
-      description: "...",
-      execute: async () => ({ pane: stateRef.current.pane }),
-    },
-  ],
-  [],
-);
-
-useWebMCP(tools);
+export function SettingsTool({ pane }: { pane: string }) {
+  useWebMCP({
+    name: "open_settings",
+    description: "Read the currently open settings pane",
+    execute: async () => ({ pane }),
+  });
+  return null;
+}
 ```
 
-This is necessary because Chrome's `AbortSignal`-driven unregister is asynchronous; a same-tick re-register can be silently skipped on a duplicate-name race, leaving the old closure in place. Reading from a ref guarantees the latest state regardless of which closure Chrome holds.
+Rerendering `SettingsTool` with a new `pane` updates execution immediately without unregistering and re-registering the tool. This avoids duplicate-name races while keeping registration changes tied to the fields an agent host can discover.
 
 ## Cleanup
 
@@ -70,32 +81,67 @@ The hook returns nothing; cleanup is automatic on unmount via `useEffect`'s retu
 
 On browsers without `document.modelContext` (or the legacy `navigator.modelContext`), the hook is a no-op. Render whatever fallback UI you want; nothing breaks.
 
+Tools created with `defineTool` can reject with `ToolValidationError` for opt-in input validation or `ToolOutputValidationError` when an `output` schema rejects the resolved result. Output schemas are SDK-only and are not forwarded to WebMCP.
+
 ## Reference
 
 ```ts
-import type { Tool, ToolAnnotations, DefineToolOptions } from "@web-ai-sdk/webmcp/react";
+import type {
+  DefineToolOptions,
+  RegisterToolOptions,
+  StandardSchemaV1,
+  Tool,
+  ToolAnnotations,
+  UseWebMCPOptions,
+} from "@web-ai-sdk/webmcp/react";
 
 interface Tool {
   name: string;
+  title?: string;
   description: string;
   execute: (input: unknown) => Promise<unknown> | unknown;
   readOnly?: boolean;              // → annotations.readOnlyHint
-  destructive?: boolean;           // → annotations.destructiveHint
+  destructive?: boolean;           // compatibility shorthand
   annotations?: ToolAnnotations;   // raw passthrough; merges on top of shorthand
-  inputSchema?: object;            // JSON Schema or Standard Schema v1
+  inputSchema?: object;            // JSON Schema
 }
 
 interface ToolAnnotations {
   readOnlyHint?: boolean;
-  destructiveHint?: boolean;
-  idempotentHint?: boolean;
-  openWorldHint?: boolean;
+  untrustedContentHint?: boolean;
+  destructiveHint?: boolean;       // compatibility
+  idempotentHint?: boolean;        // compatibility
+  openWorldHint?: boolean;         // compatibility
 }
 
-declare const useWebMCP: (tools: readonly Tool[]) => void;
+interface RegisterToolOptions {
+  exposedTo?: readonly string[];
+}
+
+interface UseWebMCPOptions extends RegisterToolOptions {
+  enabled?: boolean;
+}
+
+declare const useWebMCP: (
+  toolOrTools: Tool | readonly Tool[],
+  options?: UseWebMCPOptions,
+) => void;
 
 // Helper for type-safe tool definitions with a Standard Schema.
-declare function defineTool<T extends StandardSchemaV1>(options: DefineToolOptions<T>): Tool;
+declare function defineTool<
+  InputSchema extends StandardSchemaV1 | undefined = undefined,
+  TOutput = unknown,
+  OutputSchema extends StandardSchemaV1 | undefined = undefined,
+>(
+  options: DefineToolOptions<InputSchema, TOutput, OutputSchema>,
+): Tool<
+  InputSchema extends StandardSchemaV1
+    ? StandardSchemaV1.InferInput<InputSchema>
+    : unknown,
+  OutputSchema extends StandardSchemaV1
+    ? StandardSchemaV1.InferOutput<OutputSchema>
+    : TOutput
+>;
 ```
 
 Source: [`packages/webmcp/src/react/index.ts`](https://github.com/obetomuniz/web-ai-sdk/blob/main/packages/webmcp/src/react/index.ts).

--- a/apps/site/src/content/docs/react/use-web-mcp.mdx
+++ b/apps/site/src/content/docs/react/use-web-mcp.mdx
@@ -41,6 +41,8 @@ useWebMCP([listItems, addToCart]);
 
 The hook compares discoverable metadata and `exposedTo` values rather than object identity. Recreating an equivalent tool, tool array, or options object does not tear down its registration. Changing a name, title, description, schema, annotation, exposure value, or `enabled` state does update the registration.
 
+Memoize tool arrays and large schemas when practical to avoid rebuilding and comparing their metadata on every render. Memoization is a performance optimization here, not a correctness requirement.
+
 ## Cross-document exposure
 
 Pass `exposedTo` through the hook when descendant documents at other origins should discover the tool:

--- a/packages/webmcp/README.md
+++ b/packages/webmcp/README.md
@@ -27,8 +27,10 @@ import { registerTool } from "@web-ai-sdk/webmcp";
 const tools = [
   {
     name: "list_blog_posts",
+    title: "List blog posts",
     description: "List published blog posts.",
     readOnly: true,
+    annotations: { untrustedContentHint: true },
     execute: async () => {
       const res = await fetch("/api/posts.json");
       return { results: await res.json() };
@@ -68,40 +70,36 @@ const cleanup = () => cleanups.forEach((c) => c());
 cleanup();
 ```
 
-`registerTool(tool)` registers a single tool and returns the cleanup. Re-registering a tool with the same name is safe; the previous registration is dropped first.
+`registerTool(tool, options?)` registers a single tool and returns the cleanup. Re-registering a tool with the same name is safe; the previous registration is dropped first.
 
 ## React
 
 ```tsx
 import { useWebMCP, type Tool } from "@web-ai-sdk/webmcp/react";
-import { useMemo } from "react";
 
-const TOOLS: Tool[] = [
-  {
-    name: "list_blog_posts",
-    description: "List published blog posts.",
-    readOnly: true,
-    execute: async () => {
-      const res = await fetch("/api/posts.json");
-      return { results: await res.json() };
-    },
+const LIST_POSTS: Tool = {
+  name: "list_blog_posts",
+  title: "List blog posts",
+  description: "List published blog posts.",
+  readOnly: true,
+  annotations: { untrustedContentHint: true },
+  execute: async () => {
+    const res = await fetch("/api/posts.json");
+    return { results: await res.json() };
   },
-];
+};
 
-export function WebMCP() {
-  // Stable reference: keep tools outside the component or wrap in useMemo,
-  // otherwise the hook will unregister/re-register on every render.
-  const tools = useMemo(() => TOOLS, []);
-  useWebMCP(tools);
+export function WebMCP({ isSignedIn }: { isSignedIn: boolean }) {
+  useWebMCP(LIST_POSTS, { enabled: isSignedIn });
   return null;
 }
 ```
 
-The hook registers on mount, unregisters on unmount, and re-registers when the array reference changes.
+The hook accepts one tool or a readonly array. It registers on mount, unregisters on unmount, and cleans up immediately when `enabled` changes to `false`. Registration follows discoverable metadata and `exposedTo` values rather than object identity, while `execute` always uses the latest committed callback. Inline tool objects, arrays, and options are safe: changing React state alone does not rebuild the registration, but changing a tool's name, title, description, schema, annotations, or exposure does.
 
 ## API
 
-### `registerTool(tool): () => void`
+### `registerTool(tool, options?): () => void`
 
 Register a single tool. Returns a cleanup function. No-op on unsupported browsers.
 
@@ -114,6 +112,16 @@ const cleanups = tools.map(registerTool);
 const cleanup = () => cleanups.forEach((c) => c());
 ```
 
+Use `exposedTo` to let descendant documents at specific origins discover the tool:
+
+```ts
+const cleanup = registerTool(tool, {
+  exposedTo: ["https://agent.example"],
+});
+```
+
+The SDK forwards the array unchanged alongside its internally owned `AbortSignal`. The browser validates each origin and rejects invalid or untrustworthy values; the wrapper preserves its non-throwing registration posture and logs that failure. Exposure is unnecessary for the owning document and should be limited to origins that genuinely need access.
+
 ### `isAvailable(): boolean`
 
 Feature-detect helper.
@@ -123,6 +131,7 @@ Feature-detect helper.
 ```ts
 interface Tool<TInput = unknown, TOutput = unknown> {
   name: string;
+  title?: string; // human-readable host UI label
   description: string;
   inputSchema?: object; // JSON Schema
   readOnly?: boolean; // shorthand for annotations.readOnlyHint
@@ -132,7 +141,19 @@ interface Tool<TInput = unknown, TOutput = unknown> {
 }
 ```
 
-`description` is consumed by the agent host (Cursor / Claude / Chrome agent / etc.). Write it as an instruction to an LLM about when to call the tool.
+`title` is for human-facing host UI. `description` is consumed by the agent host (Cursor / Claude / Chrome agent / etc.); write it as an instruction to an LLM about when to call the tool.
+
+The current WebMCP draft defines `readOnlyHint` and `untrustedContentHint`. The SDK also retains `destructiveHint`, `idempotentHint`, `openWorldHint`, and the `destructive` shorthand as source-compatible passthroughs for MCP-shaped and earlier WebMCP hosts; current-draft browsers may ignore those compatibility fields.
+
+```ts
+interface ToolAnnotations {
+  readOnlyHint?: boolean;
+  untrustedContentHint?: boolean;
+  destructiveHint?: boolean; // compatibility
+  idempotentHint?: boolean; // compatibility
+  openWorldHint?: boolean; // compatibility
+}
+```
 
 ### `defineTool({...}): Tool` — typed schema adapter (Standard Schema)
 
@@ -142,6 +163,7 @@ import { z } from "zod"; // or valibot, arktype, effect, …
 
 const sendEmail = defineTool({
   name: "send_contact_email",
+  title: "Send contact email",
   description: "Send a contact email on behalf of the visitor.",
   destructive: true,
   // Standard Schema (https://standardschema.dev): used to narrow execute's
@@ -152,6 +174,9 @@ const sendEmail = defineTool({
     subject: z.string().min(1),
     message: z.string().min(1),
   }),
+  // Output schemas validate every resolved result and may transform it.
+  // They stay inside the SDK and are not forwarded to WebMCP.
+  output: z.object({ ok: z.literal(true) }),
   // The host still wants raw JSON Schema for tool dispatch; pass it explicitly.
   // Standard Schema does not emit JSON Schema, so we don't bridge between
   // them — keeping both lets you choose your validator without coupling.
@@ -182,11 +207,17 @@ const sendEmail = defineTool({
 
 `defineTool` accepts any [Standard Schema](https://standardschema.dev) V1 validator (Zod 3.24+, Valibot, ArkType, Effect, …) — no SDK dependency on any specific library. The returned object is a plain `Tool`, so it composes with the rest of the API unchanged.
 
-**Validation:** off by default (`validate: false`). Most WebMCP hosts validate against `inputSchema` themselves; running the Standard Schema validator on top is opt-in via `validate: true`, which throws `ToolValidationError` on bad input. With `validate: false` the schema is type-only.
+**Input validation:** off by default (`validate: false`). Most WebMCP hosts validate against `inputSchema` themselves; running the Standard Schema input validator on top is opt-in via `validate: true`, which throws `ToolValidationError` on bad input. With `validate: false`, `input` is type-only.
+
+**Output validation:** supplying `output` always validates the resolved sync or async `execute` result and returns the schema's parsed value, including transformations. Invalid output throws `ToolOutputValidationError`; its `toolName` and `issues` fields identify the tool and preserve the Standard Schema issues. The output schema is SDK-only because WebMCP has no `outputSchema` field.
+
+Output validation only checks the rules encoded in the schema. It does not prove that a result is fresh, trustworthy, or factually correct.
 
 ## Safety
 
-Mark mutating tools `destructive: true`. The host (browser, agent) is responsible for gating destructive tools on explicit user approval; `@web-ai-sdk/webmcp` only forwards the annotation. For sensitive operations also defend server-side (origin allowlist, rate limit, validation).
+Set `annotations.untrustedContentHint: true` when results contain external, user-generated, or otherwise untrusted content. It is a trust-boundary signal for the host, not validation of the result's shape, truth, freshness, or safety.
+
+The compatibility shorthand `destructive: true` still communicates mutating intent to hosts that understand `destructiveHint`, but an annotation is not authorization. Confirm consequential actions with the user and defend sensitive operations server-side with authentication, authorization, validation, origin controls, and rate limits.
 
 ## Troubleshooting
 

--- a/packages/webmcp/README.md
+++ b/packages/webmcp/README.md
@@ -95,7 +95,7 @@ export function WebMCP({ isSignedIn }: { isSignedIn: boolean }) {
 }
 ```
 
-The hook accepts one tool or a readonly array. It registers on mount, unregisters on unmount, and cleans up immediately when `enabled` changes to `false`. Registration follows discoverable metadata and `exposedTo` values rather than object identity, while `execute` always uses the latest committed callback. Inline tool objects, arrays, and options are safe: changing React state alone does not rebuild the registration, but changing a tool's name, title, description, schema, annotations, or exposure does.
+The hook accepts one tool or a readonly array. It registers on mount, unregisters on unmount, and cleans up immediately when `enabled` changes to `false`. Registration follows discoverable metadata and `exposedTo` values rather than object identity, while `execute` always uses the latest committed callback. Inline tool objects, arrays, and options are safe: changing React state alone does not rebuild the registration, but changing a tool's name, title, description, schema, annotations, or exposure does. Memoize tool arrays and large schemas when practical to avoid rebuilding and comparing their metadata on every render; correctness does not depend on memoization.
 
 ## API
 

--- a/packages/webmcp/src/index.test.ts
+++ b/packages/webmcp/src/index.test.ts
@@ -1,22 +1,28 @@
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, expectTypeOf, it, vi } from "vitest";
 import {
+  type DefineToolOptions,
   defineTool,
   isAvailable,
+  type RegisterToolOptions,
   registerTool,
   type StandardSchemaV1,
+  type Tool,
+  ToolOutputValidationError,
   ToolValidationError,
 } from "./index.js";
 
 interface RegisteredCall {
   name: string;
+  title?: string;
   description: string;
   inputSchema?: object;
   annotations?: Record<string, boolean>;
   execute: (input: unknown) => unknown;
 }
 
-interface RegisterOptions {
+interface NativeRegisterOptions {
   signal?: AbortSignal;
+  exposedTo?: readonly string[];
 }
 
 type Host = "document" | "navigator";
@@ -54,7 +60,7 @@ const installFakeModelContext = (
     new Error(
       "Failed to execute 'registerTool' on 'ModelContext': Duplicate tool name",
     );
-  const apply = (def: RegisteredCall, options?: RegisterOptions) => {
+  const apply = (def: RegisteredCall, options?: NativeRegisterOptions) => {
     if (registered.has(def.name)) throw dup();
     registered.set(def.name, def);
     options?.signal?.addEventListener("abort", () => {
@@ -62,7 +68,7 @@ const installFakeModelContext = (
     });
   };
   const registerTool = vi.fn(
-    (def: RegisteredCall, options?: RegisterOptions) => {
+    (def: RegisteredCall, options?: NativeRegisterOptions) => {
       if (sync) {
         apply(def, options); // legacy: throws synchronously, returns undefined
         return undefined;
@@ -143,8 +149,28 @@ describe("registerTool", () => {
     expect(spy).toHaveBeenCalledTimes(1);
     const def = registered.get("ping");
     expect(def?.name).toBe("ping");
+    expect(def).not.toHaveProperty("title");
     expect(def?.description).toBe("Returns pong.");
     await expect(def?.execute(undefined)).resolves.toEqual({ result: "pong" });
+  });
+
+  it("forwards title when present", () => {
+    const { registerTool: spy } = installFakeModelContext();
+    const execute = async () => ({ result: "pong" });
+
+    registerTool({
+      name: "ping",
+      title: "Ping the server",
+      description: "Returns pong.",
+      execute,
+    });
+
+    expect(spy.mock.calls[0]?.[0]).toEqual({
+      name: "ping",
+      title: "Ping the server",
+      description: "Returns pong.",
+      execute,
+    });
   });
 
   it("passes an AbortSignal through to registerTool", () => {
@@ -155,9 +181,47 @@ describe("registerTool", () => {
       execute: async () => ({}),
     });
     expect(spy).toHaveBeenCalledTimes(1);
-    const options = spy.mock.calls[0]?.[1] as RegisterOptions | undefined;
+    const options = spy.mock.calls[0]?.[1] as NativeRegisterOptions | undefined;
     expect(options?.signal).toBeInstanceOf(AbortSignal);
     expect(options?.signal?.aborted).toBe(false);
+    expect(options).not.toHaveProperty("exposedTo");
+  });
+
+  it("forwards exposedTo unchanged alongside the owned signal", () => {
+    const { registerTool: spy } = installFakeModelContext();
+    const exposedTo = ["https://agent.example"] as const;
+
+    registerTool(
+      {
+        name: "shared",
+        description: "Shared with an embedded agent.",
+        execute: async () => ({}),
+      },
+      { exposedTo },
+    );
+
+    const options = spy.mock.calls[0]?.[1] as NativeRegisterOptions | undefined;
+    expect(options).toEqual({
+      signal: expect.any(AbortSignal),
+      exposedTo,
+    });
+    expect(options?.exposedTo).toBe(exposedTo);
+  });
+
+  it("remains compatible with tools.map(registerTool)", () => {
+    const { registered, registerTool: spy } = installFakeModelContext();
+    const tools = [
+      { name: "first", description: "First", execute: async () => ({}) },
+      { name: "second", description: "Second", execute: async () => ({}) },
+    ];
+
+    const cleanups: Array<() => void> = tools.map(registerTool);
+
+    expect(registered.size).toBe(2);
+    expect(spy.mock.calls[0]?.[1]).not.toHaveProperty("exposedTo");
+    expect(spy.mock.calls[1]?.[1]).not.toHaveProperty("exposedTo");
+    for (const cleanup of cleanups) cleanup();
+    expect(registered.size).toBe(0);
   });
 
   it("translates the readOnly shorthand to annotations.readOnlyHint", () => {
@@ -197,6 +261,19 @@ describe("registerTool", () => {
       readOnlyHint: true,
       idempotentHint: true,
       openWorldHint: false,
+    });
+  });
+
+  it("forwards an explicit false untrustedContentHint", () => {
+    const { registered } = installFakeModelContext();
+    registerTool({
+      name: "external-search",
+      description: "Searches an external source.",
+      annotations: { untrustedContentHint: false },
+      execute: async () => ({}),
+    });
+    expect(registered.get("external-search")?.annotations).toEqual({
+      untrustedContentHint: false,
     });
   });
 
@@ -433,7 +510,7 @@ describe("registerTool", () => {
 
   it("treats abort-during-pending registration as a clean cancellation (no error/warn)", async () => {
     const registerTool_ = vi.fn(
-      (_def: RegisteredCall, options?: RegisterOptions) =>
+      (_def: RegisteredCall, options?: NativeRegisterOptions) =>
         new Promise<void>((_resolve, reject) => {
           // Never resolves on its own; only rejects when aborted.
           options?.signal?.addEventListener("abort", () => {
@@ -498,17 +575,57 @@ describe("defineTool", () => {
     },
   });
 
+  const numericStringSchema: StandardSchemaV1<string, number> = {
+    "~standard": {
+      version: 1,
+      vendor: "test",
+      validate: (value: unknown) => {
+        if (typeof value === "string" && /^\d+$/.test(value)) {
+          return { value: Number(value) };
+        }
+        return {
+          issues: [
+            {
+              message: "output must be a numeric string",
+              path: ["value"],
+            },
+          ],
+        };
+      },
+      types: { input: "" as string, output: 0 as number },
+    },
+  };
+
   it("returns a Tool that registers via the existing surface", () => {
     const { registered } = installFakeModelContext();
     const tool = defineTool({
       name: "echo",
+      title: "Echo text",
       description: "echoes",
       input: stringSchema("input"),
       inputSchema: { type: "string" },
       execute: (text) => ({ text }),
     });
     registerTool(tool);
+    expect(registered.get("echo")?.title).toBe("Echo text");
     expect(registered.get("echo")?.inputSchema).toEqual({ type: "string" });
+  });
+
+  it("preserves the public metadata and registration option types", () => {
+    const tool = defineTool({
+      name: "external-search",
+      title: "External search",
+      description: "Searches an external source.",
+      annotations: { untrustedContentHint: true },
+      execute: () => ({ results: [] }),
+    });
+    const exposedTo = ["https://agent.example"] as const;
+    const options = { exposedTo } satisfies RegisterToolOptions;
+
+    expectTypeOf(tool.title).toEqualTypeOf<string | undefined>();
+    expectTypeOf(options.exposedTo).toEqualTypeOf<
+      readonly ["https://agent.example"]
+    >();
   });
 
   it("does NOT validate by default (purely additive type narrowing)", async () => {
@@ -522,6 +639,21 @@ describe("defineTool", () => {
     // verbatim (here sync, since the user's execute is sync).
     const out = await (tool.execute as (i: unknown) => unknown)(123);
     expect(out).toEqual({ text: 123 });
+  });
+
+  it("preserves the existing explicit DefineToolOptions generic order", () => {
+    type InputSchema = StandardSchemaV1<string, string>;
+    type Output = { text: string };
+    const options: DefineToolOptions<InputSchema, Output> = {
+      name: "echo",
+      description: "echoes",
+      input: stringSchema("input"),
+      execute: (text) => ({ text }),
+    };
+    const tool = defineTool<InputSchema, Output>(options);
+    const acceptsExistingTool = (_tool: Tool<string, Output>): void => {};
+
+    acceptsExistingTool(tool);
   });
 
   it("validates and throws ToolValidationError when validate:true and input fails", async () => {
@@ -550,6 +682,119 @@ describe("defineTool", () => {
     ).resolves.toEqual({ text: "hi" });
   });
 
+  it("validates a synchronous result with a synchronous output schema", async () => {
+    const validate = vi.fn((value: unknown) => {
+      if (typeof value === "string") return { value: value.toUpperCase() };
+      return { issues: [{ message: "output must be a string" }] };
+    });
+    const output: StandardSchemaV1<string, string> = {
+      "~standard": { version: 1, vendor: "test", validate },
+    };
+    const tool = defineTool({
+      name: "greet",
+      description: "greets",
+      output,
+      execute: () => "hello",
+    });
+
+    await expect(tool.execute(undefined)).resolves.toBe("HELLO");
+    expect(validate).toHaveBeenCalledWith("hello");
+  });
+
+  it("supports asynchronous results and asynchronous output validators", async () => {
+    const output: StandardSchemaV1<string, string> = {
+      "~standard": {
+        version: 1,
+        vendor: "test",
+        validate: async (value: unknown) => {
+          await Promise.resolve();
+          return typeof value === "string"
+            ? { value: `${value}!` }
+            : { issues: [{ message: "output must be a string" }] };
+        },
+      },
+    };
+    const tool = defineTool({
+      name: "async-greet",
+      description: "greets asynchronously",
+      output,
+      execute: async () => {
+        await Promise.resolve();
+        return "hello";
+      },
+    });
+
+    await expect(tool.execute(undefined)).resolves.toBe("hello!");
+  });
+
+  it("returns schema transformations with the inferred output type", async () => {
+    const tool = defineTool({
+      name: "count",
+      description: "returns a count",
+      output: numericStringSchema,
+      execute: () => "42",
+    });
+
+    const result = await tool.execute(undefined);
+    expect(result).toBe(42);
+    expectTypeOf(result).toEqualTypeOf<number>();
+  });
+
+  it("throws ToolOutputValidationError with the tool name and issues", async () => {
+    const tool = defineTool({
+      name: "count",
+      description: "returns a count",
+      output: numericStringSchema,
+      execute: () => "not-a-number",
+    });
+
+    await expect(tool.execute(undefined)).rejects.toMatchObject({
+      name: "ToolOutputValidationError",
+      toolName: "count",
+      issues: [
+        {
+          message: "output must be a numeric string",
+          path: ["value"],
+        },
+      ],
+    });
+    await expect(tool.execute(undefined)).rejects.toBeInstanceOf(
+      ToolOutputValidationError,
+    );
+  });
+
+  it("passes execute rejections through without running output validation", async () => {
+    const failure = new Error("request failed");
+    const validate = vi.fn((value: unknown) => ({ value: String(value) }));
+    const output: StandardSchemaV1<string, string> = {
+      "~standard": { version: 1, vendor: "test", validate },
+    };
+    const tool = defineTool({
+      name: "failing",
+      description: "fails",
+      output,
+      execute: async () => {
+        throw failure;
+      },
+    });
+
+    await expect(tool.execute(undefined)).rejects.toBe(failure);
+    expect(validate).not.toHaveBeenCalled();
+  });
+
+  it("does not forward an outputSchema field to WebMCP", () => {
+    const { registered } = installFakeModelContext();
+    const tool = defineTool({
+      name: "count",
+      description: "returns a count",
+      output: numericStringSchema,
+      execute: () => "42",
+    });
+    registerTool(tool);
+
+    expect(registered.get("count")).not.toHaveProperty("outputSchema");
+  });
+
   it("forwards readOnly / destructive shorthands to the resulting Tool", () => {
     const tool = defineTool({
       name: "list",
@@ -571,5 +816,20 @@ describe("defineTool", () => {
     });
     registerTool(tool);
     expect(registered.get("plain")?.inputSchema).toEqual({ type: "object" });
+  });
+
+  it("preserves synchronous results and output inference without output", () => {
+    const tool = defineTool({
+      name: "plain",
+      description: "plain",
+      execute: () => ({ ok: true as const }),
+    });
+    const acceptsInferredTool = (
+      _tool: Tool<unknown, { readonly ok: true }>,
+    ): void => {};
+
+    acceptsInferredTool(tool);
+    expect(tool.execute(undefined)).toEqual({ ok: true });
+    expect(tool.execute(undefined)).not.toBeInstanceOf(Promise);
   });
 });

--- a/packages/webmcp/src/index.ts
+++ b/packages/webmcp/src/index.ts
@@ -10,33 +10,14 @@
  * Spec: https://webmachinelearning.github.io/webmcp/
  */
 
-export interface ToolAnnotations {
-  /** Defined by the current WebMCP draft. */
-  readOnlyHint?: boolean;
-  /** Marks external or user-generated tool output as untrusted. */
-  untrustedContentHint?: boolean;
-  /** Compatibility passthrough for MCP-shaped and earlier WebMCP hosts. */
-  destructiveHint?: boolean;
-  /** Compatibility passthrough for MCP-shaped and earlier WebMCP hosts. */
-  idempotentHint?: boolean;
-  /** Compatibility passthrough for MCP-shaped and earlier WebMCP hosts. */
-  openWorldHint?: boolean;
-}
+import {
+  type RegisteredToolMetadata,
+  type Tool,
+  type ToolAnnotations,
+  toRegisteredToolMetadata,
+} from "./tool.js";
 
-export interface Tool<TInput = unknown, TOutput = unknown> {
-  name: string;
-  /** Optional human-readable title for display in host user interfaces. */
-  title?: string;
-  description: string;
-  inputSchema?: object;
-  /** Shorthand for `annotations.readOnlyHint = true`. */
-  readOnly?: boolean;
-  /** Compatibility shorthand for `annotations.destructiveHint = true`. */
-  destructive?: boolean;
-  /** Raw passthrough; merged on top of the shorthand flags. */
-  annotations?: ToolAnnotations;
-  execute: (input: TInput) => Promise<TOutput> | TOutput;
-}
+export type { Tool, ToolAnnotations } from "./tool.js";
 
 /**
  * Minimal Standard Schema V1 surface — see https://standardschema.dev. Any
@@ -247,12 +228,7 @@ export const defineTool = <
   return tool;
 };
 
-interface RegisteredTool {
-  name: string;
-  title?: string;
-  description: string;
-  inputSchema?: object;
-  annotations?: ToolAnnotations;
+interface RegisteredTool extends RegisteredToolMetadata {
   execute: (input: unknown) => Promise<unknown> | unknown;
 }
 
@@ -299,21 +275,10 @@ const getModelContext = (): ModelContext | undefined => {
 export const isAvailable = (): boolean => getModelContext() !== undefined;
 
 const toRegistered = (tool: Tool): RegisteredTool => {
-  const annotations: ToolAnnotations = {
-    ...(tool.readOnly ? { readOnlyHint: true } : {}),
-    ...(tool.destructive ? { destructiveHint: true } : {}),
-    ...tool.annotations,
-  };
-
-  const registered: RegisteredTool = {
-    name: tool.name,
-    description: tool.description,
+  return {
+    ...toRegisteredToolMetadata(tool),
     execute: tool.execute as RegisteredTool["execute"],
   };
-  if (tool.title !== undefined) registered.title = tool.title;
-  if (tool.inputSchema !== undefined) registered.inputSchema = tool.inputSchema;
-  if (Object.keys(annotations).length > 0) registered.annotations = annotations;
-  return registered;
 };
 
 /**

--- a/packages/webmcp/src/index.ts
+++ b/packages/webmcp/src/index.ts
@@ -11,19 +11,27 @@
  */
 
 export interface ToolAnnotations {
+  /** Defined by the current WebMCP draft. */
   readOnlyHint?: boolean;
+  /** Marks external or user-generated tool output as untrusted. */
+  untrustedContentHint?: boolean;
+  /** Compatibility passthrough for MCP-shaped and earlier WebMCP hosts. */
   destructiveHint?: boolean;
+  /** Compatibility passthrough for MCP-shaped and earlier WebMCP hosts. */
   idempotentHint?: boolean;
+  /** Compatibility passthrough for MCP-shaped and earlier WebMCP hosts. */
   openWorldHint?: boolean;
 }
 
 export interface Tool<TInput = unknown, TOutput = unknown> {
   name: string;
+  /** Optional human-readable title for display in host user interfaces. */
+  title?: string;
   description: string;
   inputSchema?: object;
   /** Shorthand for `annotations.readOnlyHint = true`. */
   readOnly?: boolean;
-  /** Shorthand for `annotations.destructiveHint = true`. */
+  /** Compatibility shorthand for `annotations.destructiveHint = true`. */
   destructive?: boolean;
   /** Raw passthrough; merged on top of the shorthand flags. */
   annotations?: ToolAnnotations;
@@ -68,10 +76,14 @@ export namespace StandardSchemaV1 {
 
   export type InferInput<S> =
     S extends StandardSchemaV1<infer In, unknown> ? In : unknown;
+
+  export type InferOutput<S> =
+    S extends StandardSchemaV1<unknown, infer Out> ? Out : unknown;
 }
 
 export class ToolValidationError extends Error {
   override readonly name = "ToolValidationError";
+  readonly toolName: string;
   readonly issues: ReadonlyArray<StandardSchemaV1.Issue>;
   constructor(toolName: string, issues: ReadonlyArray<StandardSchemaV1.Issue>) {
     const summary = issues
@@ -79,15 +91,34 @@ export class ToolValidationError extends Error {
       .map((i) => i.message)
       .join("; ");
     super(`Tool "${toolName}" input validation failed: ${summary}`);
+    this.toolName = toolName;
+    this.issues = issues;
+  }
+}
+
+export class ToolOutputValidationError extends Error {
+  override readonly name = "ToolOutputValidationError";
+  readonly toolName: string;
+  readonly issues: ReadonlyArray<StandardSchemaV1.Issue>;
+  constructor(toolName: string, issues: ReadonlyArray<StandardSchemaV1.Issue>) {
+    const summary = issues
+      .slice(0, 3)
+      .map((i) => i.message)
+      .join("; ");
+    super(`Tool "${toolName}" output validation failed: ${summary}`);
+    this.toolName = toolName;
     this.issues = issues;
   }
 }
 
 export interface DefineToolOptions<
-  Schema extends StandardSchemaV1 | undefined = undefined,
+  InputSchema extends StandardSchemaV1 | undefined = undefined,
   TOutput = unknown,
+  OutputSchema extends StandardSchemaV1 | undefined = undefined,
 > {
   name: string;
+  /** Optional human-readable title for display in host user interfaces. */
+  title?: string;
   description: string;
   /**
    * Optional Standard Schema (Zod / Valibot / ArkType / etc.) used purely to
@@ -95,7 +126,13 @@ export interface DefineToolOptions<
    * `validate: true`. Standard Schema doesn't emit JSON Schema, so pass
    * `inputSchema` explicitly when the host needs it for tool dispatch.
    */
-  input?: Schema;
+  input?: InputSchema;
+  /**
+   * Optional Standard Schema for the resolved `execute` result. When present,
+   * the SDK always validates the result and returns the schema's parsed output.
+   * This is SDK-only and is never forwarded to the WebMCP host.
+   */
+  output?: OutputSchema;
   /** Raw JSON Schema for the host. Stays explicit; the SDK does not derive it from `input`. */
   inputSchema?: object;
   readOnly?: boolean;
@@ -108,20 +145,30 @@ export interface DefineToolOptions<
    */
   validate?: boolean;
   execute: (
-    input: Schema extends StandardSchemaV1
-      ? StandardSchemaV1.InferInput<Schema>
+    input: InputSchema extends StandardSchemaV1
+      ? StandardSchemaV1.InferInput<InputSchema>
       : unknown,
-  ) => Promise<TOutput> | TOutput;
+  ) =>
+    | Promise<
+        OutputSchema extends StandardSchemaV1
+          ? StandardSchemaV1.InferInput<OutputSchema>
+          : TOutput
+      >
+    | (OutputSchema extends StandardSchemaV1
+        ? StandardSchemaV1.InferInput<OutputSchema>
+        : TOutput);
 }
 
-const validateInput = async <Output>(
+const validateWithSchema = async <Output>(
   schema: StandardSchemaV1<unknown, Output>,
   value: unknown,
-  toolName: string,
+  onFailure: (
+    issues: ReadonlyArray<StandardSchemaV1.Issue>,
+  ) => ToolValidationError | ToolOutputValidationError,
 ): Promise<Output> => {
   const result = await schema["~standard"].validate(value);
   if ("issues" in result && result.issues) {
-    throw new ToolValidationError(toolName, result.issues);
+    throw onFailure(result.issues);
   }
   return (result as { value: Output }).value;
 };
@@ -130,46 +177,69 @@ const validateInput = async <Output>(
  * Build a `Tool` whose `execute` is typed against an optional Standard Schema
  * (Zod / Valibot / ArkType / etc.) without forcing the SDK to take a dep on
  * any specific library. Pass `validate: true` to also run the schema at
- * runtime; otherwise the schema is type-only and `execute` runs verbatim.
+ * runtime; otherwise the input schema is type-only. Supplying `output` always
+ * validates the resolved result and returns the schema's parsed output.
  *
  * The returned object is a plain `Tool` and can be passed to `registerTool`
  * or the React `useWebMCP` hook unchanged.
  */
 export const defineTool = <
-  Schema extends StandardSchemaV1 | undefined = undefined,
+  InputSchema extends StandardSchemaV1 | undefined = undefined,
   TOutput = unknown,
+  OutputSchema extends StandardSchemaV1 | undefined = undefined,
 >(
-  options: DefineToolOptions<Schema, TOutput>,
+  options: DefineToolOptions<InputSchema, TOutput, OutputSchema>,
 ): Tool<
-  Schema extends StandardSchemaV1
-    ? StandardSchemaV1.InferInput<Schema>
+  InputSchema extends StandardSchemaV1
+    ? StandardSchemaV1.InferInput<InputSchema>
     : unknown,
-  TOutput
+  OutputSchema extends StandardSchemaV1
+    ? StandardSchemaV1.InferOutput<OutputSchema>
+    : TOutput
 > => {
-  type Input = Schema extends StandardSchemaV1
-    ? StandardSchemaV1.InferInput<Schema>
+  type Input = InputSchema extends StandardSchemaV1
+    ? StandardSchemaV1.InferInput<InputSchema>
     : unknown;
+  type RawOutput = OutputSchema extends StandardSchemaV1
+    ? StandardSchemaV1.InferInput<OutputSchema>
+    : TOutput;
+  type Output = OutputSchema extends StandardSchemaV1
+    ? StandardSchemaV1.InferOutput<OutputSchema>
+    : TOutput;
 
   const baseExecute = options.execute as (
     input: Input,
-  ) => Promise<TOutput> | TOutput;
-  const execute: (input: Input) => Promise<TOutput> | TOutput =
-    options.validate && options.input
+  ) => Promise<RawOutput> | RawOutput;
+  const inputSchema = options.validate ? options.input : undefined;
+  const outputSchema = options.output;
+  const execute: (input: Input) => Promise<Output> | Output =
+    inputSchema || outputSchema
       ? async (input: Input) => {
-          const validated = (await validateInput(
-            options.input as StandardSchemaV1<unknown, Input>,
-            input,
-            options.name,
-          )) as Input;
-          return baseExecute(validated);
+          const executeInput = inputSchema
+            ? ((await validateWithSchema(
+                inputSchema as StandardSchemaV1<unknown, Input>,
+                input,
+                (issues) => new ToolValidationError(options.name, issues),
+              )) as Input)
+            : input;
+          const result = await baseExecute(executeInput);
+          if (outputSchema) {
+            return validateWithSchema(
+              outputSchema as StandardSchemaV1<unknown, Output>,
+              result,
+              (issues) => new ToolOutputValidationError(options.name, issues),
+            );
+          }
+          return result as Output;
         }
-      : baseExecute;
+      : (baseExecute as (input: Input) => Promise<Output> | Output);
 
-  const tool: Tool<Input, TOutput> = {
+  const tool: Tool<Input, Output> = {
     name: options.name,
     description: options.description,
     execute,
   };
+  if (options.title !== undefined) tool.title = options.title;
   if (options.inputSchema !== undefined) tool.inputSchema = options.inputSchema;
   if (options.readOnly) tool.readOnly = true;
   if (options.destructive) tool.destructive = true;
@@ -179,20 +249,30 @@ export const defineTool = <
 
 interface RegisteredTool {
   name: string;
+  title?: string;
   description: string;
   inputSchema?: object;
   annotations?: ToolAnnotations;
   execute: (input: unknown) => Promise<unknown> | unknown;
 }
 
-interface RegisterToolOptions {
+/** Options forwarded to the native WebMCP registration. */
+export interface RegisterToolOptions {
+  /**
+   * Origins of descendant documents that may discover this tool. The browser
+   * validates these values; the SDK forwards the array unchanged.
+   */
+  exposedTo?: readonly string[];
+}
+
+interface NativeRegisterToolOptions extends RegisterToolOptions {
   signal?: AbortSignal;
 }
 
 interface ModelContext {
   registerTool: (
     def: RegisteredTool,
-    options?: RegisterToolOptions,
+    options?: NativeRegisterToolOptions,
   ) => Promise<void> | void;
 }
 
@@ -230,6 +310,7 @@ const toRegistered = (tool: Tool): RegisteredTool => {
     description: tool.description,
     execute: tool.execute as RegisteredTool["execute"],
   };
+  if (tool.title !== undefined) registered.title = tool.title;
   if (tool.inputSchema !== undefined) registered.inputSchema = tool.inputSchema;
   if (Object.keys(annotations).length > 0) registered.annotations = annotations;
   return registered;
@@ -270,11 +351,17 @@ const callRegister = (
   mc: ModelContext,
   registered: RegisteredTool,
   controller: AbortController,
+  options?: RegisterToolOptions,
 ): Promise<void> => {
+  const nativeOptions: NativeRegisterToolOptions = {
+    signal: controller.signal,
+  };
+  if (options?.exposedTo !== undefined) {
+    nativeOptions.exposedTo = options.exposedTo;
+  }
+
   try {
-    return Promise.resolve(
-      mc.registerTool(registered, { signal: controller.signal }),
-    );
+    return Promise.resolve(mc.registerTool(registered, nativeOptions));
   } catch (err) {
     return Promise.reject(err);
   }
@@ -300,6 +387,7 @@ const registerOne = async (
   mc: ModelContext,
   registered: RegisteredTool,
   controller: AbortController,
+  options?: RegisterToolOptions,
 ): Promise<boolean> => {
   // If we still hold a live controller for this name, evict it before the
   // native register call so Chrome doesn't reject with InvalidStateError.
@@ -309,7 +397,7 @@ const registerOne = async (
   }
 
   try {
-    await callRegister(mc, registered, controller);
+    await callRegister(mc, registered, controller, options);
   } catch (err) {
     // If our own controller was aborted (a later caller evicted us, or our
     // cleanup fired, while registration was still pending), treat it as a
@@ -333,7 +421,7 @@ const registerOne = async (
     await Promise.resolve();
     if (controller.signal.aborted) return false;
     try {
-      await callRegister(mc, registered, controller);
+      await callRegister(mc, registered, controller, options);
     } catch (retryErr) {
       if (controller.signal.aborted) return false;
       if (isDuplicateNameError(retryErr)) {
@@ -357,6 +445,17 @@ const registerOne = async (
   return true;
 };
 
+/** Register a tool with optional native registration options. */
+export function registerTool<TInput, TOutput>(
+  tool: Tool<TInput, TOutput>,
+  options?: RegisterToolOptions,
+): () => void;
+/** Preserve the documented `tools.map(registerTool)` callback shape. */
+export function registerTool<TInput, TOutput>(
+  tool: Tool<TInput, TOutput>,
+  index: number,
+  tools: readonly Tool<TInput, TOutput>[],
+): () => void;
 /**
  * Register a single tool. Returns a cleanup function that unregisters it.
  *
@@ -366,9 +465,13 @@ const registerOne = async (
  *
  * If WebMCP is unavailable, the call is a no-op and the cleanup is a no-op.
  */
-export const registerTool = <TInput, TOutput>(
+export function registerTool<TInput, TOutput>(
   tool: Tool<TInput, TOutput>,
-): (() => void) => {
+  optionsOrIndex?: RegisterToolOptions | number,
+  _tools?: readonly Tool<TInput, TOutput>[],
+): () => void {
+  const options =
+    typeof optionsOrIndex === "number" ? undefined : optionsOrIndex;
   const mc = getModelContext();
   if (!mc) return () => {};
 
@@ -378,7 +481,7 @@ export const registerTool = <TInput, TOutput>(
   // so there is no unhandled-rejection risk. The sync cleanup below aborts the
   // controller; if registration is still pending, the abort propagates to the
   // host and registerOne treats it as a clean cancellation.
-  void registerOne(mc, registered, controller);
+  void registerOne(mc, registered, controller, options);
 
   let disposed = false;
   return () => {
@@ -386,4 +489,4 @@ export const registerTool = <TInput, TOutput>(
     disposed = true;
     controller.abort();
   };
-};
+}

--- a/packages/webmcp/src/react/index.test.tsx
+++ b/packages/webmcp/src/react/index.test.tsx
@@ -130,6 +130,33 @@ describe("useWebMCP", () => {
     unmount();
   });
 
+  it("does not inspect registration metadata while disabled", () => {
+    const { registerTool } = installFakeModelContext();
+    const toJSON = vi.fn(() => ({ type: "object" }));
+
+    const { rerender, unmount } = renderHook(
+      ({ enabled }: { enabled: boolean }) =>
+        useWebMCP(
+          {
+            name: "disabled-metadata",
+            description: "Stay inert while disabled",
+            inputSchema: { toJSON },
+            execute: async () => ({}),
+          },
+          { enabled },
+        ),
+      { initialProps: { enabled: false } },
+    );
+
+    expect(toJSON).not.toHaveBeenCalled();
+    expect(registerTool).not.toHaveBeenCalled();
+
+    rerender({ enabled: true });
+    expect(toJSON).toHaveBeenCalledOnce();
+    expect(registerTool).toHaveBeenCalledOnce();
+    unmount();
+  });
+
   it("forwards exposedTo and re-registers when it changes", () => {
     const { registered, registerTool } = installFakeModelContext();
     const tool: Tool = {

--- a/packages/webmcp/src/react/index.test.tsx
+++ b/packages/webmcp/src/react/index.test.tsx
@@ -1,5 +1,5 @@
 import { renderHook } from "@testing-library/react";
-import { type ReactNode, StrictMode } from "react";
+import { type ReactNode, StrictMode, useLayoutEffect } from "react";
 import { afterEach, describe, expect, expectTypeOf, it, vi } from "vitest";
 import type { Tool } from "../index.js";
 import {
@@ -179,6 +179,33 @@ describe("useWebMCP", () => {
     unmount();
   });
 
+  it("compares circular metadata without crashing during render", () => {
+    const { registerTool } = installFakeModelContext();
+    const createCircularSchema = (type: string) => {
+      const schema: { self?: object; type: string } = { type };
+      schema.self = schema;
+      return schema;
+    };
+
+    const { rerender, unmount } = renderHook(
+      ({ inputSchema }: { inputSchema: object }) =>
+        useWebMCP({
+          name: "circular-schema",
+          description: "Handle non-serializable metadata",
+          inputSchema,
+          execute: async () => ({}),
+        }),
+      { initialProps: { inputSchema: createCircularSchema("object") } },
+    );
+
+    rerender({ inputSchema: createCircularSchema("object") });
+    expect(registerTool).toHaveBeenCalledTimes(1);
+
+    rerender({ inputSchema: createCircularSchema("array") });
+    expect(registerTool).toHaveBeenCalledTimes(2);
+    unmount();
+  });
+
   it("uses the latest execute callback without re-registering", () => {
     const { registered, registerTool } = installFakeModelContext();
 
@@ -202,6 +229,32 @@ describe("useWebMCP", () => {
 
     expect(registerTool).toHaveBeenCalledTimes(1);
     expect(registeredTool?.execute(undefined)).toBe(2);
+    unmount();
+  });
+
+  it("updates execute callbacks before consumer layout effects run", () => {
+    const { registered, registerTool } = installFakeModelContext();
+    const observed: number[] = [];
+
+    const { rerender, unmount } = renderHook(
+      ({ value }: { value: number }) => {
+        useWebMCP({
+          name: "commit-state",
+          description: "Read state from the latest commit",
+          execute: () => value,
+        });
+        useLayoutEffect(() => {
+          const result = registered.get("commit-state")?.execute(undefined);
+          if (typeof result === "number") observed.push(result);
+        });
+      },
+      { initialProps: { value: 1 } },
+    );
+
+    rerender({ value: 2 });
+
+    expect(registerTool).toHaveBeenCalledTimes(1);
+    expect(observed.at(-1)).toBe(2);
     unmount();
   });
 

--- a/packages/webmcp/src/react/index.test.tsx
+++ b/packages/webmcp/src/react/index.test.tsx
@@ -1,10 +1,16 @@
 import { renderHook } from "@testing-library/react";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { type ReactNode, StrictMode } from "react";
+import { afterEach, describe, expect, expectTypeOf, it, vi } from "vitest";
 import type { Tool } from "../index.js";
-import { useWebMCP } from "./index.js";
+import {
+  type RegisterToolOptions,
+  type UseWebMCPOptions,
+  useWebMCP,
+} from "./index.js";
 
 interface RegisteredCall {
   name: string;
+  title?: string;
   description: string;
   inputSchema?: object;
   annotations?: Record<string, boolean>;
@@ -24,7 +30,10 @@ const setModelContext = (host: Host, value: unknown) => {
 const installFakeModelContext = (host: Host = "navigator") => {
   const registered = new Map<string, RegisteredCall>();
   const registerTool = vi.fn(
-    (def: RegisteredCall, options?: { signal?: AbortSignal }) => {
+    (
+      def: RegisteredCall,
+      options?: { signal?: AbortSignal; exposedTo?: readonly string[] },
+    ) => {
       if (registered.has(def.name)) {
         throw new Error(
           "Failed to execute 'registerTool' on 'ModelContext': Duplicate tool name",
@@ -39,7 +48,7 @@ const installFakeModelContext = (host: Host = "navigator") => {
 
   setModelContext(host, { registerTool });
 
-  return { registered };
+  return { registered, registerTool };
 };
 
 afterEach(() => {
@@ -48,6 +57,20 @@ afterEach(() => {
 });
 
 describe("useWebMCP", () => {
+  it("registers a single tool", () => {
+    const { registered } = installFakeModelContext();
+    const tool: Tool = {
+      name: "single",
+      description: "One tool",
+      execute: async () => ({}),
+    };
+
+    const { unmount } = renderHook(() => useWebMCP(tool));
+    expect(registered.has("single")).toBe(true);
+    unmount();
+    expect(registered.has("single")).toBe(false);
+  });
+
   it("registers tools on mount and unregisters them on unmount", () => {
     const { registered } = installFakeModelContext();
     const tools: Tool[] = [
@@ -64,8 +87,8 @@ describe("useWebMCP", () => {
     expect(registered.size).toBe(0);
   });
 
-  it("re-registers when the tools array reference changes", () => {
-    const { registered } = installFakeModelContext();
+  it("re-registers when discoverable tool metadata changes", () => {
+    const { registered, registerTool } = installFakeModelContext();
     const v1: Tool[] = [
       { name: "a", description: "v1", execute: async () => ({}) },
     ];
@@ -82,6 +105,169 @@ describe("useWebMCP", () => {
     rerender({ tools: v2 });
     expect(registered.has("a")).toBe(false);
     expect(registered.has("b")).toBe(true);
+    expect(registerTool).toHaveBeenCalledTimes(2);
+  });
+
+  it("skips registration while disabled and follows enabled transitions", () => {
+    const { registered } = installFakeModelContext();
+    const tool: Tool = {
+      name: "conditional",
+      description: "Only available while signed in",
+      execute: async () => ({}),
+    };
+
+    const { rerender, unmount } = renderHook(
+      ({ enabled }: { enabled: boolean }) => useWebMCP(tool, { enabled }),
+      { initialProps: { enabled: false } },
+    );
+    expect(registered.has("conditional")).toBe(false);
+
+    rerender({ enabled: true });
+    expect(registered.has("conditional")).toBe(true);
+
+    rerender({ enabled: false });
+    expect(registered.has("conditional")).toBe(false);
+    unmount();
+  });
+
+  it("forwards exposedTo and re-registers when it changes", () => {
+    const { registered, registerTool } = installFakeModelContext();
+    const tool: Tool = {
+      name: "shared",
+      description: "Shared with embedded agents",
+      execute: async () => ({}),
+    };
+    const first = ["https://one.example"] as const;
+    const second = ["https://two.example"] as const;
+
+    const { rerender, unmount } = renderHook(
+      ({ exposedTo }: { exposedTo: readonly string[] }) =>
+        useWebMCP(tool, { exposedTo }),
+      { initialProps: { exposedTo: first as readonly string[] } },
+    );
+    expect(registerTool.mock.calls[0]?.[1]?.exposedTo).toBe(first);
+
+    rerender({ exposedTo: second });
+    expect(registerTool).toHaveBeenCalledTimes(2);
+    expect(registerTool.mock.calls[1]?.[1]?.exposedTo).toBe(second);
+    expect(registered.has("shared")).toBe(true);
+    unmount();
+    expect(registered.has("shared")).toBe(false);
+  });
+
+  it("does not re-register when stable inputs are rerendered", () => {
+    const { registerTool } = installFakeModelContext();
+    const tool: Tool = {
+      name: "stable",
+      description: "Stable tool",
+      execute: async () => ({}),
+    };
+    const options: UseWebMCPOptions = {
+      exposedTo: ["https://agent.example"],
+    };
+
+    const { rerender, unmount } = renderHook(
+      ({ value }: { value: number }) => {
+        void value;
+        useWebMCP(tool, options);
+      },
+      { initialProps: { value: 1 } },
+    );
+    rerender({ value: 2 });
+
+    expect(registerTool).toHaveBeenCalledTimes(1);
+    unmount();
+  });
+
+  it("uses the latest execute callback without re-registering", () => {
+    const { registered, registerTool } = installFakeModelContext();
+
+    const { rerender, unmount } = renderHook(
+      ({ value }: { value: number }) =>
+        useWebMCP(
+          {
+            name: "live-state",
+            description: "Read the latest state",
+            annotations: { readOnlyHint: true },
+            execute: () => value,
+          },
+          { exposedTo: ["https://agent.example"] },
+        ),
+      { initialProps: { value: 1 } },
+    );
+    const registeredTool = registered.get("live-state");
+    expect(registeredTool?.execute(undefined)).toBe(1);
+
+    rerender({ value: 2 });
+
+    expect(registerTool).toHaveBeenCalledTimes(1);
+    expect(registeredTool?.execute(undefined)).toBe(2);
+    unmount();
+  });
+
+  it("keeps fresh callbacks matched to tools in recreated arrays", () => {
+    const { registered, registerTool } = installFakeModelContext();
+
+    const { rerender, unmount } = renderHook(
+      ({ first, second }: { first: string; second: string }) =>
+        useWebMCP([
+          {
+            name: "first",
+            description: "Read the first value",
+            execute: () => first,
+          },
+          {
+            name: "second",
+            description: "Read the second value",
+            execute: () => second,
+          },
+        ]),
+      { initialProps: { first: "a", second: "b" } },
+    );
+    const firstTool = registered.get("first");
+    const secondTool = registered.get("second");
+
+    rerender({ first: "c", second: "d" });
+
+    expect(registerTool).toHaveBeenCalledTimes(2);
+    expect(firstTool?.execute(undefined)).toBe("c");
+    expect(secondTool?.execute(undefined)).toBe("d");
+    unmount();
+  });
+
+  it("keeps one live registration in Strict Mode and cleans it up", () => {
+    const { registered } = installFakeModelContext();
+    const tool: Tool = {
+      name: "strict",
+      description: "Strict Mode tool",
+      execute: async () => ({}),
+    };
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <StrictMode>{children}</StrictMode>
+    );
+
+    const { unmount } = renderHook(() => useWebMCP(tool), { wrapper });
+    expect(registered.has("strict")).toBe(true);
+    unmount();
+    expect(registered.has("strict")).toBe(false);
+  });
+
+  it("re-exports the vanilla options and accepts both input shapes", () => {
+    const tool: Tool = {
+      name: "typed",
+      description: "Typed tool",
+      execute: () => ({}),
+    };
+    const registrationOptions: RegisterToolOptions = {
+      exposedTo: ["https://agent.example"],
+    };
+    const hookOptions: UseWebMCPOptions = {
+      ...registrationOptions,
+      enabled: true,
+    };
+
+    expectTypeOf(useWebMCP).toBeCallableWith(tool, hookOptions);
+    expectTypeOf(useWebMCP).toBeCallableWith([tool] as const, hookOptions);
   });
 
   it("works when modelContext is exposed on document instead of navigator", () => {

--- a/packages/webmcp/src/react/index.test.tsx
+++ b/packages/webmcp/src/react/index.test.tsx
@@ -206,6 +206,78 @@ describe("useWebMCP", () => {
     unmount();
   });
 
+  it("compares the effective annotations sent to the host", () => {
+    const { registerTool } = installFakeModelContext();
+
+    const { rerender, unmount } = renderHook(
+      ({ readOnly }: { readOnly: boolean }) =>
+        useWebMCP({
+          name: "annotation-override",
+          description: "Respect raw annotation overrides",
+          readOnly,
+          annotations: { readOnlyHint: false },
+          execute: async () => ({}),
+        }),
+      { initialProps: { readOnly: true } },
+    );
+
+    rerender({ readOnly: false });
+
+    expect(registerTool).toHaveBeenCalledTimes(1);
+    expect(registerTool.mock.calls[0]?.[0].annotations).toEqual({
+      readOnlyHint: false,
+    });
+    unmount();
+  });
+
+  it("re-registers when an effective shorthand annotation changes", () => {
+    const { registerTool } = installFakeModelContext();
+
+    const { rerender, unmount } = renderHook(
+      ({ readOnly }: { readOnly: boolean }) =>
+        useWebMCP({
+          name: "annotation-change",
+          description: "Track effective annotations",
+          readOnly,
+          execute: async () => ({}),
+        }),
+      { initialProps: { readOnly: true } },
+    );
+
+    rerender({ readOnly: false });
+
+    expect(registerTool).toHaveBeenCalledTimes(2);
+    unmount();
+  });
+
+  it("does not re-register equivalent metadata with reordered object keys", () => {
+    const { registerTool } = installFakeModelContext();
+    const firstSchema = {
+      type: "object",
+      properties: { query: { type: "string", minLength: 1 } },
+    };
+    const reorderedSchema = {
+      properties: { query: { minLength: 1, type: "string" } },
+      type: "object",
+    };
+
+    const { rerender, unmount } = renderHook(
+      ({ inputSchema }: { inputSchema: object }) =>
+        useWebMCP({
+          name: "equivalent-schema",
+          description: "Compare metadata by value",
+          inputSchema,
+          execute: async () => ({}),
+        }),
+      { initialProps: { inputSchema: firstSchema } },
+    );
+
+    rerender({ inputSchema: reorderedSchema });
+
+    expect(registerTool).toHaveBeenCalledTimes(1);
+    unmount();
+  });
+
   it("compares circular metadata without crashing during render", () => {
     const { registerTool } = installFakeModelContext();
     const createCircularSchema = (type: string) => {
@@ -312,6 +384,33 @@ describe("useWebMCP", () => {
     expect(registerTool).toHaveBeenCalledTimes(2);
     expect(firstTool?.execute(undefined)).toBe("c");
     expect(secondTool?.execute(undefined)).toBe("d");
+    unmount();
+  });
+
+  it("keeps callbacks paired with duplicate-name tool definitions", () => {
+    const { registerTool } = installFakeModelContext();
+
+    const { unmount } = renderHook(() =>
+      useWebMCP([
+        {
+          name: "duplicate",
+          description: "First definition",
+          execute: () => "first",
+        },
+        {
+          name: "duplicate",
+          description: "Second definition",
+          execute: () => "second",
+        },
+      ]),
+    );
+
+    const firstDefinition = registerTool.mock.calls[0]?.[0];
+    const secondDefinition = registerTool.mock.calls[1]?.[0];
+    expect(firstDefinition?.description).toBe("First definition");
+    expect(firstDefinition?.execute(undefined)).toBe("first");
+    expect(secondDefinition?.description).toBe("Second definition");
+    expect(secondDefinition?.execute(undefined)).toBe("second");
     unmount();
   });
 

--- a/packages/webmcp/src/react/index.ts
+++ b/packages/webmcp/src/react/index.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from "react";
+import { useEffect, useLayoutEffect, useRef } from "react";
 import { type RegisterToolOptions, registerTool, type Tool } from "../index.js";
 
 export interface UseWebMCPOptions extends RegisterToolOptions {
@@ -15,8 +15,8 @@ interface Registration {
 const getRegistrationKey = (
   tools: readonly Tool[],
   exposedTo: readonly string[] | undefined,
-): string =>
-  JSON.stringify({
+): string => {
+  const metadata = {
     tools: tools.map((tool) => ({
       name: tool.name,
       title: tool.title,
@@ -27,7 +27,36 @@ const getRegistrationKey = (
       annotations: tool.annotations,
     })),
     exposedTo,
-  }) ?? "";
+  };
+  const seen = new WeakSet<object>();
+  try {
+    return (
+      JSON.stringify(metadata, (_key, value: unknown) => {
+        if (typeof value === "bigint") return `bigint:${value.toString()}`;
+        if (typeof value !== "object" || value === null) return value;
+        if (seen.has(value)) return "[Circular]";
+        seen.add(value);
+        return value;
+      }) ?? ""
+    );
+  } catch {
+    return JSON.stringify({
+      tools: metadata.tools.map(
+        ({ name, title, description, readOnly, destructive }) => ({
+          name,
+          title,
+          description,
+          readOnly,
+          destructive,
+        }),
+      ),
+      exposedTo,
+    });
+  }
+};
+
+const useCommitEffect =
+  typeof window === "undefined" ? useEffect : useLayoutEffect;
 
 const createRegistration = (
   key: string,
@@ -73,7 +102,7 @@ export const useWebMCP = (
   const registrationRef = useRef<Registration | undefined>(undefined);
   const registrationKey = getRegistrationKey(tools, exposedTo);
 
-  useEffect(() => {
+  useCommitEffect(() => {
     latestExecutors.current = new Map(
       tools.map((tool) => [tool.name, tool.execute]),
     );

--- a/packages/webmcp/src/react/index.ts
+++ b/packages/webmcp/src/react/index.ts
@@ -1,5 +1,6 @@
 import { useEffect, useLayoutEffect, useRef } from "react";
-import { type RegisterToolOptions, registerTool, type Tool } from "../index.js";
+import { type RegisterToolOptions, registerTool } from "../index.js";
+import { type Tool, toRegisteredToolMetadata } from "../tool.js";
 
 export interface UseWebMCPOptions extends RegisterToolOptions {
   /** Whether the tools should currently be registered. Defaults to `true`. */
@@ -15,43 +16,52 @@ const getRegistrationKey = (
   tools: readonly Tool[],
   exposedTo: readonly string[] | undefined,
 ): string => {
-  const metadata = {
-    tools: tools.map((tool) => ({
-      name: tool.name,
-      title: tool.title,
-      description: tool.description,
-      inputSchema: tool.inputSchema,
-      readOnly: tool.readOnly,
-      destructive: tool.destructive,
-      annotations: tool.annotations,
-    })),
-    exposedTo,
-  };
-  const seen = new WeakSet<object>();
   try {
-    return (
-      JSON.stringify(metadata, (_key, value: unknown) => {
-        if (typeof value === "bigint") return `bigint:${value.toString()}`;
-        if (typeof value !== "object" || value === null) return value;
-        if (seen.has(value)) return "[Circular]";
-        seen.add(value);
-        return value;
-      }) ?? ""
-    );
+    return stableStringify({
+      tools: tools.map(toRegisteredToolMetadata),
+      exposedTo,
+    });
   } catch {
     return JSON.stringify({
-      tools: metadata.tools.map(
-        ({ name, title, description, readOnly, destructive }) => ({
-          name,
-          title,
-          description,
-          readOnly,
-          destructive,
-        }),
-      ),
+      tools: tools.map(({ name, title, description }) => ({
+        name,
+        title,
+        description,
+      })),
       exposedTo,
     });
   }
+};
+
+const stableStringify = (value: unknown): string => {
+  const ancestors = new WeakSet<object>();
+
+  const normalize = (current: unknown): unknown => {
+    if (typeof current === "bigint") return `bigint:${current.toString()}`;
+    if (typeof current !== "object" || current === null) return current;
+    if (ancestors.has(current)) return "[Circular]";
+
+    ancestors.add(current);
+    try {
+      const toJSON = Reflect.get(current, "toJSON");
+      if (typeof toJSON === "function") {
+        const jsonValue: unknown = Reflect.apply(toJSON, current, []);
+        if (jsonValue !== current) return normalize(jsonValue);
+      }
+
+      if (Array.isArray(current)) return current.map(normalize);
+
+      const normalized = Object.create(null) as Record<string, unknown>;
+      for (const key of Object.keys(current).sort()) {
+        normalized[key] = normalize(Reflect.get(current, key));
+      }
+      return normalized;
+    } finally {
+      ancestors.delete(current);
+    }
+  };
+
+  return JSON.stringify(normalize(value)) ?? "";
 };
 
 const useCommitEffect =
@@ -60,15 +70,15 @@ const useCommitEffect =
 const wrapTools = (
   tools: readonly Tool[],
   latestExecutors: {
-    readonly current: ReadonlyMap<string, Tool["execute"]>;
+    readonly current: readonly Tool["execute"][];
   },
 ): readonly Tool[] =>
-  tools.map((tool) => {
+  tools.map((tool, index) => {
     const initialExecute = tool.execute;
     return {
       ...tool,
       execute: (input: unknown) =>
-        (latestExecutors.current.get(tool.name) ?? initialExecute)(input),
+        (latestExecutors.current[index] ?? initialExecute)(input),
     };
   });
 
@@ -90,15 +100,13 @@ export const useWebMCP = (
   const tools: readonly Tool[] = Array.isArray(toolOrTools)
     ? toolOrTools
     : [toolOrTools];
-  const latestExecutors = useRef<ReadonlyMap<string, Tool["execute"]>>(
-    new Map(tools.map((tool) => [tool.name, tool.execute])),
+  const latestExecutors = useRef<readonly Tool["execute"][]>(
+    tools.map((tool) => tool.execute),
   );
   const activeRegistration = useRef<ActiveRegistration | undefined>(undefined);
 
   useCommitEffect(() => {
-    latestExecutors.current = new Map(
-      tools.map((tool) => [tool.name, tool.execute]),
-    );
+    latestExecutors.current = tools.map((tool) => tool.execute);
   });
 
   useEffect(() => {

--- a/packages/webmcp/src/react/index.ts
+++ b/packages/webmcp/src/react/index.ts
@@ -6,10 +6,9 @@ export interface UseWebMCPOptions extends RegisterToolOptions {
   enabled?: boolean;
 }
 
-interface Registration {
+interface ActiveRegistration {
   key: string;
-  exposedTo: readonly string[] | undefined;
-  tools: readonly Tool[];
+  cleanup: () => void;
 }
 
 const getRegistrationKey = (
@@ -58,25 +57,20 @@ const getRegistrationKey = (
 const useCommitEffect =
   typeof window === "undefined" ? useEffect : useLayoutEffect;
 
-const createRegistration = (
-  key: string,
+const wrapTools = (
   tools: readonly Tool[],
-  exposedTo: readonly string[] | undefined,
   latestExecutors: {
     readonly current: ReadonlyMap<string, Tool["execute"]>;
   },
-): Registration => ({
-  key,
-  exposedTo,
-  tools: tools.map((tool) => {
+): readonly Tool[] =>
+  tools.map((tool) => {
     const initialExecute = tool.execute;
     return {
       ...tool,
       execute: (input: unknown) =>
         (latestExecutors.current.get(tool.name) ?? initialExecute)(input),
     };
-  }),
-});
+  });
 
 /**
  * React hook that registers one or more WebMCP tools on mount and unregisters
@@ -99,8 +93,7 @@ export const useWebMCP = (
   const latestExecutors = useRef<ReadonlyMap<string, Tool["execute"]>>(
     new Map(tools.map((tool) => [tool.name, tool.execute])),
   );
-  const registrationRef = useRef<Registration | undefined>(undefined);
-  const registrationKey = getRegistrationKey(tools, exposedTo);
+  const activeRegistration = useRef<ActiveRegistration | undefined>(undefined);
 
   useCommitEffect(() => {
     latestExecutors.current = new Map(
@@ -108,27 +101,38 @@ export const useWebMCP = (
     );
   });
 
-  const previous = registrationRef.current;
-  const registration =
-    previous?.key === registrationKey
-      ? previous
-      : createRegistration(registrationKey, tools, exposedTo, latestExecutors);
-  registrationRef.current = registration;
-
   useEffect(() => {
-    if (!enabled) return;
+    if (!enabled) {
+      activeRegistration.current?.cleanup();
+      activeRegistration.current = undefined;
+      return;
+    }
+
+    const registrationKey = getRegistrationKey(tools, exposedTo);
+    if (activeRegistration.current?.key === registrationKey) return;
+
+    activeRegistration.current?.cleanup();
 
     const registerOptions: RegisterToolOptions | undefined =
-      registration.exposedTo === undefined
-        ? undefined
-        : { exposedTo: registration.exposedTo };
-    const cleanups = registration.tools.map((tool) =>
+      exposedTo === undefined ? undefined : { exposedTo };
+    const cleanups = wrapTools(tools, latestExecutors).map((tool) =>
       registerTool(tool, registerOptions),
     );
-    return () => {
-      for (const cleanup of cleanups) cleanup();
+    activeRegistration.current = {
+      key: registrationKey,
+      cleanup: () => {
+        for (const cleanup of cleanups) cleanup();
+      },
     };
-  }, [enabled, registration]);
+  });
+
+  useEffect(
+    () => () => {
+      activeRegistration.current?.cleanup();
+      activeRegistration.current = undefined;
+    },
+    [],
+  );
 };
 
 export type {

--- a/packages/webmcp/src/react/index.ts
+++ b/packages/webmcp/src/react/index.ts
@@ -1,27 +1,116 @@
-import { useEffect } from "react";
-import { registerTool, type Tool } from "../index.js";
+import { useEffect, useRef } from "react";
+import { type RegisterToolOptions, registerTool, type Tool } from "../index.js";
+
+export interface UseWebMCPOptions extends RegisterToolOptions {
+  /** Whether the tools should currently be registered. Defaults to `true`. */
+  enabled?: boolean;
+}
+
+interface Registration {
+  key: string;
+  exposedTo: readonly string[] | undefined;
+  tools: readonly Tool[];
+}
+
+const getRegistrationKey = (
+  tools: readonly Tool[],
+  exposedTo: readonly string[] | undefined,
+): string =>
+  JSON.stringify({
+    tools: tools.map((tool) => ({
+      name: tool.name,
+      title: tool.title,
+      description: tool.description,
+      inputSchema: tool.inputSchema,
+      readOnly: tool.readOnly,
+      destructive: tool.destructive,
+      annotations: tool.annotations,
+    })),
+    exposedTo,
+  }) ?? "";
+
+const createRegistration = (
+  key: string,
+  tools: readonly Tool[],
+  exposedTo: readonly string[] | undefined,
+  latestExecutors: {
+    readonly current: ReadonlyMap<string, Tool["execute"]>;
+  },
+): Registration => ({
+  key,
+  exposedTo,
+  tools: tools.map((tool) => {
+    const initialExecute = tool.execute;
+    return {
+      ...tool,
+      execute: (input: unknown) =>
+        (latestExecutors.current.get(tool.name) ?? initialExecute)(input),
+    };
+  }),
+});
 
 /**
- * React hook that registers WebMCP tools on mount and unregisters them on
- * unmount. Pass a stable `tools` reference (e.g. via `useMemo`); the effect
- * re-runs whenever the array reference changes.
+ * React hook that registers one or more WebMCP tools on mount and unregisters
+ * them on unmount. Registration changes only when discoverable metadata,
+ * `enabled`, or `exposedTo` values change; execute callbacks always use the
+ * latest committed render.
  *
  * On browsers that don't expose `document.modelContext` (or the legacy
  * `navigator.modelContext`), the hook is a no-op.
  */
-export const useWebMCP = (tools: readonly Tool[]): void => {
+export const useWebMCP = (
+  toolOrTools: Tool | readonly Tool[],
+  options?: UseWebMCPOptions,
+): void => {
+  const enabled = options?.enabled ?? true;
+  const exposedTo = options?.exposedTo;
+  const tools: readonly Tool[] = Array.isArray(toolOrTools)
+    ? toolOrTools
+    : [toolOrTools];
+  const latestExecutors = useRef<ReadonlyMap<string, Tool["execute"]>>(
+    new Map(tools.map((tool) => [tool.name, tool.execute])),
+  );
+  const registrationRef = useRef<Registration | undefined>(undefined);
+  const registrationKey = getRegistrationKey(tools, exposedTo);
+
   useEffect(() => {
-    const cleanups = tools.map(registerTool);
+    latestExecutors.current = new Map(
+      tools.map((tool) => [tool.name, tool.execute]),
+    );
+  });
+
+  const previous = registrationRef.current;
+  const registration =
+    previous?.key === registrationKey
+      ? previous
+      : createRegistration(registrationKey, tools, exposedTo, latestExecutors);
+  registrationRef.current = registration;
+
+  useEffect(() => {
+    if (!enabled) return;
+
+    const registerOptions: RegisterToolOptions | undefined =
+      registration.exposedTo === undefined
+        ? undefined
+        : { exposedTo: registration.exposedTo };
+    const cleanups = registration.tools.map((tool) =>
+      registerTool(tool, registerOptions),
+    );
     return () => {
       for (const cleanup of cleanups) cleanup();
     };
-  }, [tools]);
+  }, [enabled, registration]);
 };
 
 export type {
   DefineToolOptions,
+  RegisterToolOptions,
   StandardSchemaV1,
   Tool,
   ToolAnnotations,
 } from "../index.js";
-export { defineTool, ToolValidationError } from "../index.js";
+export {
+  defineTool,
+  ToolOutputValidationError,
+  ToolValidationError,
+} from "../index.js";

--- a/packages/webmcp/src/tool.ts
+++ b/packages/webmcp/src/tool.ts
@@ -1,0 +1,55 @@
+export interface ToolAnnotations {
+  /** Defined by the current WebMCP draft. */
+  readOnlyHint?: boolean;
+  /** Marks external or user-generated tool output as untrusted. */
+  untrustedContentHint?: boolean;
+  /** Compatibility passthrough for MCP-shaped and earlier WebMCP hosts. */
+  destructiveHint?: boolean;
+  /** Compatibility passthrough for MCP-shaped and earlier WebMCP hosts. */
+  idempotentHint?: boolean;
+  /** Compatibility passthrough for MCP-shaped and earlier WebMCP hosts. */
+  openWorldHint?: boolean;
+}
+
+export interface Tool<TInput = unknown, TOutput = unknown> {
+  name: string;
+  /** Optional human-readable title for display in host user interfaces. */
+  title?: string;
+  description: string;
+  inputSchema?: object;
+  /** Shorthand for `annotations.readOnlyHint = true`. */
+  readOnly?: boolean;
+  /** Compatibility shorthand for `annotations.destructiveHint = true`. */
+  destructive?: boolean;
+  /** Raw passthrough; merged on top of the shorthand flags. */
+  annotations?: ToolAnnotations;
+  execute: (input: TInput) => Promise<TOutput> | TOutput;
+}
+
+export interface RegisteredToolMetadata {
+  name: string;
+  title?: string;
+  description: string;
+  inputSchema?: object;
+  annotations?: ToolAnnotations;
+}
+
+/** Build the discoverable metadata exactly as it is sent to the WebMCP host. */
+export const toRegisteredToolMetadata = (
+  tool: Tool,
+): RegisteredToolMetadata => {
+  const annotations: ToolAnnotations = {
+    ...(tool.readOnly ? { readOnlyHint: true } : {}),
+    ...(tool.destructive ? { destructiveHint: true } : {}),
+    ...tool.annotations,
+  };
+
+  const metadata: RegisteredToolMetadata = {
+    name: tool.name,
+    description: tool.description,
+  };
+  if (tool.title !== undefined) metadata.title = tool.title;
+  if (tool.inputSchema !== undefined) metadata.inputSchema = tool.inputSchema;
+  if (Object.keys(annotations).length > 0) metadata.annotations = annotations;
+  return metadata;
+};


### PR DESCRIPTION
## Summary

- align WebMCP tool metadata and registration with the current public draft through `title`, `untrustedContentHint`, and `exposedTo`
- support single or multiple React tools, conditional registration, and current `execute` callbacks without registration churn
- add SDK-only Standard Schema output validation, transformations, inferred parsed results, and typed failures
- preserve existing cleanup, duplicate-name, async registration, annotation compatibility, and `tools.map(registerTool)` behavior
- update package/site documentation, tests, and changesets for one WebMCP minor release

## Why

Issues #157 and #159 address complementary result contracts. An untrusted-content annotation communicates a trust boundary to the host, while Standard Schema validates the resolved result's shape and may transform it. Neither mechanism claims that output is fresh, true, or safe.


## Developer impact

Existing vanilla and React calls remain source-compatible. New metadata, registration options, output schemas, and conditional React registration are additive. The hook signature still returns `void`; lifecycle cleanup remains automatic.

## Validation

- `pnpm gate`
- WebMCP: 53 tests passing
- emitted ESM, CJS, and declaration builds audited

Closes #157
Closes #159
