### PR TITLE
fix(playground): strip trailing punctuation from eager-fetch URLs

### DIFF
--- a/apps/site/src/features/playground/experimental/agent/loop.test.ts
+++ b/apps/site/src/features/playground/experimental/agent/loop.test.ts
@@ -88,6 +88,51 @@ describe("createAgentLoop", () => {
     });
   });
 
+  it("dispatches a direct URL without trailing prose punctuation", async () => {
+    const fixture = createSessionFixture(["Fetch-only answer."]);
+    createSessionMock.mockReturnValue(fixture.base);
+    const calls: string[] = [];
+    const fetchedUrls: string[] = [];
+    const agent = createAgentLoop({
+      tools: [
+        createFetchFixtureTool(calls, fetchedUrls),
+        createClockFixtureTool(calls),
+      ],
+    });
+
+    await agent.run(
+      "Fetch https://github.com/obetomuniz/web-ai-sdk/issues/160, then summarize it.",
+    );
+    agent.destroy();
+
+    expect(fetchedUrls).toEqual([
+      "https://github.com/obetomuniz/web-ai-sdk/issues/160",
+    ]);
+  });
+
+  it("dispatches canonical URLs for punctuated multi-URL prompts", async () => {
+    const fixture = createSessionFixture(["Fetch-only answer."]);
+    createSessionMock.mockReturnValue(fixture.base);
+    const calls: string[] = [];
+    const fetchedUrls: string[] = [];
+    const agent = createAgentLoop({
+      tools: [
+        createFetchFixtureTool(calls, fetchedUrls),
+        createClockFixtureTool(calls),
+      ],
+    });
+
+    await agent.run(
+      "Compare https://one.test/items/1; with https://two.test/wiki/Function_(mathematics).",
+    );
+    agent.destroy();
+
+    expect(fetchedUrls).toEqual([
+      "https://one.test/items/1",
+      "https://two.test/wiki/Function_(mathematics)",
+    ]);
+  });
+
   it("reports explicitly requested tool work that remains uncalled", async () => {
     const fixture = createSessionFixture([
       "The URLs are done.",
@@ -157,6 +202,7 @@ describe("createAgentLoop", () => {
 
 function createFetchFixtureTool(
   calls: string[],
+  fetchedUrls?: string[],
 ): AgentTool<{ url: string }, { status: number; url: string; text: string }> {
   return {
     name: "fetch_url",
@@ -168,6 +214,7 @@ function createFetchFixtureTool(
     },
     async execute({ url }) {
       calls.push("fetch_url");
+      fetchedUrls?.push(url);
       return { status: 200, url, text: `Content from ${url}` };
     },
   };

--- a/apps/site/src/features/playground/experimental/agent/urls.test.ts
+++ b/apps/site/src/features/playground/experimental/agent/urls.test.ts
@@ -1,9 +1,55 @@
 import { describe, expect, it } from "vitest";
 import {
+  extractUrls,
   isContextuallyGroundedUrl,
   normUrl,
   resolveContextualUrls,
 } from "./urls.js";
+
+describe("extractUrls", () => {
+  it("strips prose punctuation and unmatched closing parentheses", () => {
+    expect(
+      extractUrls(
+        "Fetch https://example.test/one, https://example.test/two.; and (https://example.test/three).",
+      ),
+    ).toEqual([
+      "https://example.test/one",
+      "https://example.test/two",
+      "https://example.test/three",
+    ]);
+  });
+
+  it("preserves URL punctuation, balanced parentheses, and percent encoding", () => {
+    expect(
+      extractUrls(
+        "Compare https://example.test/a;b,c?items=1,2#part;two with https://example.test/wiki/Function_(mathematics). Keep https://example.test/encoded%29.",
+      ),
+    ).toEqual([
+      "https://example.test/a;b,c?items=1,2#part;two",
+      "https://example.test/wiki/Function_(mathematics)",
+      "https://example.test/encoded%29",
+    ]);
+  });
+
+  it("deduplicates canonical URLs", () => {
+    expect(
+      extractUrls(
+        "Fetch https://example.test/item, then https://example.test/item.",
+      ),
+    ).toEqual(["https://example.test/item"]);
+  });
+});
+
+describe("normUrl", () => {
+  it("uses the same punctuation rules as direct URL extraction", () => {
+    expect(normUrl("https://example.test/wiki/Function_(mathematics).")).toBe(
+      "https://example.test/wiki/Function_(mathematics)",
+    );
+    expect(normUrl("https://example.test/item);")).toBe(
+      "https://example.test/item",
+    );
+  });
+});
 
 describe("resolveContextualUrls", () => {
   it("uses a direct URL without applying conversational inference", () => {

--- a/apps/site/src/features/playground/experimental/agent/urls.ts
+++ b/apps/site/src/features/playground/experimental/agent/urls.ts
@@ -1,7 +1,49 @@
 /** Extract HTTP(S) URLs from free-text input. Conservative on purpose. */
 export function extractUrls(text: string): string[] {
   const matches = text.match(/https?:\/\/[^\s<>'"`]+/g);
-  return matches ? Array.from(new Set(matches)) : [];
+  return matches
+    ? Array.from(new Set(matches.map(stripTrailingProsePunctuation)))
+    : [];
+}
+
+/**
+ * Remove delimiters captured from surrounding prose without damaging URL
+ * punctuation. A closing parenthesis is part of the URL when it balances an
+ * opening parenthesis, as in many wiki paths; otherwise it belongs to prose.
+ * Percent-encoded delimiters are untouched because they do not end in the raw
+ * punctuation character.
+ */
+function stripTrailingProsePunctuation(value: string): string {
+  let result = value.trim();
+
+  while (result) {
+    const withoutDelimiters = result.replace(/[.,;]+$/, "");
+    if (withoutDelimiters !== result) {
+      result = withoutDelimiters;
+      continue;
+    }
+
+    if (
+      result.endsWith(")") &&
+      !hasUnmatchedOpeningParenthesis(result.slice(0, -1))
+    ) {
+      result = result.slice(0, -1);
+      continue;
+    }
+
+    return result;
+  }
+
+  return result;
+}
+
+function hasUnmatchedOpeningParenthesis(value: string): boolean {
+  let depth = 0;
+  for (const character of value) {
+    if (character === "(") depth++;
+    if (character === ")" && depth > 0) depth--;
+  }
+  return depth > 0;
 }
 
 /**
@@ -41,10 +83,7 @@ export function resolveContextualUrls(
 
 /** Normalize a URL for matching (trailing slash / trailing punctuation). */
 export function normUrl(u: string): string {
-  return u
-    .trim()
-    .replace(/[).,;]+$/, "")
-    .replace(/\/+$/, "");
+  return stripTrailingProsePunctuation(u).replace(/\/+$/, "");
 }
 
 export function userUrlSet(input: string): ReadonlySet<string> {


### PR DESCRIPTION
## Summary

- canonicalize direct URLs before eager `fetch_url` dispatch
- remove surrounding prose punctuation while preserving balanced parentheses and percent-encoded punctuation
- cover exact single- and multi-URL dispatch arguments with deterministic tests

## Root cause

`extractUrls()` returned raw regex matches, while `normUrl()` only cleaned URLs used for tracking. Eager fetching therefore dispatched punctuation that tracking had already removed.

## Impact

Punctuated URLs now fetch the intended resource instead of punctuation-suffixed paths that can return 404 responses.

## Validation

- `pnpm gate`
- Chrome DevTools MCP against the Astro production preview
- verified canonical single- and multi-URL tool inputs and network requests

Closes #169
