### PR TITLE
feat(site): improve browser tool metadata and validation

### DIFF
--- a/apps/site/src/features/docs/components/WebMCPDemo.tsx
+++ b/apps/site/src/features/docs/components/WebMCPDemo.tsx
@@ -1,19 +1,19 @@
-import { isAvailable, type Tool } from "@web-ai-sdk/webmcp";
+import { defineTool, isAvailable, type Tool } from "@web-ai-sdk/webmcp";
 import { useWebMCP } from "@web-ai-sdk/webmcp/react";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useEffect, useState } from "react";
+import * as v from "valibot";
 import { UnavailableHint } from "./UnavailableHint.js";
 
-interface ListedTool {
-  name: string;
-  description: string;
-  inputSchema: string;
-}
-
 interface ModelContextTesting {
-  listTools(): ListedTool[];
   // Native Chrome serializes the result to a JSON string before returning.
   executeTool(name: string, input?: string): Promise<string>;
 }
+
+const ListDemoItemsOutput = v.object({ items: v.array(v.string()) });
+const EchoMessageInput = v.object({
+  message: v.pipe(v.string(), v.minLength(1), v.maxLength(200)),
+});
+const EchoMessageOutput = v.object({ echoed: v.string() });
 
 const getTesting = (): ModelContextTesting | undefined => {
   if (typeof navigator === "undefined") return undefined;
@@ -26,44 +26,48 @@ export const WebMCPDemo = () => {
   const [available, setAvailable] = useState<boolean>(() => isAvailable());
   const [echoInput, setEchoInput] = useState("hello world");
 
-  // `useCallback` so the reference stays stable and the tools memo below
-  // doesn't have to re-run on every render.
-  const append = useCallback((line: string) => {
+  const append = (line: string) => {
     setLog((prev) => [...prev, `${new Date().toLocaleTimeString()} ${line}`]);
-  }, []);
+  };
 
-  const tools = useMemo<Tool[]>(
-    () => [
-      {
-        name: "list_demo_items",
-        description:
-          "List demo items. Use when the user asks for the demo catalog.",
-        readOnly: true,
-        execute: async () => {
-          append("list_demo_items invoked");
-          return { items: ["alpha", "beta", "gamma"] };
-        },
+  // The hook compares discoverable metadata while keeping execute callbacks
+  // current, so these definitions can read the latest render without a ref or
+  // callback memoization bridge.
+  const tools = [
+    defineTool({
+      name: "list_demo_items",
+      title: "List demo items",
+      description:
+        "List demo items. Use when the user asks for the demo catalog.",
+      readOnly: true,
+      output: ListDemoItemsOutput,
+      execute: async () => {
+        append("list_demo_items invoked");
+        return { items: ["alpha", "beta", "gamma"] };
       },
-      {
-        name: "echo_message",
-        description: "Echo a message back. Demonstrates input schema.",
-        readOnly: true,
-        inputSchema: {
-          type: "object",
-          properties: {
-            message: { type: "string", minLength: 1, maxLength: 200 },
-          },
-          required: ["message"],
+    }),
+    defineTool({
+      name: "echo_message",
+      title: "Echo a message",
+      description: "Echo a message back. Demonstrates input schema.",
+      readOnly: true,
+      input: EchoMessageInput,
+      validate: true,
+      output: EchoMessageOutput,
+      inputSchema: {
+        type: "object",
+        properties: {
+          message: { type: "string", minLength: 1, maxLength: 200 },
         },
-        execute: async (input) => {
-          const { message } = input as { message: string };
-          append(`echo_message called with "${message}"`);
-          return { echoed: message };
-        },
+        required: ["message"],
+        additionalProperties: false,
       },
-    ],
-    [append],
-  );
+      execute: async ({ message }) => {
+        append(`echo_message called with "${message}"`);
+        return { echoed: message };
+      },
+    }),
+  ] as unknown as Tool[];
 
   useWebMCP(tools);
 
@@ -72,7 +76,7 @@ export const WebMCPDemo = () => {
   // separate `listTools()` read. Avoids races between the registration effect
   // and a one-shot list read, and behaves identically whether this story
   // mounts inside the docs Canvas or as a standalone story.
-  const registered = useMemo(() => tools.map((t) => t.name), [tools]);
+  const registered = tools.map(({ name, title }) => ({ name, title }));
 
   useEffect(() => {
     setAvailable(isAvailable());
@@ -103,9 +107,9 @@ export const WebMCPDemo = () => {
   return (
     <div className="demo-card demo-card--narrow">
       <p className="demo-muted">
-        Two tools registered against <code>document.modelContext</code>:{" "}
-        <code>list_demo_items</code> (read-only) and <code>echo_message</code>{" "}
-        (with input schema).
+        Two titled, read-only tools registered against{" "}
+        <code>document.modelContext</code>. The echo tool validates its input,
+        and both tools validate their output.
       </p>
       <p className="demo-muted">
         WebMCP available: <strong>{available ? "yes" : "no"}</strong>
@@ -133,9 +137,9 @@ export const WebMCPDemo = () => {
           <em className="demo-muted">(none)</em>
         ) : (
           <ul style={{ margin: 0, paddingLeft: 20 }}>
-            {registered.map((name) => (
+            {registered.map(({ name, title }) => (
               <li key={name}>
-                <code>{name}</code>
+                {title}: <code>{name}</code>
               </li>
             ))}
           </ul>

--- a/apps/site/src/features/docs/components/WebMCPDemo.tsx
+++ b/apps/site/src/features/docs/components/WebMCPDemo.tsx
@@ -33,6 +33,8 @@ export const WebMCPDemo = () => {
   // The hook compares discoverable metadata while keeping execute callbacks
   // current, so these definitions can read the latest render without a ref or
   // callback memoization bridge.
+  // Each definition retains its own inferred input type; erase that variance
+  // only at the registration boundary until heterogeneous arrays are native.
   const tools = [
     defineTool({
       name: "list_demo_items",

--- a/apps/site/src/features/home/components/WebMCPDemo.tsx
+++ b/apps/site/src/features/home/components/WebMCPDemo.tsx
@@ -8,7 +8,7 @@ import {
   type Tool,
 } from "@web-ai-sdk/webmcp";
 import { useWebMCP } from "@web-ai-sdk/webmcp/react";
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import {
   btnSm,
   card,
@@ -44,6 +44,7 @@ import {
 interface ToolSpec {
   id: string;
   name: string;
+  title: string;
   desc: string;
   on: boolean;
   match: RegExp;
@@ -57,6 +58,7 @@ const TOOL_SPECS: readonly ToolSpec[] = [
   {
     id: "add_to_cart",
     name: "add_to_cart",
+    title: "Add to cart",
     desc: "Add a SKU to the user's cart",
     on: true,
     match: /\bcart\b|\badd\b|MX-\d+/i,
@@ -78,6 +80,7 @@ const TOOL_SPECS: readonly ToolSpec[] = [
   {
     id: "search_orders",
     name: "search_orders",
+    title: "Search orders",
     desc: "Search past orders by date or item",
     on: true,
     match: /\border|\btuesday|\bpurchase/i,
@@ -87,6 +90,7 @@ const TOOL_SPECS: readonly ToolSpec[] = [
   {
     id: "open_settings",
     name: "open_settings",
+    title: "Open settings",
     desc: "List the agent's registered tools and their state",
     on: false,
     match: /\bsetting|\bnotification|\bpreference|\btool|\bregister/i,
@@ -98,6 +102,7 @@ const TOOL_SPECS: readonly ToolSpec[] = [
   {
     id: "refund",
     name: "refund",
+    title: "Issue a refund",
     desc: "Issue a refund (requires confirmation)",
     on: false,
     match: /\brefund|\breturn\b/i,
@@ -147,26 +152,13 @@ export const WebMCPDemo = () => {
     setAvailable(isWebMcpAvailable());
   }, []);
 
-  // Keep a live ref to the latest toggle state. The open_settings execute
-  // closure below reads from this ref instead of a captured `enabledIds`
-  // value, because Chrome's WebMCP processes AbortSignal-driven
-  // unregistration asynchronously: a sync re-register fired by useWebMCP's
-  // effect cycle can hit a not-yet-propagated abort and the library's
-  // microtask retry can silently skip on a second duplicate-name error.
-  // When that happens, the OLD execute closure stays registered and would
-  // report stale enabled flags. The ref dodges the problem entirely:
-  // whichever closure Chrome ends up holding, it always reads the latest
-  // state at invocation time.
-  const enabledIdsRef = useRef(enabledIds);
-  enabledIdsRef.current = enabledIds;
-
-  // Build the live Tool[] from the toggle state. Stable per (enabledIds set)
-  // so the hook only re-registers when toggles change.
-  // `open_settings` gets a closure that reports the live registration state,
-  // turning it into a self-describing tool the agent can introspect.
+  // Build the live Tool[] from the toggle state. `useWebMCP` re-registers only
+  // when discoverable metadata changes and keeps execute callbacks current,
+  // so `open_settings` can read this render's state directly.
   const tools = useMemo<Tool[]>(() => {
     return TOOL_SPECS.filter((t) => enabledIds.has(t.id)).map((spec) => ({
       name: spec.name,
+      title: spec.title,
       description: spec.desc,
       ...(spec.inputSchema ? { inputSchema: spec.inputSchema } : {}),
       ...(spec.readOnly ? { readOnly: true } : {}),
@@ -178,12 +170,13 @@ export const WebMCPDemo = () => {
               // Only the actually-registered tools. A disabled tool is not
               // in the model context at all, so listing it here would be
               // inaccurate.
-              registered: TOOL_SPECS.filter((t) =>
-                enabledIdsRef.current.has(t.id),
-              ).map((t) => ({
-                name: t.name,
-                description: t.desc,
-              })),
+              registered: TOOL_SPECS.filter((t) => enabledIds.has(t.id)).map(
+                (t) => ({
+                  name: t.name,
+                  title: t.title,
+                  description: t.desc,
+                }),
+              ),
             })
           : spec.execute,
     }));

--- a/apps/site/src/features/playground/lib/useWebMCPTools.test.ts
+++ b/apps/site/src/features/playground/lib/useWebMCPTools.test.ts
@@ -1,5 +1,6 @@
 import type { Tool } from "@web-ai-sdk/webmcp";
 import { describe, expect, it, vi } from "vitest";
+import { MODES } from "../experimental/playground/presets.js";
 import type { AgentThread } from "./agentThreads.js";
 import {
   createPlaygroundWebMCPTools,
@@ -54,7 +55,7 @@ describe("createPlaygroundWebMCPTools", () => {
   ])("rejects %s while a response is running", async (name, input) => {
     const context = createContext({ busy: true });
     const result = await findTool(
-      createPlaygroundWebMCPTools({ current: context }),
+      createPlaygroundWebMCPTools(context),
       name,
     ).execute(input);
 
@@ -69,7 +70,7 @@ describe("createPlaygroundWebMCPTools", () => {
   it("reports whether a message was accepted", async () => {
     const context = createContext({ send: vi.fn(async () => false) });
     const result = await findTool(
-      createPlaygroundWebMCPTools({ current: context }),
+      createPlaygroundWebMCPTools(context),
       "send_message",
     ).execute({ text: "Hello" });
 
@@ -79,7 +80,7 @@ describe("createPlaygroundWebMCPTools", () => {
   it("validates WebMCP input before invoking application code", async () => {
     const context = createContext();
     const sendMessage = findTool(
-      createPlaygroundWebMCPTools({ current: context }),
+      createPlaygroundWebMCPTools(context),
       "send_message",
     );
 
@@ -87,5 +88,98 @@ describe("createPlaygroundWebMCPTools", () => {
       name: "ToolValidationError",
     });
     expect(context.send).not.toHaveBeenCalled();
+  });
+
+  it("executes every registered tool on its happy path", async () => {
+    const context = createContext();
+    const tools = createPlaygroundWebMCPTools(context);
+    const calls: Array<[string, Record<string, unknown>]> = [
+      ["list_modes", {}],
+      ["list_conversations", {}],
+      ["new_conversation", { modeId: "minimal" }],
+      ["switch_conversation", { id: conversation.id }],
+      ["delete_conversation", { id: conversation.id }],
+      ["set_mode", { modeId: "minimal" }],
+      ["send_message", { text: "Hello" }],
+    ];
+
+    for (const [name, input] of calls) {
+      await expect(findTool(tools, name).execute(input)).resolves.toBeDefined();
+    }
+
+    expect(tools).toHaveLength(7);
+    expect(context.ops.create).toHaveBeenCalledWith("minimal");
+    expect(context.ops.select).toHaveBeenCalledWith(conversation.id);
+    expect(context.ops.remove).toHaveBeenCalledWith(conversation.id);
+    expect(context.ops.setMode).toHaveBeenCalledWith(
+      conversation.id,
+      "minimal",
+    );
+    expect(context.send).toHaveBeenCalledWith("Hello");
+  });
+
+  it("publishes display titles and marks user-derived output as untrusted", () => {
+    const tools = createPlaygroundWebMCPTools(createContext());
+
+    expect(tools.every((tool) => Boolean(tool.title))).toBe(true);
+    expect(findTool(tools, "list_conversations").annotations).toMatchObject({
+      untrustedContentHint: true,
+    });
+    expect(findTool(tools, "list_modes").annotations).toBeUndefined();
+  });
+
+  it("publishes and validates the supported mode ids", async () => {
+    const context = createContext();
+    const setMode = findTool(createPlaygroundWebMCPTools(context), "set_mode");
+
+    expect(setMode.inputSchema).toMatchObject({
+      properties: {
+        modeId: { enum: MODES.map((mode) => mode.id) },
+      },
+    });
+    await expect(
+      setMode.execute({ modeId: "example_string" }),
+    ).rejects.toMatchObject({ name: "ToolValidationError" });
+    expect(context.ops.setMode).not.toHaveBeenCalled();
+  });
+
+  it("publishes and validates the current conversation ids", async () => {
+    const secondConversation = { ...conversation, id: "conversation-2" };
+    const context = createContext({
+      threads: [secondConversation, conversation],
+    });
+    const tools = createPlaygroundWebMCPTools(context);
+    const expectedIds = [conversation.id, secondConversation.id].sort();
+
+    for (const name of ["switch_conversation", "delete_conversation"]) {
+      expect(findTool(tools, name).inputSchema).toMatchObject({
+        properties: { id: { enum: expectedIds } },
+      });
+      await expect(
+        findTool(tools, name).execute({ id: "example_string" }),
+      ).rejects.toMatchObject({ name: "ToolValidationError" });
+    }
+    expect(context.ops.select).not.toHaveBeenCalled();
+    expect(context.ops.remove).not.toHaveBeenCalled();
+  });
+
+  it("validates WebMCP output before returning it to the host", async () => {
+    const context = createContext({
+      ops: {
+        ...createContext().ops,
+        create: vi.fn(
+          () => ({ id: 42, modeId: "minimal" }) as unknown as AgentThread,
+        ),
+      },
+    });
+    const newConversation = findTool(
+      createPlaygroundWebMCPTools(context),
+      "new_conversation",
+    );
+
+    await expect(newConversation.execute({})).rejects.toMatchObject({
+      name: "ToolOutputValidationError",
+      toolName: "new_conversation",
+    });
   });
 });

--- a/apps/site/src/features/playground/lib/useWebMCPTools.test.ts
+++ b/apps/site/src/features/playground/lib/useWebMCPTools.test.ts
@@ -143,6 +143,23 @@ describe("createPlaygroundWebMCPTools", () => {
     expect(context.ops.setMode).not.toHaveBeenCalled();
   });
 
+  it("publishes closed object schemas for every tool input", () => {
+    const tools = createPlaygroundWebMCPTools(createContext());
+
+    for (const name of [
+      "new_conversation",
+      "switch_conversation",
+      "delete_conversation",
+      "set_mode",
+      "send_message",
+    ]) {
+      expect(findTool(tools, name).inputSchema).toMatchObject({
+        type: "object",
+        additionalProperties: false,
+      });
+    }
+  });
+
   it("publishes and validates the current conversation ids", async () => {
     const secondConversation = { ...conversation, id: "conversation-2" };
     const context = createContext({

--- a/apps/site/src/features/playground/lib/useWebMCPTools.ts
+++ b/apps/site/src/features/playground/lib/useWebMCPTools.ts
@@ -4,7 +4,6 @@ import {
   type Tool,
 } from "@web-ai-sdk/webmcp";
 import { useWebMCP } from "@web-ai-sdk/webmcp/react";
-import { useMemo, useRef } from "react";
 import * as v from "valibot";
 import { MODES } from "../experimental/playground/presets.js";
 import { type AgentThread, findMode } from "./agentThreads.js";
@@ -21,24 +20,80 @@ export interface PlaygroundWebMCPContext {
   pushActivity: (event: Omit<ActivityEvent, "id" | "ts">) => void;
 }
 
-interface Current<T> {
-  current: T;
-}
-
-const ConversationIdInput = v.object({
-  id: v.pipe(v.string(), v.minLength(1)),
-});
-const NewConversationInput = v.object({ modeId: v.optional(v.string()) });
-const SetModeInput = v.object({ modeId: v.pipe(v.string(), v.minLength(1)) });
+const ModeIds = MODES.map((mode) => mode.id) as [string, ...string[]];
+const ModeIdInput = v.picklist(ModeIds);
+const NewConversationInput = v.object({ modeId: v.optional(ModeIdInput) });
+const SetModeInput = v.object({ modeId: ModeIdInput });
 const SendMessageInput = v.object({
   text: v.pipe(v.string(), v.minLength(1)),
 });
 
+const OperationErrorOutput = v.object({
+  ok: v.literal(false),
+  error: v.string(),
+});
+const OperationOkOutput = v.object({ ok: v.literal(true) });
+const ListModesOutput = v.object({
+  modes: v.array(
+    v.object({
+      id: v.string(),
+      name: v.string(),
+      description: v.string(),
+      toolCount: v.number(),
+    }),
+  ),
+});
+const ListConversationsOutput = v.object({
+  activeConversationId: v.string(),
+  conversations: v.array(
+    v.object({
+      id: v.string(),
+      name: v.string(),
+      modeId: v.string(),
+      modeName: v.string(),
+      turnCount: v.number(),
+      createdAt: v.number(),
+      updatedAt: v.number(),
+    }),
+  ),
+});
+const NewConversationOutput = v.union([
+  v.object({ id: v.string(), modeId: v.string() }),
+  OperationErrorOutput,
+]);
+const SwitchConversationOutput = v.union([
+  v.object({
+    ok: v.literal(true),
+    activeConversationId: v.string(),
+  }),
+  OperationErrorOutput,
+]);
+const SetModeOutput = v.union([
+  v.object({ ok: v.literal(true), modeId: v.string() }),
+  OperationErrorOutput,
+]);
+const OperationOutput = v.union([OperationOkOutput, OperationErrorOutput]);
+
 export function createPlaygroundWebMCPTools(
-  argsRef: Current<PlaygroundWebMCPContext>,
+  args: PlaygroundWebMCPContext,
 ): Tool[] {
+  const ConversationIds = Array.from(
+    new Set([args.activeThread.id, ...args.threads.map((thread) => thread.id)]),
+  ).sort() as [string, ...string[]];
+  const ConversationIdInput = v.object({ id: v.picklist(ConversationIds) });
+  const ConversationIdSchema = {
+    type: "object",
+    properties: {
+      id: {
+        type: "string",
+        description: "Conversation identifier returned by list_conversations.",
+        enum: ConversationIds,
+      },
+    },
+    required: ["id"],
+  };
   const report = (name: string, detail?: string) => {
-    argsRef.current.pushActivity({
+    args.pushActivity({
       kind: "tool_invoked",
       message: name,
       detail,
@@ -54,9 +109,11 @@ export function createPlaygroundWebMCPTools(
 
   const listModes = defineTool({
     name: "list_modes",
+    title: "List playground modes",
     description:
       "List the agent modes available in Playground. Each mode configures the system prompt, tools, examples, and renderers.",
     readOnly: true,
+    output: ListModesOutput,
     execute: async () => {
       report("list_modes");
       return {
@@ -72,12 +129,15 @@ export function createPlaygroundWebMCPTools(
 
   const listConversations = defineTool({
     name: "list_conversations",
+    title: "List conversations",
     description:
       "List persisted agent conversations, with mode ids and turn counts. Use this before switching, deleting, or sending.",
     readOnly: true,
+    annotations: { untrustedContentHint: true },
+    output: ListConversationsOutput,
     execute: async () => {
       report("list_conversations");
-      const { threads, activeThread } = argsRef.current;
+      const { threads, activeThread } = args;
       return {
         activeConversationId: activeThread.id,
         conversations: threads.map((thread) => ({
@@ -95,19 +155,27 @@ export function createPlaygroundWebMCPTools(
 
   const newConversation = defineTool({
     name: "new_conversation",
+    title: "New conversation",
     description:
       "Create and select a new agent conversation. Optionally pass a modeId from list_modes.",
     input: NewConversationInput,
     validate: true,
+    output: NewConversationOutput,
     inputSchema: {
       type: "object",
-      properties: { modeId: { type: "string" } },
+      properties: {
+        modeId: {
+          type: "string",
+          description: "Mode identifier returned by list_modes.",
+          enum: ModeIds,
+        },
+      },
     },
     execute: async ({ modeId }) => {
-      if (argsRef.current.busy) return rejectBusy("new_conversation");
+      if (args.busy) return rejectBusy("new_conversation");
       const target = modeId ? findMode(modeId).id : undefined;
-      const thread = argsRef.current.ops.create(target);
-      argsRef.current.newSession();
+      const thread = args.ops.create(target);
+      args.newSession();
       report("new_conversation", `-> ${thread.id}`);
       return { id: thread.id, modeId: thread.modeId };
     },
@@ -115,97 +183,103 @@ export function createPlaygroundWebMCPTools(
 
   const switchConversation = defineTool({
     name: "switch_conversation",
+    title: "Switch conversation",
     description: "Switch the active agent conversation by id.",
     input: ConversationIdInput,
     validate: true,
-    inputSchema: {
-      type: "object",
-      properties: { id: { type: "string", minLength: 1 } },
-      required: ["id"],
-    },
+    output: SwitchConversationOutput,
+    inputSchema: ConversationIdSchema,
     execute: async ({ id }) => {
-      if (argsRef.current.busy) return rejectBusy("switch_conversation");
-      const match = argsRef.current.threads.find((thread) => thread.id === id);
+      if (args.busy) return rejectBusy("switch_conversation");
+      const match = args.threads.find((thread) => thread.id === id);
       if (!match) {
         report("switch_conversation", `unknown id: ${id}`);
         throw new Error(`No conversation with id "${id}".`);
       }
-      argsRef.current.ops.select(id);
-      argsRef.current.newSession();
+      args.ops.select(id);
+      args.newSession();
       report("switch_conversation", `-> ${match.name}`);
-      return { ok: true, activeConversationId: id };
+      return { ok: true as const, activeConversationId: id };
     },
   });
 
   const deleteConversation = defineTool({
     name: "delete_conversation",
+    title: "Delete conversation",
     description:
       "Delete an agent conversation by id. Destructive: persisted turns cannot be recovered.",
     destructive: true,
     input: ConversationIdInput,
     validate: true,
-    inputSchema: {
-      type: "object",
-      properties: { id: { type: "string", minLength: 1 } },
-      required: ["id"],
-    },
+    output: OperationOutput,
+    inputSchema: ConversationIdSchema,
     execute: async ({ id }) => {
-      if (argsRef.current.busy) return rejectBusy("delete_conversation");
-      const match = argsRef.current.threads.find((thread) => thread.id === id);
+      if (args.busy) return rejectBusy("delete_conversation");
+      const match = args.threads.find((thread) => thread.id === id);
       if (!match) {
         report("delete_conversation", `unknown id: ${id}`);
         throw new Error(`No conversation with id "${id}".`);
       }
-      argsRef.current.ops.remove(id);
-      if (match.id === argsRef.current.activeThread.id) {
-        argsRef.current.newSession();
+      args.ops.remove(id);
+      if (match.id === args.activeThread.id) {
+        args.newSession();
       }
       report("delete_conversation", `x ${match.name}`);
-      return { ok: true };
+      return { ok: true as const };
     },
   });
 
   const setMode = defineTool({
     name: "set_mode",
+    title: "Set conversation mode",
     description:
       "Set the active conversation mode while keeping its existing turns.",
     input: SetModeInput,
     validate: true,
+    output: SetModeOutput,
     inputSchema: {
       type: "object",
-      properties: { modeId: { type: "string", minLength: 1 } },
+      properties: {
+        modeId: {
+          type: "string",
+          description: "Mode identifier returned by list_modes.",
+          enum: ModeIds,
+        },
+      },
       required: ["modeId"],
     },
     execute: async ({ modeId }) => {
-      if (argsRef.current.busy) return rejectBusy("set_mode");
+      if (args.busy) return rejectBusy("set_mode");
       const mode = MODES.find((candidate) => candidate.id === modeId);
       if (!mode) {
         report("set_mode", `unknown modeId: ${modeId}`);
         throw new Error(`No mode with id "${modeId}".`);
       }
-      const { activeThread, ops } = argsRef.current;
+      const { activeThread, ops } = args;
       ops.setMode(activeThread.id, mode.id);
-      argsRef.current.newSession();
+      args.newSession();
       report("set_mode", `-> ${mode.name}`);
-      return { ok: true, modeId: mode.id };
+      return { ok: true as const, modeId: mode.id };
     },
   });
 
   const sendMessage = defineTool({
     name: "send_message",
+    title: "Send playground message",
     description:
       "Send a message to the active agent conversation. The reply streams into the conversation.",
     input: SendMessageInput,
     validate: true,
+    output: OperationOutput,
     inputSchema: {
       type: "object",
       properties: { text: { type: "string", minLength: 1 } },
       required: ["text"],
     },
     execute: async ({ text }) => {
-      if (argsRef.current.busy) return rejectBusy("send_message");
+      if (args.busy) return rejectBusy("send_message");
       report("send_message", text);
-      const accepted = await argsRef.current.send(text);
+      const accepted = await args.send(text);
       return accepted
         ? { ok: true as const }
         : {
@@ -227,11 +301,8 @@ export function createPlaygroundWebMCPTools(
 }
 
 export function useWebMCPTools(args: PlaygroundWebMCPContext) {
-  const argsRef = useRef(args);
-  argsRef.current = args;
-
   const available = isWebMCPAvailable();
-  const tools = useMemo(() => createPlaygroundWebMCPTools(argsRef), []);
+  const tools = createPlaygroundWebMCPTools(args);
 
   useWebMCP(tools);
 

--- a/apps/site/src/features/playground/lib/useWebMCPTools.ts
+++ b/apps/site/src/features/playground/lib/useWebMCPTools.ts
@@ -91,6 +91,7 @@ export function createPlaygroundWebMCPTools(
       },
     },
     required: ["id"],
+    additionalProperties: false,
   };
   const report = (name: string, detail?: string) => {
     args.pushActivity({
@@ -170,6 +171,7 @@ export function createPlaygroundWebMCPTools(
           enum: ModeIds,
         },
       },
+      additionalProperties: false,
     },
     execute: async ({ modeId }) => {
       if (args.busy) return rejectBusy("new_conversation");
@@ -247,6 +249,7 @@ export function createPlaygroundWebMCPTools(
         },
       },
       required: ["modeId"],
+      additionalProperties: false,
     },
     execute: async ({ modeId }) => {
       if (args.busy) return rejectBusy("set_mode");
@@ -275,6 +278,7 @@ export function createPlaygroundWebMCPTools(
       type: "object",
       properties: { text: { type: "string", minLength: 1 } },
       required: ["text"],
+      additionalProperties: false,
     },
     execute: async ({ text }) => {
       if (args.busy) return rejectBusy("send_message");
@@ -289,6 +293,8 @@ export function createPlaygroundWebMCPTools(
     },
   });
 
+  // Each definition retains its own inferred input type; erase that variance
+  // only at the registration boundary until heterogeneous arrays are native.
   return [
     listModes,
     listConversations,

--- a/apps/site/src/pages/index.astro
+++ b/apps/site/src/pages/index.astro
@@ -372,6 +372,7 @@ const browserColumns = [
 
       registerTool({
         name: "get_web_ai_sdk_resources",
+        title: "Get web-ai-sdk resources",
         description:
           "List canonical web-ai-sdk packages, documentation, and agent-friendly resources.",
         inputSchema: {
@@ -379,9 +380,8 @@ const browserColumns = [
           properties: {},
           additionalProperties: false,
         },
+        readOnly: true,
         annotations: {
-          readOnlyHint: true,
-          destructiveHint: false,
           idempotentHint: true,
           openWorldHint: false,
         },


### PR DESCRIPTION
## Summary

- add human-readable titles and runtime output validation to Playground browser tools
- constrain mode and conversation inputs to valid identifiers so Chrome generates usable examples
- update the homepage and docs demos to use current callback, metadata, and annotation behavior

## Testing

- full lint, docs check, build, typecheck, and test gate
- production-style Pages build and preview
- Chrome DevTools MCP audit of all seven Playground tools
- Chrome testing of homepage and docs WebMCP demos
