### PR TITLE
feat(webmcp): accept Standard Schema directly in tool definitions

### DIFF
--- a/.changeset/real-masks-fold.md
+++ b/.changeset/real-masks-fold.md
@@ -1,0 +1,6 @@
+---
+"@web-ai-sdk/webmcp": minor
+"@web-ai-sdk/all": patch
+---
+
+Accept Standard Schema input and output definitions directly in registerTool and useWebMCP, with automatic input validation, transformed values, typed errors, and a deprecated defineTool compatibility wrapper.

--- a/apps/site/package.json
+++ b/apps/site/package.json
@@ -34,7 +34,7 @@
     "remark-gfm": "^4.0.1",
     "remend": "^1.3.0",
     "sharp": "^0.35.3",
-    "valibot": "^1.4.0"
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "@astrojs/check": "^0.9.10",

--- a/apps/site/src/content/docs/guides/meta-package.mdx
+++ b/apps/site/src/content/docs/guides/meta-package.mdx
@@ -32,7 +32,7 @@ import { detect } from "@web-ai-sdk/all/detector";
 import { write } from "@web-ai-sdk/all/writer";
 import { rewrite } from "@web-ai-sdk/all/rewriter";
 import { proofread } from "@web-ai-sdk/all/proofreader";
-import { registerTool, defineTool } from "@web-ai-sdk/all/webmcp";
+import { registerTool } from "@web-ai-sdk/all/webmcp";
 ```
 
 ```tsx

--- a/apps/site/src/content/docs/guides/webmcp.mdx
+++ b/apps/site/src/content/docs/guides/webmcp.mdx
@@ -15,11 +15,26 @@ WebMCP is a proposed standard in early preview: behind flags and an origin trial
 
 ```ts
 import { registerTool } from "@web-ai-sdk/webmcp";
+import { z } from "zod"; // or valibot, arktype, effect, …
+
+const AddToCartInput = z.object({
+  sku: z.string().min(1),
+  quantity: z.number().int().positive().default(1),
+});
 
 const cleanup = registerTool({
   name: "add_to_cart",
   description: "Add a SKU to the user's cart",
-  execute: async (input) => ({ ok: true, ...input }),
+  input: AddToCartInput,
+  inputSchema: {
+    type: "object",
+    properties: {
+      sku: { type: "string", minLength: 1 },
+      quantity: { type: "integer", minimum: 1, default: 1 },
+    },
+    required: ["sku"],
+  },
+  execute: async ({ sku, quantity }) => addToCart(sku, quantity),
 });
 
 // Later, when the tool should no longer be exposed:
@@ -48,6 +63,26 @@ interface Tool<TInput = unknown, TOutput = unknown> {
 }
 ```
 
+Schema-aware definitions add optional Standard Schema fields. `input` is
+validated before application code runs, and `execute` receives its parsed or
+transformed output. `output` validates the resolved result and returns its
+parsed or transformed output.
+
+```ts
+interface ToolDefinition<InputSchema, TOutput, OutputSchema> {
+  // Same metadata fields as Tool
+  name: string;
+  description: string;
+  input?: InputSchema;   // Standard Schema; SDK-only
+  output?: OutputSchema; // Standard Schema; SDK-only
+  execute: (input: StandardSchemaV1.InferOutput<InputSchema>) => TOutput;
+}
+```
+
+Standard Schema is library-neutral and adds no runtime dependency to the SDK.
+The browser-facing `inputSchema` remains explicit because Standard Schema has
+no universal JSON Schema conversion contract.
+
 <div class="options-table">
 
 | Name | Type | Description |
@@ -56,6 +91,8 @@ interface Tool<TInput = unknown, TOutput = unknown> {
 | `title` | `string` | Human-readable title for host user interfaces. |
 | `description` <sup>required</sup> | `string` | What the tool does. Routed to the agent's tool selector. |
 | `execute` <sup>required</sup> | `(input) => Promise<T> \| T` | The function the agent calls. |
+| `input` | `StandardSchemaV1` | SDK-only input validator. Its parsed or transformed value is passed to `execute`. |
+| `output` | `StandardSchemaV1` | SDK-only resolved-output validator. Its parsed or transformed value is returned. |
 | `inputSchema` | `object` | JSON Schema describing the input shape. Some hosts validate against it before dispatch. |
 | `readOnly` | `boolean` | Shorthand for `annotations.readOnlyHint = true`. |
 | `destructive` | `boolean` | Compatibility shorthand for `annotations.destructiveHint = true`. |
@@ -69,11 +106,12 @@ interface Tool<TInput = unknown, TOutput = unknown> {
 
 ## How it works
 
-`document.modelContext.registerTool({...}, { signal, exposedTo })` is the spec entry point. (For backward compatibility with the previous shape of the API, this package also reads from `navigator.modelContext`.) The wrapper sits on top with three quality-of-life additions:
+`document.modelContext.registerTool({...}, { signal, exposedTo })` is the spec entry point. (For backward compatibility with the previous shape of the API, this package also reads from `navigator.modelContext`.) The wrapper sits on top with these quality-of-life additions:
 
 - **Feature detection.** On browsers without `document.modelContext` (or the legacy `navigator.modelContext`), every entry point is a no-op so consumer code ships unchanged. `isAvailable()` returns `false`.
 - **Last-writer-wins on duplicate names.** React effect cleanup is asynchronous; a fast re-render can attempt to register `"foo"` before Chrome processed the prior `abort()`. The wrapper detects the resulting duplicate-name error, queues a microtask retry, and tracks ownership so a stale registration can't squat the name.
 - **One AbortController per call.** `registerTool` returns a cleanup function that aborts the underlying controller and unregisters the tool.
+- **Library-neutral validation.** Direct definitions may carry Standard Schema input and output validators. The SDK validates and transforms around `execute`, then strips those SDK-only fields before native registration.
 
 ## Cross-document exposure
 
@@ -133,6 +171,16 @@ if (!isAvailable()) {
 
 registerTool({ ... });
 ```
+
+When a direct definition includes `input`, invalid input rejects with
+`ToolValidationError` before `execute` runs. When it includes `output`, an
+invalid resolved result rejects with `ToolOutputValidationError`. Both errors
+preserve the tool name and Standard Schema issues. Synchronous and asynchronous
+validators and schema transformations are supported.
+
+`defineTool()` remains as a deprecated compatibility wrapper. It preserves its
+historical `validate: true` input-validation opt-in, but new code should pass
+definitions directly to `registerTool()` or `useWebMCP()`.
 
 ## Origin trial
 

--- a/apps/site/src/content/docs/guides/webmcp.mdx
+++ b/apps/site/src/content/docs/guides/webmcp.mdx
@@ -65,13 +65,26 @@ transformed output. `output` validates the resolved result and returns its
 parsed or transformed output.
 
 ```ts
-interface ToolDefinition<InputSchema, TOutput, OutputSchema> {
-  // Same metadata fields as Tool
-  name: string;
-  description: string;
-  input?: InputSchema;   // Standard Schema; SDK-only
+interface ToolDefinition<
+  InputSchema extends StandardSchemaV1 | undefined = undefined,
+  TOutput = unknown,
+  OutputSchema extends StandardSchemaV1 | undefined = undefined,
+> extends Omit<Tool, "execute"> {
+  input?: InputSchema; // Standard Schema; SDK-only
   output?: OutputSchema; // Standard Schema; SDK-only
-  execute: (input: StandardSchemaV1.InferOutput<InputSchema>) => TOutput;
+  execute: (
+    input: InputSchema extends StandardSchemaV1
+      ? StandardSchemaV1.InferOutput<InputSchema>
+      : unknown,
+  ) =>
+    | Promise<
+        OutputSchema extends StandardSchemaV1
+          ? StandardSchemaV1.InferInput<OutputSchema>
+          : TOutput
+      >
+    | (OutputSchema extends StandardSchemaV1
+        ? StandardSchemaV1.InferInput<OutputSchema>
+        : TOutput);
 }
 ```
 

--- a/apps/site/src/content/docs/guides/webmcp.mdx
+++ b/apps/site/src/content/docs/guides/webmcp.mdx
@@ -15,7 +15,7 @@ WebMCP is a proposed standard in early preview: behind flags and an origin trial
 
 ```ts
 import { registerTool } from "@web-ai-sdk/webmcp";
-import { z } from "zod"; // or valibot, arktype, effect, …
+import { z } from "zod"; // Zod 4; other Standard Schema libraries work too
 
 const AddToCartInput = z.object({
   sku: z.string().min(1),
@@ -26,14 +26,10 @@ const cleanup = registerTool({
   name: "add_to_cart",
   description: "Add a SKU to the user's cart",
   input: AddToCartInput,
-  inputSchema: {
-    type: "object",
-    properties: {
-      sku: { type: "string", minLength: 1 },
-      quantity: { type: "integer", minimum: 1, default: 1 },
-    },
-    required: ["sku"],
-  },
+  inputSchema: z.toJSONSchema(AddToCartInput, {
+    io: "input",
+    target: "draft-2020-12",
+  }),
   execute: async ({ sku, quantity }) => addToCart(sku, quantity),
 });
 
@@ -80,8 +76,11 @@ interface ToolDefinition<InputSchema, TOutput, OutputSchema> {
 ```
 
 Standard Schema is library-neutral and adds no runtime dependency to the SDK.
-The browser-facing `inputSchema` remains explicit because Standard Schema has
-no universal JSON Schema conversion contract.
+Standard Schema validation and [Standard JSON Schema](https://standardschema.dev/json-schema)
+conversion are orthogonal capabilities. The browser-facing `inputSchema`
+remains explicit so consumers choose the converter and JSON Schema dialect.
+When a library supports conversion, derive it from the same schema rather than
+maintaining a second handwritten definition.
 
 <div class="options-table">
 

--- a/apps/site/src/content/docs/packages/all.md
+++ b/apps/site/src/content/docs/packages/all.md
@@ -47,7 +47,7 @@ import { detect } from "@web-ai-sdk/all/detector";
 import { write } from "@web-ai-sdk/all/writer";
 import { rewrite } from "@web-ai-sdk/all/rewriter";
 import { proofread } from "@web-ai-sdk/all/proofreader";
-import { registerTool, defineTool } from "@web-ai-sdk/all/webmcp";
+import { registerTool } from "@web-ai-sdk/all/webmcp";
 ```
 
 ```tsx

--- a/apps/site/src/content/docs/packages/webmcp.md
+++ b/apps/site/src/content/docs/packages/webmcp.md
@@ -82,22 +82,30 @@ cleanup();
 ## React
 
 ```tsx
-import { useWebMCP, type Tool } from "@web-ai-sdk/webmcp/react";
+import { useWebMCP } from "@web-ai-sdk/webmcp/react";
+import { z } from "zod"; // or valibot, arktype, effect, …
 
-const LIST_POSTS: Tool = {
-  name: "list_blog_posts",
-  title: "List blog posts",
-  description: "List published blog posts.",
-  readOnly: true,
-  annotations: { untrustedContentHint: true },
-  execute: async () => {
-    const res = await fetch("/api/posts.json");
-    return { results: await res.json() };
-  },
-};
+const SearchPostsInput = z.object({ query: z.string().min(1) });
 
 export function WebMCP({ isSignedIn }: { isSignedIn: boolean }) {
-  useWebMCP(LIST_POSTS, { enabled: isSignedIn });
+  useWebMCP(
+    {
+      name: "search_blog_posts",
+      description: "Search published blog posts.",
+      readOnly: true,
+      input: SearchPostsInput,
+      inputSchema: {
+        type: "object",
+        properties: { query: { type: "string", minLength: 1 } },
+        required: ["query"],
+      },
+      execute: async ({ query }) => {
+        const res = await fetch(`/api/posts.json?q=${encodeURIComponent(query)}`);
+        return { results: await res.json() };
+      },
+    },
+    { enabled: isSignedIn },
+  );
   return null;
 }
 ```
@@ -148,6 +156,40 @@ interface Tool<TInput = unknown, TOutput = unknown> {
 }
 ```
 
+Plain `Tool` objects remain supported. Use `ToolDefinition` when declaring a
+schema-aware tool separately from its registration call.
+
+```ts
+interface ToolDefinition<
+  InputSchema extends StandardSchemaV1 | undefined = undefined,
+  TOutput = unknown,
+  OutputSchema extends StandardSchemaV1 | undefined = undefined,
+> {
+  name: string;
+  title?: string;
+  description: string;
+  input?: InputSchema;
+  output?: OutputSchema;
+  inputSchema?: object;
+  readOnly?: boolean;
+  destructive?: boolean;
+  annotations?: ToolAnnotations;
+  execute: (
+    input: InputSchema extends StandardSchemaV1
+      ? StandardSchemaV1.InferOutput<InputSchema>
+      : unknown,
+  ) =>
+    | Promise<
+        OutputSchema extends StandardSchemaV1
+          ? StandardSchemaV1.InferInput<OutputSchema>
+          : TOutput
+      >
+    | (OutputSchema extends StandardSchemaV1
+        ? StandardSchemaV1.InferInput<OutputSchema>
+        : TOutput);
+}
+```
+
 `title` is for human-facing host UI. `description` is consumed by the agent host (Cursor / Claude / Chrome agent / etc.); write it as an instruction to an LLM about when to call the tool.
 
 The current WebMCP draft defines `readOnlyHint` and `untrustedContentHint`. The SDK also retains `destructiveHint`, `idempotentHint`, `openWorldHint`, and the `destructive` shorthand as source-compatible passthroughs for MCP-shaped and earlier WebMCP hosts; current-draft browsers may ignore those compatibility fields.
@@ -162,19 +204,19 @@ interface ToolAnnotations {
 }
 ```
 
-### `defineTool({...}): Tool` — typed schema adapter (Standard Schema)
+### Standard Schema definitions
 
 ```ts
-import { defineTool } from "@web-ai-sdk/webmcp";
+import { registerTool } from "@web-ai-sdk/webmcp";
 import { z } from "zod"; // or valibot, arktype, effect, …
 
-const sendEmail = defineTool({
+const cleanup = registerTool({
   name: "send_contact_email",
   title: "Send contact email",
   description: "Send a contact email on behalf of the visitor.",
   destructive: true,
-  // Standard Schema (https://standardschema.dev): used to narrow execute's
-  // input type. Validation at runtime is opt-in via `validate: true`.
+  // Standard Schema validates input before application code runs. execute
+  // receives the schema's parsed or transformed output type.
   input: z.object({
     name: z.string().min(1),
     email: z.string().email(),
@@ -182,11 +224,9 @@ const sendEmail = defineTool({
     message: z.string().min(1),
   }),
   // Output schemas validate every resolved result and may transform it.
-  // They stay inside the SDK and are not forwarded to WebMCP.
   output: z.object({ ok: z.literal(true) }),
-  // The host still wants raw JSON Schema for tool dispatch; pass it explicitly.
-  // Standard Schema does not emit JSON Schema, so we don't bridge between
-  // them — keeping both lets you choose your validator without coupling.
+  // Keep browser-facing JSON Schema explicit. Standard Schema has no universal
+  // JSON Schema conversion contract, so the SDK does not derive this field.
   inputSchema: {
     type: "object",
     properties: {
@@ -208,17 +248,26 @@ const sendEmail = defineTool({
     return { ok: true };
   },
 });
-
-// `sendEmail` is a plain Tool and can be passed to registerTool or useWebMCP.
 ```
 
-`defineTool` accepts any [Standard Schema](https://standardschema.dev) V1 validator (Zod 3.24+, Valibot, ArkType, Effect, …) — no SDK dependency on any specific library. The returned object is a plain `Tool`, so it composes with the rest of the API unchanged.
+`registerTool` and `useWebMCP` accept any [Standard Schema](https://standardschema.dev) V1 validator (Zod 3.24+, Valibot, ArkType, Effect, …) directly, with no SDK dependency on a validation library. Heterogeneous readonly arrays are supported without casting them to `Tool[]`.
 
-**Input validation:** off by default (`validate: false`). Most WebMCP hosts validate against `inputSchema` themselves; running the Standard Schema input validator on top is opt-in via `validate: true`, which throws `ToolValidationError` on bad input. With `validate: false`, `input` is type-only.
+**Input validation:** supplying `input` validates before application code runs and passes the schema's parsed or transformed value to `execute`. Invalid input throws `ToolValidationError`; its `toolName` and `issues` fields identify the tool and preserve the Standard Schema issues.
 
 **Output validation:** supplying `output` always validates the resolved sync or async `execute` result and returns the schema's parsed value, including transformations. Invalid output throws `ToolOutputValidationError`; its `toolName` and `issues` fields identify the tool and preserve the Standard Schema issues. The output schema is SDK-only because WebMCP has no `outputSchema` field.
 
 Output validation only checks the rules encoded in the schema. It does not prove that a result is fresh, trustworthy, or factually correct.
+
+The SDK-only `input` and `output` fields are never forwarded to the native
+WebMCP host. `inputSchema`, metadata, annotations, and registration options keep
+their native forwarding behavior.
+
+### `defineTool({...}): Tool` — deprecated compatibility wrapper
+
+`defineTool()` remains available for migration compatibility, including its
+historical opt-in input validation through `validate: true`. New code should
+pass schema-aware definitions directly to `registerTool()` or `useWebMCP()`.
+The wrapper will only be removed in a documented breaking release.
 
 ## Safety
 

--- a/apps/site/src/content/docs/packages/webmcp.md
+++ b/apps/site/src/content/docs/packages/webmcp.md
@@ -83,7 +83,7 @@ cleanup();
 
 ```tsx
 import { useWebMCP } from "@web-ai-sdk/webmcp/react";
-import { z } from "zod"; // or valibot, arktype, effect, …
+import { z } from "zod"; // Zod 4; other Standard Schema libraries work too
 
 const SearchPostsInput = z.object({ query: z.string().min(1) });
 
@@ -94,11 +94,10 @@ export function WebMCP({ isSignedIn }: { isSignedIn: boolean }) {
       description: "Search published blog posts.",
       readOnly: true,
       input: SearchPostsInput,
-      inputSchema: {
-        type: "object",
-        properties: { query: { type: "string", minLength: 1 } },
-        required: ["query"],
-      },
+      inputSchema: z.toJSONSchema(SearchPostsInput, {
+        io: "input",
+        target: "draft-2020-12",
+      }),
       execute: async ({ query }) => {
         const res = await fetch(`/api/posts.json?q=${encodeURIComponent(query)}`);
         return { results: await res.json() };
@@ -208,7 +207,14 @@ interface ToolAnnotations {
 
 ```ts
 import { registerTool } from "@web-ai-sdk/webmcp";
-import { z } from "zod"; // or valibot, arktype, effect, …
+import { z } from "zod";
+
+const SendContactEmailInput = z.object({
+  name: z.string().min(1),
+  email: z.string().email(),
+  subject: z.string().min(1),
+  message: z.string().min(1),
+});
 
 const cleanup = registerTool({
   name: "send_contact_email",
@@ -217,26 +223,14 @@ const cleanup = registerTool({
   destructive: true,
   // Standard Schema validates input before application code runs. execute
   // receives the schema's parsed or transformed output type.
-  input: z.object({
-    name: z.string().min(1),
-    email: z.string().email(),
-    subject: z.string().min(1),
-    message: z.string().min(1),
-  }),
+  input: SendContactEmailInput,
   // Output schemas validate every resolved result and may transform it.
   output: z.object({ ok: z.literal(true) }),
-  // Keep browser-facing JSON Schema explicit. Standard Schema has no universal
-  // JSON Schema conversion contract, so the SDK does not derive this field.
-  inputSchema: {
-    type: "object",
-    properties: {
-      name: { type: "string", minLength: 1 },
-      email: { type: "string", format: "email" },
-      subject: { type: "string", minLength: 1 },
-      message: { type: "string", minLength: 1 },
-    },
-    required: ["name", "email", "subject", "message"],
-  },
+  // Derive the browser-facing JSON Schema from the same source of truth.
+  inputSchema: z.toJSONSchema(SendContactEmailInput, {
+    io: "input",
+    target: "draft-2020-12",
+  }),
   async execute({ name, email, subject, message }) {
     // `name`, `email`, etc. are typed from the Zod schema.
     const res = await fetch("/api/send-email", {
@@ -251,6 +245,8 @@ const cleanup = registerTool({
 ```
 
 `registerTool` and `useWebMCP` accept any [Standard Schema](https://standardschema.dev) V1 validator (Zod 3.24+, Valibot, ArkType, Effect, …) directly, with no SDK dependency on a validation library. Heterogeneous readonly arrays are supported without casting them to `Tool[]`.
+
+Standard Schema validation and [Standard JSON Schema](https://standardschema.dev/json-schema) conversion are orthogonal capabilities. The SDK keeps `inputSchema` explicit so consumers choose the converter and JSON Schema dialect. The example uses Zod 4's converter; other libraries can provide a Standard JSON Schema converter or pass an explicit JSON Schema object.
 
 **Input validation:** supplying `input` validates before application code runs and passes the schema's parsed or transformed value to `execute`. Invalid input throws `ToolValidationError`; its `toolName` and `issues` fields identify the tool and preserve the Standard Schema issues.
 

--- a/apps/site/src/content/docs/react/use-web-mcp.mdx
+++ b/apps/site/src/content/docs/react/use-web-mcp.mdx
@@ -16,28 +16,60 @@ Use the invoke controls below to call a registered tool. On browsers with WebMCP
 ## Usage
 
 ```tsx
-import { useWebMCP, type Tool } from "@web-ai-sdk/webmcp/react";
+import { useWebMCP } from "@web-ai-sdk/webmcp/react";
+import { z } from "zod"; // or valibot, arktype, effect, …
 
-const ADD_TO_CART: Tool = {
-  name: "add_to_cart",
-  title: "Add to cart",
-  description: "Add a SKU to the user's cart",
-  execute: async (input) => ({ ok: true, ...input }),
-};
+const AddToCartInput = z.object({ sku: z.string().min(1) });
 
 export function AgentTools({ isSignedIn }: { isSignedIn: boolean }) {
-  useWebMCP(ADD_TO_CART, { enabled: isSignedIn });
+  useWebMCP(
+    {
+      name: "add_to_cart",
+      title: "Add to cart",
+      description: "Add a SKU to the user's cart",
+      input: AddToCartInput,
+      inputSchema: {
+        type: "object",
+        properties: { sku: { type: "string", minLength: 1 } },
+        required: ["sku"],
+      },
+      execute: async ({ sku }) => ({ ok: true, sku }),
+    },
+    { enabled: isSignedIn },
+  );
   return null; // pure logic; render whatever UI you want elsewhere
 }
 ```
 
-The hook accepts a single `Tool` or a readonly array. It registers on mount, cleans up on unmount, and cleans up whenever `enabled` changes to `false`.
+The hook accepts a single plain tool or schema-aware definition, plus readonly arrays containing either shape. It registers on mount, cleans up on unmount, and cleans up whenever `enabled` changes to `false`.
 
 Multiple tools can be passed directly:
 
 ```tsx
-useWebMCP([listItems, addToCart]);
+import type { ToolDefinition } from "@web-ai-sdk/webmcp/react";
+
+const findItemTool = {
+  name: "find_item",
+  description: "Find an item by SKU",
+  input: FindItemInput,
+  inputSchema: findItemJsonSchema,
+  execute: ({ sku }) => findItem(sku),
+} satisfies ToolDefinition<typeof FindItemInput>;
+
+const addToCartTool = {
+  name: "add_to_cart",
+  description: "Add an item to the cart",
+  input: AddToCartInput,
+  inputSchema: addToCartJsonSchema,
+  execute: ({ sku }) => addToCart(sku),
+} satisfies ToolDefinition<typeof AddToCartInput>;
+
+useWebMCP([findItemTool, addToCartTool] as const);
 ```
+
+Typing or checking each definition at its definition site preserves its own
+schema-derived `execute` input type; the heterogeneous readonly array needs no
+`as unknown as Tool[]` cast.
 
 The hook compares discoverable metadata and `exposedTo` values rather than object identity. Recreating an equivalent tool, tool array, or options object does not tear down its registration. Changing a name, title, description, schema, annotation, exposure value, or `enabled` state does update the registration.
 
@@ -50,7 +82,7 @@ Pass `exposedTo` through the hook when descendant documents at other origins sho
 ```tsx
 const EXPOSED_TO = ["https://agent.example"] as const;
 
-useWebMCP(ADD_TO_CART, {
+useWebMCP(addToCartTool, {
   enabled: isSignedIn,
   exposedTo: EXPOSED_TO,
 });
@@ -83,7 +115,9 @@ The hook returns nothing; cleanup is automatic on unmount via `useEffect`'s retu
 
 On browsers without `document.modelContext` (or the legacy `navigator.modelContext`), the hook is a no-op. Render whatever fallback UI you want; nothing breaks.
 
-Tools created with `defineTool` can reject with `ToolValidationError` for opt-in input validation or `ToolOutputValidationError` when an `output` schema rejects the resolved result. Output schemas are SDK-only and are not forwarded to WebMCP.
+Direct definitions with `input` reject with `ToolValidationError` before application code runs when validation fails. Definitions with `output` reject with `ToolOutputValidationError` when the resolved result fails validation. Both schemas may transform values and may validate synchronously or asynchronously. The SDK-only `input` and `output` fields are never forwarded to WebMCP.
+
+`defineTool()` remains as a deprecated compatibility wrapper with its historical `validate: true` input-validation opt-in. New code should pass definitions directly to the hook.
 
 ## Reference
 
@@ -94,6 +128,7 @@ import type {
   StandardSchemaV1,
   Tool,
   ToolAnnotations,
+  ToolDefinition,
   UseWebMCPOptions,
 } from "@web-ai-sdk/webmcp/react";
 
@@ -106,6 +141,15 @@ interface Tool {
   destructive?: boolean;           // compatibility shorthand
   annotations?: ToolAnnotations;   // raw passthrough; merges on top of shorthand
   inputSchema?: object;            // JSON Schema
+}
+
+interface ToolDefinition<InputSchema, TOutput, OutputSchema> {
+  name: string;
+  description: string;
+  input?: InputSchema;
+  output?: OutputSchema;
+  inputSchema?: object;
+  execute: (input: StandardSchemaV1.InferOutput<InputSchema>) => TOutput;
 }
 
 interface ToolAnnotations {
@@ -124,12 +168,16 @@ interface UseWebMCPOptions extends RegisterToolOptions {
   enabled?: boolean;
 }
 
-declare const useWebMCP: (
-  toolOrTools: Tool | readonly Tool[],
+declare function useWebMCP(
+  toolOrTools:
+    | Tool
+    | ToolDefinition
+    | readonly (Tool | ToolDefinition)[],
   options?: UseWebMCPOptions,
 ) => void;
 
-// Helper for type-safe tool definitions with a Standard Schema.
+// Deprecated compatibility helper. Direct definitions are the primary API.
+/** @deprecated */
 declare function defineTool<
   InputSchema extends StandardSchemaV1 | undefined = undefined,
   TOutput = unknown,

--- a/apps/site/src/content/docs/react/use-web-mcp.mdx
+++ b/apps/site/src/content/docs/react/use-web-mcp.mdx
@@ -17,7 +17,7 @@ Use the invoke controls below to call a registered tool. On browsers with WebMCP
 
 ```tsx
 import { useWebMCP } from "@web-ai-sdk/webmcp/react";
-import { z } from "zod"; // or valibot, arktype, effect, …
+import { z } from "zod"; // Zod 4; other Standard Schema libraries work too
 
 const AddToCartInput = z.object({ sku: z.string().min(1) });
 
@@ -28,11 +28,10 @@ export function AgentTools({ isSignedIn }: { isSignedIn: boolean }) {
       title: "Add to cart",
       description: "Add a SKU to the user's cart",
       input: AddToCartInput,
-      inputSchema: {
-        type: "object",
-        properties: { sku: { type: "string", minLength: 1 } },
-        required: ["sku"],
-      },
+      inputSchema: z.toJSONSchema(AddToCartInput, {
+        io: "input",
+        target: "draft-2020-12",
+      }),
       execute: async ({ sku }) => ({ ok: true, sku }),
     },
     { enabled: isSignedIn },
@@ -52,7 +51,10 @@ const findItemTool = {
   name: "find_item",
   description: "Find an item by SKU",
   input: FindItemInput,
-  inputSchema: findItemJsonSchema,
+  inputSchema: z.toJSONSchema(FindItemInput, {
+    io: "input",
+    target: "draft-2020-12",
+  }),
   execute: ({ sku }) => findItem(sku),
 } satisfies ToolDefinition<typeof FindItemInput>;
 
@@ -60,7 +62,10 @@ const addToCartTool = {
   name: "add_to_cart",
   description: "Add an item to the cart",
   input: AddToCartInput,
-  inputSchema: addToCartJsonSchema,
+  inputSchema: z.toJSONSchema(AddToCartInput, {
+    io: "input",
+    target: "draft-2020-12",
+  }),
   execute: ({ sku }) => addToCart(sku),
 } satisfies ToolDefinition<typeof AddToCartInput>;
 

--- a/apps/site/src/content/docs/react/use-web-mcp.mdx
+++ b/apps/site/src/content/docs/react/use-web-mcp.mdx
@@ -148,13 +148,26 @@ interface Tool {
   inputSchema?: object;            // JSON Schema
 }
 
-interface ToolDefinition<InputSchema, TOutput, OutputSchema> {
-  name: string;
-  description: string;
+interface ToolDefinition<
+  InputSchema extends StandardSchemaV1 | undefined = undefined,
+  TOutput = unknown,
+  OutputSchema extends StandardSchemaV1 | undefined = undefined,
+> extends Omit<Tool, "execute"> {
   input?: InputSchema;
   output?: OutputSchema;
-  inputSchema?: object;
-  execute: (input: StandardSchemaV1.InferOutput<InputSchema>) => TOutput;
+  execute: (
+    input: InputSchema extends StandardSchemaV1
+      ? StandardSchemaV1.InferOutput<InputSchema>
+      : unknown,
+  ) =>
+    | Promise<
+        OutputSchema extends StandardSchemaV1
+          ? StandardSchemaV1.InferInput<OutputSchema>
+          : TOutput
+      >
+    | (OutputSchema extends StandardSchemaV1
+        ? StandardSchemaV1.InferInput<OutputSchema>
+        : TOutput);
 }
 
 interface ToolAnnotations {

--- a/apps/site/src/features/docs/components/WebMCPDemo.tsx
+++ b/apps/site/src/features/docs/components/WebMCPDemo.tsx
@@ -1,6 +1,7 @@
-import { isAvailable, type Tool } from "@web-ai-sdk/webmcp";
+import { isAvailable } from "@web-ai-sdk/webmcp";
 import { useWebMCP } from "@web-ai-sdk/webmcp/react";
 import { useCallback, useEffect, useMemo, useState } from "react";
+import * as v from "valibot";
 import { UnavailableHint } from "./UnavailableHint.js";
 
 interface ListedTool {
@@ -21,6 +22,10 @@ const getTesting = (): ModelContextTesting | undefined => {
     .modelContextTesting;
 };
 
+const EchoMessageInput = v.object({
+  message: v.pipe(v.string(), v.minLength(1), v.maxLength(200)),
+});
+
 export const WebMCPDemo = () => {
   const [log, setLog] = useState<string[]>([]);
   const [available, setAvailable] = useState<boolean>(() => isAvailable());
@@ -32,7 +37,7 @@ export const WebMCPDemo = () => {
     setLog((prev) => [...prev, `${new Date().toLocaleTimeString()} ${line}`]);
   }, []);
 
-  const tools = useMemo<Tool[]>(
+  const tools = useMemo(
     () => [
       {
         name: "list_demo_items",
@@ -48,6 +53,7 @@ export const WebMCPDemo = () => {
         name: "echo_message",
         description: "Echo a message back. Demonstrates input schema.",
         readOnly: true,
+        input: EchoMessageInput,
         inputSchema: {
           type: "object",
           properties: {
@@ -55,8 +61,9 @@ export const WebMCPDemo = () => {
           },
           required: ["message"],
         },
-        execute: async (input) => {
-          const { message } = input as { message: string };
+        execute: async ({
+          message,
+        }: v.InferOutput<typeof EchoMessageInput>) => {
           append(`echo_message called with "${message}"`);
           return { echoed: message };
         },

--- a/apps/site/src/features/docs/components/WebMCPDemo.tsx
+++ b/apps/site/src/features/docs/components/WebMCPDemo.tsx
@@ -1,7 +1,7 @@
 import { isAvailable } from "@web-ai-sdk/webmcp";
 import { useWebMCP } from "@web-ai-sdk/webmcp/react";
 import { useCallback, useEffect, useMemo, useState } from "react";
-import * as v from "valibot";
+import { z } from "zod";
 import { UnavailableHint } from "./UnavailableHint.js";
 
 interface ListedTool {
@@ -22,8 +22,8 @@ const getTesting = (): ModelContextTesting | undefined => {
     .modelContextTesting;
 };
 
-const EchoMessageInput = v.object({
-  message: v.pipe(v.string(), v.minLength(1), v.maxLength(200)),
+const EchoMessageInput = z.object({
+  message: z.string().min(1).max(200),
 });
 
 export const WebMCPDemo = () => {
@@ -54,16 +54,11 @@ export const WebMCPDemo = () => {
         description: "Echo a message back. Demonstrates input schema.",
         readOnly: true,
         input: EchoMessageInput,
-        inputSchema: {
-          type: "object",
-          properties: {
-            message: { type: "string", minLength: 1, maxLength: 200 },
-          },
-          required: ["message"],
-        },
-        execute: async ({
-          message,
-        }: v.InferOutput<typeof EchoMessageInput>) => {
+        inputSchema: z.toJSONSchema(EchoMessageInput, {
+          io: "input",
+          target: "draft-2020-12",
+        }),
+        execute: async ({ message }: z.output<typeof EchoMessageInput>) => {
           append(`echo_message called with "${message}"`);
           return { echoed: message };
         },

--- a/apps/site/src/features/home/components/WebMCPDemo.tsx
+++ b/apps/site/src/features/home/components/WebMCPDemo.tsx
@@ -9,7 +9,7 @@ import {
 } from "@web-ai-sdk/webmcp";
 import { useWebMCP } from "@web-ai-sdk/webmcp/react";
 import { useEffect, useMemo, useRef, useState } from "react";
-import * as v from "valibot";
+import { z } from "zod";
 import {
   btnSm,
   card,
@@ -55,9 +55,9 @@ interface ToolSpec {
   execute(input: unknown): Promise<unknown>;
 }
 
-const AddToCartInput = v.object({
-  sku: v.pipe(v.string(), v.minLength(1)),
-  qty: v.optional(v.pipe(v.number(), v.integer(), v.minValue(1))),
+const AddToCartInput = z.object({
+  sku: z.string().min(1).describe("The product SKU to add"),
+  qty: z.number().int().min(1).describe("Units to add").optional(),
 });
 
 const TOOL_SPECS: readonly ToolSpec[] = [
@@ -68,15 +68,11 @@ const TOOL_SPECS: readonly ToolSpec[] = [
     on: true,
     match: /\bcart\b|\badd\b|MX-\d+/i,
     input: AddToCartInput,
-    inputSchema: {
-      type: "object",
-      properties: {
-        sku: { type: "string", description: "The product SKU to add" },
-        qty: { type: "integer", minimum: 1, description: "Units to add" },
-      },
-      required: ["sku"],
-    },
-    execute: async (input: v.InferOutput<typeof AddToCartInput>) => ({
+    inputSchema: z.toJSONSchema(AddToCartInput, {
+      io: "input",
+      target: "draft-2020-12",
+    }),
+    execute: async (input: z.output<typeof AddToCartInput>) => ({
       ok: true,
       ...input,
     }),

--- a/apps/site/src/features/home/components/WebMCPDemo.tsx
+++ b/apps/site/src/features/home/components/WebMCPDemo.tsx
@@ -5,10 +5,11 @@ import {
 } from "@web-ai-sdk/prompt";
 import {
   isAvailable as isWebMcpAvailable,
-  type Tool,
+  type StandardSchemaV1,
 } from "@web-ai-sdk/webmcp";
 import { useWebMCP } from "@web-ai-sdk/webmcp/react";
 import { useEffect, useMemo, useRef, useState } from "react";
+import * as v from "valibot";
 import {
   btnSm,
   card,
@@ -49,9 +50,15 @@ interface ToolSpec {
   match: RegExp;
   readOnly?: boolean;
   destructive?: boolean;
+  input?: StandardSchemaV1;
   inputSchema?: object;
-  execute: (input: unknown) => Promise<unknown>;
+  execute(input: unknown): Promise<unknown>;
 }
+
+const AddToCartInput = v.object({
+  sku: v.pipe(v.string(), v.minLength(1)),
+  qty: v.optional(v.pipe(v.number(), v.integer(), v.minValue(1))),
+});
 
 const TOOL_SPECS: readonly ToolSpec[] = [
   {
@@ -60,6 +67,7 @@ const TOOL_SPECS: readonly ToolSpec[] = [
     desc: "Add a SKU to the user's cart",
     on: true,
     match: /\bcart\b|\badd\b|MX-\d+/i,
+    input: AddToCartInput,
     inputSchema: {
       type: "object",
       properties: {
@@ -68,11 +76,9 @@ const TOOL_SPECS: readonly ToolSpec[] = [
       },
       required: ["sku"],
     },
-    execute: async (input) => ({
+    execute: async (input: v.InferOutput<typeof AddToCartInput>) => ({
       ok: true,
-      // Manual invocations (DevTools, testing surface) can pass primitives;
-      // only spread real objects so the payload stays well-formed.
-      ...(typeof input === "object" && input !== null ? input : {}),
+      ...input,
     }),
   },
   {
@@ -160,14 +166,15 @@ export const WebMCPDemo = () => {
   const enabledIdsRef = useRef(enabledIds);
   enabledIdsRef.current = enabledIds;
 
-  // Build the live Tool[] from the toggle state. Stable per (enabledIds set)
+  // Build the live definitions from the toggle state. Stable per enabled set
   // so the hook only re-registers when toggles change.
   // `open_settings` gets a closure that reports the live registration state,
   // turning it into a self-describing tool the agent can introspect.
-  const tools = useMemo<Tool[]>(() => {
+  const tools = useMemo(() => {
     return TOOL_SPECS.filter((t) => enabledIds.has(t.id)).map((spec) => ({
       name: spec.name,
       description: spec.desc,
+      ...(spec.input ? { input: spec.input } : {}),
       ...(spec.inputSchema ? { inputSchema: spec.inputSchema } : {}),
       ...(spec.readOnly ? { readOnly: true } : {}),
       ...(spec.destructive ? { destructive: true } : {}),

--- a/apps/site/src/features/playground/lib/useWebMCPTools.test.ts
+++ b/apps/site/src/features/playground/lib/useWebMCPTools.test.ts
@@ -1,5 +1,5 @@
-import type { Tool } from "@web-ai-sdk/webmcp";
-import { describe, expect, it, vi } from "vitest";
+import { registerTool } from "@web-ai-sdk/webmcp";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import type { AgentThread } from "./agentThreads.js";
 import {
   createPlaygroundWebMCPTools,
@@ -38,11 +38,39 @@ function createContext(
   };
 }
 
-function findTool(tools: Tool[], name: string): Tool {
-  const tool = tools.find((candidate) => candidate.name === name);
+interface RegisteredTool {
+  name: string;
+  execute: (input: unknown) => unknown;
+}
+
+function registerPlaygroundTools(context: PlaygroundWebMCPContext) {
+  const registered = new Map<string, RegisteredTool>();
+  Object.defineProperty(navigator, "modelContext", {
+    value: {
+      registerTool: (tool: RegisteredTool) => {
+        registered.set(tool.name, tool);
+      },
+    },
+    configurable: true,
+  });
+  const cleanups = createPlaygroundWebMCPTools({ current: context }).map(
+    registerTool,
+  );
+  return { cleanups, registered };
+}
+
+function findTool(tools: Map<string, RegisteredTool>, name: string) {
+  const tool = tools.get(name);
   if (!tool) throw new Error(`Missing tool ${name}`);
   return tool;
 }
+
+afterEach(() => {
+  Object.defineProperty(navigator, "modelContext", {
+    value: undefined,
+    configurable: true,
+  });
+});
 
 describe("createPlaygroundWebMCPTools", () => {
   it.each([
@@ -53,10 +81,8 @@ describe("createPlaygroundWebMCPTools", () => {
     ["send_message", { text: "Hello" }],
   ])("rejects %s while a response is running", async (name, input) => {
     const context = createContext({ busy: true });
-    const result = await findTool(
-      createPlaygroundWebMCPTools({ current: context }),
-      name,
-    ).execute(input);
+    const { cleanups, registered } = registerPlaygroundTools(context);
+    const result = await findTool(registered, name).execute(input);
 
     expect(result).toMatchObject({ ok: false, error: expect.any(String) });
     expect(context.send).not.toHaveBeenCalled();
@@ -64,28 +90,29 @@ describe("createPlaygroundWebMCPTools", () => {
     expect(context.ops.remove).not.toHaveBeenCalled();
     expect(context.ops.select).not.toHaveBeenCalled();
     expect(context.ops.setMode).not.toHaveBeenCalled();
+    for (const cleanup of cleanups) cleanup();
   });
 
   it("reports whether a message was accepted", async () => {
     const context = createContext({ send: vi.fn(async () => false) });
-    const result = await findTool(
-      createPlaygroundWebMCPTools({ current: context }),
-      "send_message",
-    ).execute({ text: "Hello" });
+    const { cleanups, registered } = registerPlaygroundTools(context);
+    const result = await findTool(registered, "send_message").execute({
+      text: "Hello",
+    });
 
     expect(result).toMatchObject({ ok: false, error: expect.any(String) });
+    for (const cleanup of cleanups) cleanup();
   });
 
   it("validates WebMCP input before invoking application code", async () => {
     const context = createContext();
-    const sendMessage = findTool(
-      createPlaygroundWebMCPTools({ current: context }),
-      "send_message",
-    );
+    const { cleanups, registered } = registerPlaygroundTools(context);
+    const sendMessage = findTool(registered, "send_message");
 
     await expect(sendMessage.execute({ text: 42 })).rejects.toMatchObject({
       name: "ToolValidationError",
     });
     expect(context.send).not.toHaveBeenCalled();
+    for (const cleanup of cleanups) cleanup();
   });
 });

--- a/apps/site/src/features/playground/lib/useWebMCPTools.ts
+++ b/apps/site/src/features/playground/lib/useWebMCPTools.ts
@@ -4,7 +4,7 @@ import {
 } from "@web-ai-sdk/webmcp";
 import { useWebMCP } from "@web-ai-sdk/webmcp/react";
 import { useMemo, useRef } from "react";
-import * as v from "valibot";
+import { z } from "zod";
 import { MODES } from "../experimental/playground/presets.js";
 import { type AgentThread, findMode } from "./agentThreads.js";
 import type { ActivityEvent } from "./types.js";
@@ -24,13 +24,13 @@ interface Current<T> {
   current: T;
 }
 
-const ConversationIdInput = v.object({
-  id: v.pipe(v.string(), v.minLength(1)),
+const ConversationIdInput = z.object({
+  id: z.string().min(1),
 });
-const NewConversationInput = v.object({ modeId: v.optional(v.string()) });
-const SetModeInput = v.object({ modeId: v.pipe(v.string(), v.minLength(1)) });
-const SendMessageInput = v.object({
-  text: v.pipe(v.string(), v.minLength(1)),
+const NewConversationInput = z.object({ modeId: z.string().optional() });
+const SetModeInput = z.object({ modeId: z.string().min(1) });
+const SendMessageInput = z.object({
+  text: z.string().min(1),
 });
 
 export function createPlaygroundWebMCPTools(
@@ -97,10 +97,10 @@ export function createPlaygroundWebMCPTools(
     description:
       "Create and select a new agent conversation. Optionally pass a modeId from list_modes.",
     input: NewConversationInput,
-    inputSchema: {
-      type: "object",
-      properties: { modeId: { type: "string" } },
-    },
+    inputSchema: z.toJSONSchema(NewConversationInput, {
+      io: "input",
+      target: "draft-2020-12",
+    }),
     execute: async ({ modeId }) => {
       if (argsRef.current.busy) return rejectBusy("new_conversation");
       const target = modeId ? findMode(modeId).id : undefined;
@@ -115,11 +115,10 @@ export function createPlaygroundWebMCPTools(
     name: "switch_conversation",
     description: "Switch the active agent conversation by id.",
     input: ConversationIdInput,
-    inputSchema: {
-      type: "object",
-      properties: { id: { type: "string", minLength: 1 } },
-      required: ["id"],
-    },
+    inputSchema: z.toJSONSchema(ConversationIdInput, {
+      io: "input",
+      target: "draft-2020-12",
+    }),
     execute: async ({ id }) => {
       if (argsRef.current.busy) return rejectBusy("switch_conversation");
       const match = argsRef.current.threads.find((thread) => thread.id === id);
@@ -140,11 +139,10 @@ export function createPlaygroundWebMCPTools(
       "Delete an agent conversation by id. Destructive: persisted turns cannot be recovered.",
     destructive: true,
     input: ConversationIdInput,
-    inputSchema: {
-      type: "object",
-      properties: { id: { type: "string", minLength: 1 } },
-      required: ["id"],
-    },
+    inputSchema: z.toJSONSchema(ConversationIdInput, {
+      io: "input",
+      target: "draft-2020-12",
+    }),
     execute: async ({ id }) => {
       if (argsRef.current.busy) return rejectBusy("delete_conversation");
       const match = argsRef.current.threads.find((thread) => thread.id === id);
@@ -166,11 +164,10 @@ export function createPlaygroundWebMCPTools(
     description:
       "Set the active conversation mode while keeping its existing turns.",
     input: SetModeInput,
-    inputSchema: {
-      type: "object",
-      properties: { modeId: { type: "string", minLength: 1 } },
-      required: ["modeId"],
-    },
+    inputSchema: z.toJSONSchema(SetModeInput, {
+      io: "input",
+      target: "draft-2020-12",
+    }),
     execute: async ({ modeId }) => {
       if (argsRef.current.busy) return rejectBusy("set_mode");
       const mode = MODES.find((candidate) => candidate.id === modeId);
@@ -191,11 +188,10 @@ export function createPlaygroundWebMCPTools(
     description:
       "Send a message to the active agent conversation. The reply streams into the conversation.",
     input: SendMessageInput,
-    inputSchema: {
-      type: "object",
-      properties: { text: { type: "string", minLength: 1 } },
-      required: ["text"],
-    },
+    inputSchema: z.toJSONSchema(SendMessageInput, {
+      io: "input",
+      target: "draft-2020-12",
+    }),
     execute: async ({ text }) => {
       if (argsRef.current.busy) return rejectBusy("send_message");
       report("send_message", text);

--- a/apps/site/src/features/playground/lib/useWebMCPTools.ts
+++ b/apps/site/src/features/playground/lib/useWebMCPTools.ts
@@ -1,7 +1,6 @@
 import {
-  defineTool,
   isAvailable as isWebMCPAvailable,
-  type Tool,
+  type ToolDefinition,
 } from "@web-ai-sdk/webmcp";
 import { useWebMCP } from "@web-ai-sdk/webmcp/react";
 import { useMemo, useRef } from "react";
@@ -36,7 +35,7 @@ const SendMessageInput = v.object({
 
 export function createPlaygroundWebMCPTools(
   argsRef: Current<PlaygroundWebMCPContext>,
-): Tool[] {
+) {
   const report = (name: string, detail?: string) => {
     argsRef.current.pushActivity({
       kind: "tool_invoked",
@@ -52,7 +51,7 @@ export function createPlaygroundWebMCPTools(
     };
   };
 
-  const listModes = defineTool({
+  const listModes: ToolDefinition = {
     name: "list_modes",
     description:
       "List the agent modes available in Playground. Each mode configures the system prompt, tools, examples, and renderers.",
@@ -68,9 +67,9 @@ export function createPlaygroundWebMCPTools(
         })),
       };
     },
-  });
+  };
 
-  const listConversations = defineTool({
+  const listConversations: ToolDefinition = {
     name: "list_conversations",
     description:
       "List persisted agent conversations, with mode ids and turn counts. Use this before switching, deleting, or sending.",
@@ -91,14 +90,13 @@ export function createPlaygroundWebMCPTools(
         })),
       };
     },
-  });
+  };
 
-  const newConversation = defineTool({
+  const newConversation: ToolDefinition<typeof NewConversationInput> = {
     name: "new_conversation",
     description:
       "Create and select a new agent conversation. Optionally pass a modeId from list_modes.",
     input: NewConversationInput,
-    validate: true,
     inputSchema: {
       type: "object",
       properties: { modeId: { type: "string" } },
@@ -111,13 +109,12 @@ export function createPlaygroundWebMCPTools(
       report("new_conversation", `-> ${thread.id}`);
       return { id: thread.id, modeId: thread.modeId };
     },
-  });
+  };
 
-  const switchConversation = defineTool({
+  const switchConversation: ToolDefinition<typeof ConversationIdInput> = {
     name: "switch_conversation",
     description: "Switch the active agent conversation by id.",
     input: ConversationIdInput,
-    validate: true,
     inputSchema: {
       type: "object",
       properties: { id: { type: "string", minLength: 1 } },
@@ -135,15 +132,14 @@ export function createPlaygroundWebMCPTools(
       report("switch_conversation", `-> ${match.name}`);
       return { ok: true, activeConversationId: id };
     },
-  });
+  };
 
-  const deleteConversation = defineTool({
+  const deleteConversation: ToolDefinition<typeof ConversationIdInput> = {
     name: "delete_conversation",
     description:
       "Delete an agent conversation by id. Destructive: persisted turns cannot be recovered.",
     destructive: true,
     input: ConversationIdInput,
-    validate: true,
     inputSchema: {
       type: "object",
       properties: { id: { type: "string", minLength: 1 } },
@@ -163,14 +159,13 @@ export function createPlaygroundWebMCPTools(
       report("delete_conversation", `x ${match.name}`);
       return { ok: true };
     },
-  });
+  };
 
-  const setMode = defineTool({
+  const setMode: ToolDefinition<typeof SetModeInput> = {
     name: "set_mode",
     description:
       "Set the active conversation mode while keeping its existing turns.",
     input: SetModeInput,
-    validate: true,
     inputSchema: {
       type: "object",
       properties: { modeId: { type: "string", minLength: 1 } },
@@ -189,14 +184,13 @@ export function createPlaygroundWebMCPTools(
       report("set_mode", `-> ${mode.name}`);
       return { ok: true, modeId: mode.id };
     },
-  });
+  };
 
-  const sendMessage = defineTool({
+  const sendMessage: ToolDefinition<typeof SendMessageInput> = {
     name: "send_message",
     description:
       "Send a message to the active agent conversation. The reply streams into the conversation.",
     input: SendMessageInput,
-    validate: true,
     inputSchema: {
       type: "object",
       properties: { text: { type: "string", minLength: 1 } },
@@ -213,7 +207,7 @@ export function createPlaygroundWebMCPTools(
             error: "Message was empty or the on-device model is unavailable.",
           };
     },
-  });
+  };
 
   return [
     listModes,
@@ -223,7 +217,7 @@ export function createPlaygroundWebMCPTools(
     deleteConversation,
     setMode,
     sendMessage,
-  ] as unknown as Tool[];
+  ] as const;
 }
 
 export function useWebMCPTools(args: PlaygroundWebMCPContext) {

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -40,7 +40,7 @@ import { detect } from "@web-ai-sdk/all/detector";
 import { write } from "@web-ai-sdk/all/writer";
 import { rewrite } from "@web-ai-sdk/all/rewriter";
 import { proofread } from "@web-ai-sdk/all/proofreader";
-import { registerTool, defineTool } from "@web-ai-sdk/all/webmcp";
+import { registerTool } from "@web-ai-sdk/all/webmcp";
 ```
 
 ```tsx

--- a/packages/webmcp/README.md
+++ b/packages/webmcp/README.md
@@ -75,22 +75,30 @@ cleanup();
 ## React
 
 ```tsx
-import { useWebMCP, type Tool } from "@web-ai-sdk/webmcp/react";
+import { useWebMCP } from "@web-ai-sdk/webmcp/react";
+import { z } from "zod"; // or valibot, arktype, effect, …
 
-const LIST_POSTS: Tool = {
-  name: "list_blog_posts",
-  title: "List blog posts",
-  description: "List published blog posts.",
-  readOnly: true,
-  annotations: { untrustedContentHint: true },
-  execute: async () => {
-    const res = await fetch("/api/posts.json");
-    return { results: await res.json() };
-  },
-};
+const SearchPostsInput = z.object({ query: z.string().min(1) });
 
 export function WebMCP({ isSignedIn }: { isSignedIn: boolean }) {
-  useWebMCP(LIST_POSTS, { enabled: isSignedIn });
+  useWebMCP(
+    {
+      name: "search_blog_posts",
+      description: "Search published blog posts.",
+      readOnly: true,
+      input: SearchPostsInput,
+      inputSchema: {
+        type: "object",
+        properties: { query: { type: "string", minLength: 1 } },
+        required: ["query"],
+      },
+      execute: async ({ query }) => {
+        const res = await fetch(`/api/posts.json?q=${encodeURIComponent(query)}`);
+        return { results: await res.json() };
+      },
+    },
+    { enabled: isSignedIn },
+  );
   return null;
 }
 ```
@@ -141,6 +149,40 @@ interface Tool<TInput = unknown, TOutput = unknown> {
 }
 ```
 
+Plain `Tool` objects remain supported. Use `ToolDefinition` when declaring a
+schema-aware tool separately from its registration call.
+
+```ts
+interface ToolDefinition<
+  InputSchema extends StandardSchemaV1 | undefined = undefined,
+  TOutput = unknown,
+  OutputSchema extends StandardSchemaV1 | undefined = undefined,
+> {
+  name: string;
+  title?: string;
+  description: string;
+  input?: InputSchema;
+  output?: OutputSchema;
+  inputSchema?: object;
+  readOnly?: boolean;
+  destructive?: boolean;
+  annotations?: ToolAnnotations;
+  execute: (
+    input: InputSchema extends StandardSchemaV1
+      ? StandardSchemaV1.InferOutput<InputSchema>
+      : unknown,
+  ) =>
+    | Promise<
+        OutputSchema extends StandardSchemaV1
+          ? StandardSchemaV1.InferInput<OutputSchema>
+          : TOutput
+      >
+    | (OutputSchema extends StandardSchemaV1
+        ? StandardSchemaV1.InferInput<OutputSchema>
+        : TOutput);
+}
+```
+
 `title` is for human-facing host UI. `description` is consumed by the agent host (Cursor / Claude / Chrome agent / etc.); write it as an instruction to an LLM about when to call the tool.
 
 The current WebMCP draft defines `readOnlyHint` and `untrustedContentHint`. The SDK also retains `destructiveHint`, `idempotentHint`, `openWorldHint`, and the `destructive` shorthand as source-compatible passthroughs for MCP-shaped and earlier WebMCP hosts; current-draft browsers may ignore those compatibility fields.
@@ -155,19 +197,19 @@ interface ToolAnnotations {
 }
 ```
 
-### `defineTool({...}): Tool` — typed schema adapter (Standard Schema)
+### Standard Schema definitions
 
 ```ts
-import { defineTool } from "@web-ai-sdk/webmcp";
+import { registerTool } from "@web-ai-sdk/webmcp";
 import { z } from "zod"; // or valibot, arktype, effect, …
 
-const sendEmail = defineTool({
+const cleanup = registerTool({
   name: "send_contact_email",
   title: "Send contact email",
   description: "Send a contact email on behalf of the visitor.",
   destructive: true,
-  // Standard Schema (https://standardschema.dev): used to narrow execute's
-  // input type. Validation at runtime is opt-in via `validate: true`.
+  // Standard Schema validates input before application code runs. execute
+  // receives the schema's parsed or transformed output type.
   input: z.object({
     name: z.string().min(1),
     email: z.string().email(),
@@ -175,11 +217,9 @@ const sendEmail = defineTool({
     message: z.string().min(1),
   }),
   // Output schemas validate every resolved result and may transform it.
-  // They stay inside the SDK and are not forwarded to WebMCP.
   output: z.object({ ok: z.literal(true) }),
-  // The host still wants raw JSON Schema for tool dispatch; pass it explicitly.
-  // Standard Schema does not emit JSON Schema, so we don't bridge between
-  // them — keeping both lets you choose your validator without coupling.
+  // Keep browser-facing JSON Schema explicit. Standard Schema has no universal
+  // JSON Schema conversion contract, so the SDK does not derive this field.
   inputSchema: {
     type: "object",
     properties: {
@@ -201,17 +241,26 @@ const sendEmail = defineTool({
     return { ok: true };
   },
 });
-
-// `sendEmail` is a plain Tool and can be passed to registerTool or useWebMCP.
 ```
 
-`defineTool` accepts any [Standard Schema](https://standardschema.dev) V1 validator (Zod 3.24+, Valibot, ArkType, Effect, …) — no SDK dependency on any specific library. The returned object is a plain `Tool`, so it composes with the rest of the API unchanged.
+`registerTool` and `useWebMCP` accept any [Standard Schema](https://standardschema.dev) V1 validator (Zod 3.24+, Valibot, ArkType, Effect, …) directly, with no SDK dependency on a validation library. Heterogeneous readonly arrays are supported without casting them to `Tool[]`.
 
-**Input validation:** off by default (`validate: false`). Most WebMCP hosts validate against `inputSchema` themselves; running the Standard Schema input validator on top is opt-in via `validate: true`, which throws `ToolValidationError` on bad input. With `validate: false`, `input` is type-only.
+**Input validation:** supplying `input` validates before application code runs and passes the schema's parsed or transformed value to `execute`. Invalid input throws `ToolValidationError`; its `toolName` and `issues` fields identify the tool and preserve the Standard Schema issues.
 
 **Output validation:** supplying `output` always validates the resolved sync or async `execute` result and returns the schema's parsed value, including transformations. Invalid output throws `ToolOutputValidationError`; its `toolName` and `issues` fields identify the tool and preserve the Standard Schema issues. The output schema is SDK-only because WebMCP has no `outputSchema` field.
 
 Output validation only checks the rules encoded in the schema. It does not prove that a result is fresh, trustworthy, or factually correct.
+
+The SDK-only `input` and `output` fields are never forwarded to the native
+WebMCP host. `inputSchema`, metadata, annotations, and registration options keep
+their native forwarding behavior.
+
+### `defineTool({...}): Tool` — deprecated compatibility wrapper
+
+`defineTool()` remains available for migration compatibility, including its
+historical opt-in input validation through `validate: true`. New code should
+pass schema-aware definitions directly to `registerTool()` or `useWebMCP()`.
+The wrapper will only be removed in a documented breaking release.
 
 ## Safety
 

--- a/packages/webmcp/README.md
+++ b/packages/webmcp/README.md
@@ -76,7 +76,7 @@ cleanup();
 
 ```tsx
 import { useWebMCP } from "@web-ai-sdk/webmcp/react";
-import { z } from "zod"; // or valibot, arktype, effect, …
+import { z } from "zod"; // Zod 4; other Standard Schema libraries work too
 
 const SearchPostsInput = z.object({ query: z.string().min(1) });
 
@@ -87,11 +87,10 @@ export function WebMCP({ isSignedIn }: { isSignedIn: boolean }) {
       description: "Search published blog posts.",
       readOnly: true,
       input: SearchPostsInput,
-      inputSchema: {
-        type: "object",
-        properties: { query: { type: "string", minLength: 1 } },
-        required: ["query"],
-      },
+      inputSchema: z.toJSONSchema(SearchPostsInput, {
+        io: "input",
+        target: "draft-2020-12",
+      }),
       execute: async ({ query }) => {
         const res = await fetch(`/api/posts.json?q=${encodeURIComponent(query)}`);
         return { results: await res.json() };
@@ -201,7 +200,14 @@ interface ToolAnnotations {
 
 ```ts
 import { registerTool } from "@web-ai-sdk/webmcp";
-import { z } from "zod"; // or valibot, arktype, effect, …
+import { z } from "zod";
+
+const SendContactEmailInput = z.object({
+  name: z.string().min(1),
+  email: z.string().email(),
+  subject: z.string().min(1),
+  message: z.string().min(1),
+});
 
 const cleanup = registerTool({
   name: "send_contact_email",
@@ -210,26 +216,14 @@ const cleanup = registerTool({
   destructive: true,
   // Standard Schema validates input before application code runs. execute
   // receives the schema's parsed or transformed output type.
-  input: z.object({
-    name: z.string().min(1),
-    email: z.string().email(),
-    subject: z.string().min(1),
-    message: z.string().min(1),
-  }),
+  input: SendContactEmailInput,
   // Output schemas validate every resolved result and may transform it.
   output: z.object({ ok: z.literal(true) }),
-  // Keep browser-facing JSON Schema explicit. Standard Schema has no universal
-  // JSON Schema conversion contract, so the SDK does not derive this field.
-  inputSchema: {
-    type: "object",
-    properties: {
-      name: { type: "string", minLength: 1 },
-      email: { type: "string", format: "email" },
-      subject: { type: "string", minLength: 1 },
-      message: { type: "string", minLength: 1 },
-    },
-    required: ["name", "email", "subject", "message"],
-  },
+  // Derive the browser-facing JSON Schema from the same source of truth.
+  inputSchema: z.toJSONSchema(SendContactEmailInput, {
+    io: "input",
+    target: "draft-2020-12",
+  }),
   async execute({ name, email, subject, message }) {
     // `name`, `email`, etc. are typed from the Zod schema.
     const res = await fetch("/api/send-email", {
@@ -244,6 +238,8 @@ const cleanup = registerTool({
 ```
 
 `registerTool` and `useWebMCP` accept any [Standard Schema](https://standardschema.dev) V1 validator (Zod 3.24+, Valibot, ArkType, Effect, …) directly, with no SDK dependency on a validation library. Heterogeneous readonly arrays are supported without casting them to `Tool[]`.
+
+Standard Schema validation and [Standard JSON Schema](https://standardschema.dev/json-schema) conversion are orthogonal capabilities. The SDK keeps `inputSchema` explicit so consumers choose the converter and JSON Schema dialect. The example uses Zod 4's converter; other libraries can provide a Standard JSON Schema converter or pass an explicit JSON Schema object.
 
 **Input validation:** supplying `input` validates before application code runs and passes the schema's parsed or transformed value to `execute`. Invalid input throws `ToolValidationError`; its `toolName` and `issues` fields identify the tool and preserve the Standard Schema issues.
 

--- a/packages/webmcp/src/definition.ts
+++ b/packages/webmcp/src/definition.ts
@@ -1,0 +1,237 @@
+import type { Tool, ToolAnnotations, ToolMetadata } from "./tool.js";
+
+/**
+ * Minimal Standard Schema V1 surface — see https://standardschema.dev. Any
+ * validation library that implements the spec satisfies this interface
+ * without an adapter or runtime dependency.
+ */
+export interface StandardSchemaV1<Input = unknown, Output = Input> {
+  readonly "~standard": {
+    readonly version: 1;
+    readonly vendor: string;
+    readonly validate: (
+      value: unknown,
+    ) =>
+      | StandardSchemaV1.Result<Output>
+      | Promise<StandardSchemaV1.Result<Output>>;
+    readonly types?: {
+      readonly input: Input;
+      readonly output: Output;
+    };
+  };
+}
+
+export namespace StandardSchemaV1 {
+  export type Result<Output> =
+    | { readonly value: Output; readonly issues?: undefined }
+    | { readonly issues: ReadonlyArray<Issue> };
+
+  export interface Issue {
+    readonly message: string;
+    readonly path?: ReadonlyArray<PropertyKey | PathSegment>;
+  }
+
+  export interface PathSegment {
+    readonly key: PropertyKey;
+  }
+
+  export type InferInput<S> =
+    S extends StandardSchemaV1<infer Input, unknown> ? Input : unknown;
+
+  export type InferOutput<S> =
+    S extends StandardSchemaV1<unknown, infer Output> ? Output : unknown;
+}
+
+export class ToolValidationError extends Error {
+  override readonly name = "ToolValidationError";
+  readonly toolName: string;
+  readonly issues: ReadonlyArray<StandardSchemaV1.Issue>;
+
+  constructor(toolName: string, issues: ReadonlyArray<StandardSchemaV1.Issue>) {
+    const summary = issues
+      .slice(0, 3)
+      .map((issue) => issue.message)
+      .join("; ");
+    super(`Tool "${toolName}" input validation failed: ${summary}`);
+    this.toolName = toolName;
+    this.issues = issues;
+  }
+}
+
+export class ToolOutputValidationError extends Error {
+  override readonly name = "ToolOutputValidationError";
+  readonly toolName: string;
+  readonly issues: ReadonlyArray<StandardSchemaV1.Issue>;
+
+  constructor(toolName: string, issues: ReadonlyArray<StandardSchemaV1.Issue>) {
+    const summary = issues
+      .slice(0, 3)
+      .map((issue) => issue.message)
+      .join("; ");
+    super(`Tool "${toolName}" output validation failed: ${summary}`);
+    this.toolName = toolName;
+    this.issues = issues;
+  }
+}
+
+/** A WebMCP tool definition with optional dependency-free Standard Schemas. */
+export interface ToolDefinition<
+  InputSchema extends StandardSchemaV1 | undefined = undefined,
+  TOutput = unknown,
+  OutputSchema extends StandardSchemaV1 | undefined = undefined,
+> extends ToolMetadata {
+  /**
+   * Standard Schema for application-facing input validation. The browser's
+   * JSON Schema remains explicit in `inputSchema`.
+   */
+  input?: InputSchema;
+  /** Standard Schema for validating and transforming the resolved result. */
+  output?: OutputSchema;
+  execute: (
+    input: InputSchema extends StandardSchemaV1
+      ? StandardSchemaV1.InferOutput<InputSchema>
+      : unknown,
+  ) =>
+    | Promise<
+        OutputSchema extends StandardSchemaV1
+          ? StandardSchemaV1.InferInput<OutputSchema>
+          : TOutput
+      >
+    | (OutputSchema extends StandardSchemaV1
+        ? StandardSchemaV1.InferInput<OutputSchema>
+        : TOutput);
+}
+
+/**
+ * Compatibility options for the deprecated `defineTool()` builder.
+ *
+ * Unlike direct definitions, input validation remains opt-in here so existing
+ * callers keep their historical runtime behavior.
+ */
+export interface DefineToolOptions<
+  InputSchema extends StandardSchemaV1 | undefined = undefined,
+  TOutput = unknown,
+  OutputSchema extends StandardSchemaV1 | undefined = undefined,
+> extends ToolMetadata {
+  input?: InputSchema;
+  output?: OutputSchema;
+  validate?: boolean;
+  execute: (
+    input: InputSchema extends StandardSchemaV1
+      ? StandardSchemaV1.InferInput<InputSchema>
+      : unknown,
+  ) =>
+    | Promise<
+        OutputSchema extends StandardSchemaV1
+          ? StandardSchemaV1.InferInput<OutputSchema>
+          : TOutput
+      >
+    | (OutputSchema extends StandardSchemaV1
+        ? StandardSchemaV1.InferInput<OutputSchema>
+        : TOutput);
+}
+
+/** Type-erased carrier used by registration and React internals. */
+export interface RegistrableTool extends ToolMetadata {
+  input?: StandardSchemaV1;
+  output?: StandardSchemaV1;
+  execute: (input: never) => unknown;
+}
+
+const validateWithSchema = async <Output>(
+  schema: StandardSchemaV1<unknown, Output>,
+  value: unknown,
+  onFailure: (
+    issues: ReadonlyArray<StandardSchemaV1.Issue>,
+  ) => ToolValidationError | ToolOutputValidationError,
+): Promise<Output> => {
+  const result = await schema["~standard"].validate(value);
+  if ("issues" in result && result.issues) {
+    throw onFailure(result.issues);
+  }
+  return (result as { value: Output }).value;
+};
+
+const copyMetadata = (
+  definition: ToolMetadata,
+  execute: Tool["execute"],
+): Tool => {
+  const tool: Tool = {
+    name: definition.name,
+    description: definition.description,
+    execute,
+  };
+  if (definition.title !== undefined) tool.title = definition.title;
+  if (definition.inputSchema !== undefined) {
+    tool.inputSchema = definition.inputSchema;
+  }
+  if (definition.readOnly) tool.readOnly = true;
+  if (definition.destructive) tool.destructive = true;
+  if (definition.annotations) tool.annotations = definition.annotations;
+  return tool;
+};
+
+/** Normalize SDK-only schemas into a plain native-facing `Tool`. */
+export const normalizeToolDefinition = (
+  definition: RegistrableTool,
+  { validateInput = true }: { validateInput?: boolean } = {},
+): Tool => {
+  const baseExecute = definition.execute as (
+    input: unknown,
+  ) => Promise<unknown> | unknown;
+  const inputSchema = validateInput ? definition.input : undefined;
+  const outputSchema = definition.output;
+
+  if (!inputSchema && !outputSchema) {
+    return copyMetadata(definition, baseExecute);
+  }
+
+  return copyMetadata(definition, async (input: unknown) => {
+    const executeInput = inputSchema
+      ? await validateWithSchema(
+          inputSchema,
+          input,
+          (issues) => new ToolValidationError(definition.name, issues),
+        )
+      : input;
+    const result = await baseExecute(executeInput);
+    if (!outputSchema) return result;
+    return validateWithSchema(
+      outputSchema,
+      result,
+      (issues) => new ToolOutputValidationError(definition.name, issues),
+    );
+  });
+};
+
+/**
+ * @deprecated Pass the definition directly to `registerTool()` or
+ * `useWebMCP()`. This compatibility wrapper will be removed in a documented
+ * breaking release.
+ */
+export const defineTool = <
+  InputSchema extends StandardSchemaV1 | undefined = undefined,
+  TOutput = unknown,
+  OutputSchema extends StandardSchemaV1 | undefined = undefined,
+>(
+  options: DefineToolOptions<InputSchema, TOutput, OutputSchema>,
+): Tool<
+  InputSchema extends StandardSchemaV1
+    ? StandardSchemaV1.InferInput<InputSchema>
+    : unknown,
+  OutputSchema extends StandardSchemaV1
+    ? StandardSchemaV1.InferOutput<OutputSchema>
+    : TOutput
+> =>
+  normalizeToolDefinition(options as RegistrableTool, {
+    validateInput: options.validate ?? false,
+  }) as Tool<
+    InputSchema extends StandardSchemaV1
+      ? StandardSchemaV1.InferInput<InputSchema>
+      : unknown,
+    OutputSchema extends StandardSchemaV1
+      ? StandardSchemaV1.InferOutput<OutputSchema>
+      : TOutput
+  >;
+
+export type { ToolAnnotations };

--- a/packages/webmcp/src/index.test.ts
+++ b/packages/webmcp/src/index.test.ts
@@ -7,6 +7,7 @@ import {
   registerTool,
   type StandardSchemaV1,
   type Tool,
+  type ToolDefinition,
   ToolOutputValidationError,
   ToolValidationError,
 } from "./index.js";
@@ -555,7 +556,7 @@ describe("registerTool", () => {
   });
 });
 
-describe("defineTool", () => {
+describe("Standard Schema tool definitions", () => {
   // Tiny Standard-Schema-shaped validator for tests; mirrors what a real
   // Zod/Valibot schema would expose via the `~standard` property. Kept inline
   // so the webmcp package stays dependency-free.
@@ -595,6 +596,169 @@ describe("defineTool", () => {
       types: { input: "" as string, output: 0 as number },
     },
   };
+
+  it("accepts schemas directly and passes transformed input to execute", async () => {
+    const { registered } = installFakeModelContext();
+    const execute = vi.fn((count: number) => String(count + 1));
+
+    registerTool({
+      name: "increment",
+      description: "increments a numeric string",
+      input: numericStringSchema,
+      inputSchema: { type: "string", pattern: "^\\d+$" },
+      execute: (count) => {
+        expectTypeOf(count).toEqualTypeOf<number>();
+        return execute(count);
+      },
+    });
+
+    await expect(registered.get("increment")?.execute("41")).resolves.toBe(
+      "42",
+    );
+    expect(execute).toHaveBeenCalledWith(41);
+  });
+
+  it("validates transformed outputs from synchronous and asynchronous schemas", async () => {
+    const { registered } = installFakeModelContext();
+    const asyncOutput: StandardSchemaV1<string, number> = {
+      "~standard": {
+        version: 1,
+        vendor: "test",
+        validate: async (value: unknown) => {
+          await Promise.resolve();
+          return numericStringSchema["~standard"].validate(value);
+        },
+        types: { input: "" as string, output: 0 as number },
+      },
+    };
+
+    registerTool({
+      name: "count",
+      description: "returns a count",
+      output: asyncOutput,
+      execute: async () => "42",
+    });
+
+    await expect(registered.get("count")?.execute(undefined)).resolves.toBe(42);
+  });
+
+  it("preserves typed input validation errors without validate ceremony", async () => {
+    const { registered } = installFakeModelContext();
+    const execute = vi.fn(() => ({ ok: true }));
+
+    registerTool({
+      name: "increment",
+      description: "increments a numeric string",
+      input: numericStringSchema,
+      execute,
+    });
+
+    await expect(
+      registered.get("increment")?.execute("not-a-number"),
+    ).rejects.toMatchObject({
+      name: "ToolValidationError",
+      toolName: "increment",
+      issues: [{ message: "output must be a numeric string" }],
+    });
+    await expect(
+      registered.get("increment")?.execute("not-a-number"),
+    ).rejects.toBeInstanceOf(ToolValidationError);
+    expect(execute).not.toHaveBeenCalled();
+  });
+
+  it("preserves typed output validation errors", async () => {
+    const { registered } = installFakeModelContext();
+
+    registerTool({
+      name: "count",
+      description: "returns a count",
+      output: numericStringSchema,
+      execute: () => "not-a-number",
+    });
+
+    await expect(
+      registered.get("count")?.execute(undefined),
+    ).rejects.toMatchObject({
+      name: "ToolOutputValidationError",
+      toolName: "count",
+      issues: [{ message: "output must be a numeric string" }],
+    });
+  });
+
+  it("never forwards SDK-only schemas while retaining native metadata", () => {
+    const { registerTool: nativeRegister } = installFakeModelContext();
+    const annotations = { idempotentHint: true } as const;
+    const inputSchema = { type: "string" };
+    const exposedTo = ["https://agent.example"] as const;
+
+    registerTool(
+      {
+        name: "echo",
+        title: "Echo text",
+        description: "echoes",
+        input: stringSchema("input"),
+        output: stringSchema("output"),
+        inputSchema,
+        readOnly: true,
+        annotations,
+        execute: (text) => text,
+      },
+      { exposedTo },
+    );
+
+    const definition = nativeRegister.mock.calls[0]?.[0];
+    const options = nativeRegister.mock.calls[0]?.[1];
+    expect(definition).toMatchObject({
+      name: "echo",
+      title: "Echo text",
+      description: "echoes",
+      inputSchema,
+      annotations: { readOnlyHint: true, idempotentHint: true },
+    });
+    expect(definition).not.toHaveProperty("input");
+    expect(definition).not.toHaveProperty("output");
+    expect(options?.exposedTo).toBe(exposedTo);
+  });
+
+  it("accepts heterogeneous schema definitions without a Tool[] cast", () => {
+    const { registered } = installFakeModelContext();
+    const textTool = {
+      name: "text",
+      description: "returns text",
+      input: stringSchema("input"),
+      execute: (text) => {
+        expectTypeOf(text).toEqualTypeOf<string>();
+        return text;
+      },
+    } satisfies ToolDefinition<StandardSchemaV1<string, string>, string>;
+    const numberTool = {
+      name: "number",
+      description: "returns a number",
+      input: numericStringSchema,
+      execute: (count) => {
+        expectTypeOf(count).toEqualTypeOf<number>();
+        return count;
+      },
+    } satisfies ToolDefinition<StandardSchemaV1<string, number>, number>;
+    const tools = [textTool, numberTool] as const;
+
+    const cleanups = tools.map(registerTool);
+
+    expect(registered.has("text")).toBe(true);
+    expect(registered.has("number")).toBe(true);
+    for (const cleanup of cleanups) cleanup();
+  });
+
+  it("keeps defineTool as an opt-in-validation compatibility wrapper", async () => {
+    const tool = defineTool({
+      name: "echo",
+      description: "echoes",
+      input: stringSchema("input"),
+      execute: (text) => ({ text }),
+    });
+    const out = await (tool.execute as (input: unknown) => unknown)(123);
+    expect(out).toEqual({ text: 123 });
+  });
 
   it("returns a Tool that registers via the existing surface", () => {
     const { registered } = installFakeModelContext();

--- a/packages/webmcp/src/index.ts
+++ b/packages/webmcp/src/index.ts
@@ -11,222 +11,28 @@
  */
 
 import {
+  normalizeToolDefinition,
+  type RegistrableTool,
+  type StandardSchemaV1,
+  type ToolDefinition,
+} from "./definition.js";
+import {
   type RegisteredToolMetadata,
   type Tool,
-  type ToolAnnotations,
   toRegisteredToolMetadata,
 } from "./tool.js";
 
+export type {
+  DefineToolOptions,
+  StandardSchemaV1,
+  ToolDefinition,
+} from "./definition.js";
+export {
+  defineTool,
+  ToolOutputValidationError,
+  ToolValidationError,
+} from "./definition.js";
 export type { Tool, ToolAnnotations } from "./tool.js";
-
-/**
- * Minimal Standard Schema V1 surface — see https://standardschema.dev. Any
- * validation library that implements the spec (Zod 3.24+, Valibot, ArkType,
- * Effect, etc.) satisfies this interface without an adapter or dep. We declare
- * the types locally so this package stays dependency-free.
- */
-export interface StandardSchemaV1<Input = unknown, Output = Input> {
-  readonly "~standard": {
-    readonly version: 1;
-    readonly vendor: string;
-    readonly validate: (
-      value: unknown,
-    ) =>
-      | StandardSchemaV1.Result<Output>
-      | Promise<StandardSchemaV1.Result<Output>>;
-    readonly types?: {
-      readonly input: Input;
-      readonly output: Output;
-    };
-  };
-}
-
-export namespace StandardSchemaV1 {
-  export type Result<Output> =
-    | { readonly value: Output; readonly issues?: undefined }
-    | { readonly issues: ReadonlyArray<Issue> };
-
-  export interface Issue {
-    readonly message: string;
-    readonly path?: ReadonlyArray<PropertyKey | PathSegment>;
-  }
-
-  export interface PathSegment {
-    readonly key: PropertyKey;
-  }
-
-  export type InferInput<S> =
-    S extends StandardSchemaV1<infer In, unknown> ? In : unknown;
-
-  export type InferOutput<S> =
-    S extends StandardSchemaV1<unknown, infer Out> ? Out : unknown;
-}
-
-export class ToolValidationError extends Error {
-  override readonly name = "ToolValidationError";
-  readonly toolName: string;
-  readonly issues: ReadonlyArray<StandardSchemaV1.Issue>;
-  constructor(toolName: string, issues: ReadonlyArray<StandardSchemaV1.Issue>) {
-    const summary = issues
-      .slice(0, 3)
-      .map((i) => i.message)
-      .join("; ");
-    super(`Tool "${toolName}" input validation failed: ${summary}`);
-    this.toolName = toolName;
-    this.issues = issues;
-  }
-}
-
-export class ToolOutputValidationError extends Error {
-  override readonly name = "ToolOutputValidationError";
-  readonly toolName: string;
-  readonly issues: ReadonlyArray<StandardSchemaV1.Issue>;
-  constructor(toolName: string, issues: ReadonlyArray<StandardSchemaV1.Issue>) {
-    const summary = issues
-      .slice(0, 3)
-      .map((i) => i.message)
-      .join("; ");
-    super(`Tool "${toolName}" output validation failed: ${summary}`);
-    this.toolName = toolName;
-    this.issues = issues;
-  }
-}
-
-export interface DefineToolOptions<
-  InputSchema extends StandardSchemaV1 | undefined = undefined,
-  TOutput = unknown,
-  OutputSchema extends StandardSchemaV1 | undefined = undefined,
-> {
-  name: string;
-  /** Optional human-readable title for display in host user interfaces. */
-  title?: string;
-  description: string;
-  /**
-   * Optional Standard Schema (Zod / Valibot / ArkType / etc.) used purely to
-   * narrow `execute`'s input type. Runtime validation is opt-in via
-   * `validate: true`. Standard Schema doesn't emit JSON Schema, so pass
-   * `inputSchema` explicitly when the host needs it for tool dispatch.
-   */
-  input?: InputSchema;
-  /**
-   * Optional Standard Schema for the resolved `execute` result. When present,
-   * the SDK always validates the result and returns the schema's parsed output.
-   * This is SDK-only and is never forwarded to the WebMCP host.
-   */
-  output?: OutputSchema;
-  /** Raw JSON Schema for the host. Stays explicit; the SDK does not derive it from `input`. */
-  inputSchema?: object;
-  readOnly?: boolean;
-  destructive?: boolean;
-  annotations?: ToolAnnotations;
-  /**
-   * When `true`, run `input.~standard.validate` before `execute` and throw
-   * `ToolValidationError` on failure. Default `false` — most WebMCP hosts
-   * validate against `inputSchema` themselves, so the SDK doesn't double up.
-   */
-  validate?: boolean;
-  execute: (
-    input: InputSchema extends StandardSchemaV1
-      ? StandardSchemaV1.InferInput<InputSchema>
-      : unknown,
-  ) =>
-    | Promise<
-        OutputSchema extends StandardSchemaV1
-          ? StandardSchemaV1.InferInput<OutputSchema>
-          : TOutput
-      >
-    | (OutputSchema extends StandardSchemaV1
-        ? StandardSchemaV1.InferInput<OutputSchema>
-        : TOutput);
-}
-
-const validateWithSchema = async <Output>(
-  schema: StandardSchemaV1<unknown, Output>,
-  value: unknown,
-  onFailure: (
-    issues: ReadonlyArray<StandardSchemaV1.Issue>,
-  ) => ToolValidationError | ToolOutputValidationError,
-): Promise<Output> => {
-  const result = await schema["~standard"].validate(value);
-  if ("issues" in result && result.issues) {
-    throw onFailure(result.issues);
-  }
-  return (result as { value: Output }).value;
-};
-
-/**
- * Build a `Tool` whose `execute` is typed against an optional Standard Schema
- * (Zod / Valibot / ArkType / etc.) without forcing the SDK to take a dep on
- * any specific library. Pass `validate: true` to also run the schema at
- * runtime; otherwise the input schema is type-only. Supplying `output` always
- * validates the resolved result and returns the schema's parsed output.
- *
- * The returned object is a plain `Tool` and can be passed to `registerTool`
- * or the React `useWebMCP` hook unchanged.
- */
-export const defineTool = <
-  InputSchema extends StandardSchemaV1 | undefined = undefined,
-  TOutput = unknown,
-  OutputSchema extends StandardSchemaV1 | undefined = undefined,
->(
-  options: DefineToolOptions<InputSchema, TOutput, OutputSchema>,
-): Tool<
-  InputSchema extends StandardSchemaV1
-    ? StandardSchemaV1.InferInput<InputSchema>
-    : unknown,
-  OutputSchema extends StandardSchemaV1
-    ? StandardSchemaV1.InferOutput<OutputSchema>
-    : TOutput
-> => {
-  type Input = InputSchema extends StandardSchemaV1
-    ? StandardSchemaV1.InferInput<InputSchema>
-    : unknown;
-  type RawOutput = OutputSchema extends StandardSchemaV1
-    ? StandardSchemaV1.InferInput<OutputSchema>
-    : TOutput;
-  type Output = OutputSchema extends StandardSchemaV1
-    ? StandardSchemaV1.InferOutput<OutputSchema>
-    : TOutput;
-
-  const baseExecute = options.execute as (
-    input: Input,
-  ) => Promise<RawOutput> | RawOutput;
-  const inputSchema = options.validate ? options.input : undefined;
-  const outputSchema = options.output;
-  const execute: (input: Input) => Promise<Output> | Output =
-    inputSchema || outputSchema
-      ? async (input: Input) => {
-          const executeInput = inputSchema
-            ? ((await validateWithSchema(
-                inputSchema as StandardSchemaV1<unknown, Input>,
-                input,
-                (issues) => new ToolValidationError(options.name, issues),
-              )) as Input)
-            : input;
-          const result = await baseExecute(executeInput);
-          if (outputSchema) {
-            return validateWithSchema(
-              outputSchema as StandardSchemaV1<unknown, Output>,
-              result,
-              (issues) => new ToolOutputValidationError(options.name, issues),
-            );
-          }
-          return result as Output;
-        }
-      : (baseExecute as (input: Input) => Promise<Output> | Output);
-
-  const tool: Tool<Input, Output> = {
-    name: options.name,
-    description: options.description,
-    execute,
-  };
-  if (options.title !== undefined) tool.title = options.title;
-  if (options.inputSchema !== undefined) tool.inputSchema = options.inputSchema;
-  if (options.readOnly) tool.readOnly = true;
-  if (options.destructive) tool.destructive = true;
-  if (options.annotations) tool.annotations = options.annotations;
-  return tool;
-};
 
 interface RegisteredTool extends RegisteredToolMetadata {
   execute: (input: unknown) => Promise<unknown> | unknown;
@@ -410,16 +216,25 @@ const registerOne = async (
   return true;
 };
 
-/** Register a tool with optional native registration options. */
+/** Register a schema-aware definition with optional native options. */
+export function registerTool<
+  InputSchema extends StandardSchemaV1 | undefined = undefined,
+  TOutput = unknown,
+  OutputSchema extends StandardSchemaV1 | undefined = undefined,
+>(
+  tool: ToolDefinition<InputSchema, TOutput, OutputSchema>,
+  options?: RegisterToolOptions,
+): () => void;
+/** Register a plain tool with optional native registration options. */
 export function registerTool<TInput, TOutput>(
   tool: Tool<TInput, TOutput>,
   options?: RegisterToolOptions,
 ): () => void;
 /** Preserve the documented `tools.map(registerTool)` callback shape. */
-export function registerTool<TInput, TOutput>(
-  tool: Tool<TInput, TOutput>,
+export function registerTool(
+  tool: RegistrableTool,
   index: number,
-  tools: readonly Tool<TInput, TOutput>[],
+  tools: readonly RegistrableTool[],
 ): () => void;
 /**
  * Register a single tool. Returns a cleanup function that unregisters it.
@@ -430,17 +245,17 @@ export function registerTool<TInput, TOutput>(
  *
  * If WebMCP is unavailable, the call is a no-op and the cleanup is a no-op.
  */
-export function registerTool<TInput, TOutput>(
-  tool: Tool<TInput, TOutput>,
+export function registerTool(
+  tool: RegistrableTool,
   optionsOrIndex?: RegisterToolOptions | number,
-  _tools?: readonly Tool<TInput, TOutput>[],
+  _tools?: readonly RegistrableTool[],
 ): () => void {
   const options =
     typeof optionsOrIndex === "number" ? undefined : optionsOrIndex;
   const mc = getModelContext();
   if (!mc) return () => {};
 
-  const registered = toRegistered(tool as Tool);
+  const registered = toRegistered(normalizeToolDefinition(tool));
   const controller = new AbortController();
   // Fire-and-forget: registerOne is total (never rejects — see its contract),
   // so there is no unhandled-rejection risk. The sync cleanup below aborts the

--- a/packages/webmcp/src/react/index.test.tsx
+++ b/packages/webmcp/src/react/index.test.tsx
@@ -1,7 +1,7 @@
 import { renderHook } from "@testing-library/react";
 import { type ReactNode, StrictMode, useLayoutEffect } from "react";
 import { afterEach, describe, expect, expectTypeOf, it, vi } from "vitest";
-import type { Tool } from "../index.js";
+import type { StandardSchemaV1, Tool, ToolDefinition } from "../index.js";
 import {
   type RegisterToolOptions,
   type UseWebMCPOptions,
@@ -56,6 +56,30 @@ afterEach(() => {
   setModelContext("navigator", undefined);
 });
 
+const stringSchema = (label: string): StandardSchemaV1<string, string> => ({
+  "~standard": {
+    version: 1,
+    vendor: "test",
+    validate: (value: unknown) =>
+      typeof value === "string"
+        ? { value }
+        : { issues: [{ message: `${label} must be a string` }] },
+    types: { input: "" as string, output: "" as string },
+  },
+});
+
+const numericStringSchema: StandardSchemaV1<string, number> = {
+  "~standard": {
+    version: 1,
+    vendor: "test",
+    validate: (value: unknown) =>
+      typeof value === "string" && /^\d+$/.test(value)
+        ? { value: Number(value) }
+        : { issues: [{ message: "value must be a numeric string" }] },
+    types: { input: "" as string, output: 0 as number },
+  },
+};
+
 describe("useWebMCP", () => {
   it("registers a single tool", () => {
     const { registered } = installFakeModelContext();
@@ -69,6 +93,91 @@ describe("useWebMCP", () => {
     expect(registered.has("single")).toBe(true);
     unmount();
     expect(registered.has("single")).toBe(false);
+  });
+
+  it("registers and validates a direct schema-aware definition", async () => {
+    const { registered, registerTool } = installFakeModelContext();
+
+    const { unmount } = renderHook(() =>
+      useWebMCP({
+        name: "increment",
+        description: "Increment a numeric string",
+        input: numericStringSchema,
+        inputSchema: { type: "string", pattern: "^\\d+$" },
+        execute: (count) => {
+          expectTypeOf(count).toEqualTypeOf<number>();
+          return count + 1;
+        },
+      }),
+    );
+
+    const definition = registerTool.mock.calls[0]?.[0];
+    expect(definition).not.toHaveProperty("input");
+    await expect(registered.get("increment")?.execute("41")).resolves.toBe(42);
+    await expect(
+      registered.get("increment")?.execute("nope"),
+    ).rejects.toMatchObject({
+      name: "ToolValidationError",
+      toolName: "increment",
+    });
+    unmount();
+  });
+
+  it("accepts heterogeneous direct definitions with per-tool inference", async () => {
+    const { registered } = installFakeModelContext();
+    const textTool = {
+      name: "text",
+      description: "Echo text",
+      input: stringSchema("text"),
+      execute: (text) => {
+        expectTypeOf(text).toEqualTypeOf<string>();
+        return text.toUpperCase();
+      },
+    } satisfies ToolDefinition<StandardSchemaV1<string, string>, string>;
+    const numberTool = {
+      name: "number",
+      description: "Parse a number",
+      input: numericStringSchema,
+      execute: (count) => {
+        expectTypeOf(count).toEqualTypeOf<number>();
+        return count + 1;
+      },
+    } satisfies ToolDefinition<StandardSchemaV1<string, number>, number>;
+
+    const { unmount } = renderHook(() =>
+      useWebMCP([textTool, numberTool] as const),
+    );
+
+    await expect(registered.get("text")?.execute("hello")).resolves.toBe(
+      "HELLO",
+    );
+    await expect(registered.get("number")?.execute("41")).resolves.toBe(42);
+    unmount();
+  });
+
+  it("uses the latest schema and callback without re-registering", async () => {
+    const { registered, registerTool } = installFakeModelContext();
+
+    const { rerender, unmount } = renderHook(
+      ({ label, suffix }: { label: string; suffix: string }) =>
+        useWebMCP({
+          name: "fresh-schema",
+          description: "Use current validation and state",
+          input: stringSchema(label),
+          execute: (text) => `${text}:${suffix}`,
+        }),
+      { initialProps: { label: "first", suffix: "a" } },
+    );
+    const registeredTool = registered.get("fresh-schema");
+
+    rerender({ label: "second", suffix: "b" });
+
+    expect(registerTool).toHaveBeenCalledTimes(1);
+    await expect(registeredTool?.execute("value")).resolves.toBe("value:b");
+    await expect(registeredTool?.execute(123)).rejects.toThrow(
+      "second must be a string",
+    );
+    unmount();
   });
 
   it("registers tools on mount and unregisters them on unmount", () => {

--- a/packages/webmcp/src/react/index.ts
+++ b/packages/webmcp/src/react/index.ts
@@ -1,4 +1,10 @@
 import { useEffect, useLayoutEffect, useRef } from "react";
+import {
+  normalizeToolDefinition,
+  type RegistrableTool,
+  type StandardSchemaV1,
+  type ToolDefinition,
+} from "../definition.js";
 import { type RegisterToolOptions, registerTool } from "../index.js";
 import { type Tool, toRegisteredToolMetadata } from "../tool.js";
 
@@ -13,7 +19,7 @@ interface ActiveRegistration {
 }
 
 const getRegistrationKey = (
-  tools: readonly Tool[],
+  tools: readonly RegistrableTool[],
   exposedTo: readonly string[] | undefined,
 ): string => {
   try {
@@ -68,45 +74,74 @@ const useCommitEffect =
   typeof window === "undefined" ? useEffect : useLayoutEffect;
 
 const wrapTools = (
-  tools: readonly Tool[],
-  latestExecutors: {
-    readonly current: readonly Tool["execute"][];
+  tools: readonly RegistrableTool[],
+  latestTools: {
+    readonly current: readonly Tool[];
   },
 ): readonly Tool[] =>
-  tools.map((tool, index) => {
-    const initialExecute = tool.execute;
-    return {
-      ...tool,
+  tools.map((definition, index) => {
+    const initialTool = latestTools.current[index];
+    const tool: Tool = {
+      name: definition.name,
+      description: definition.description,
       execute: (input: unknown) =>
-        (latestExecutors.current[index] ?? initialExecute)(input),
+        (latestTools.current[index] ?? initialTool)?.execute(input),
     };
+    if (definition.title !== undefined) tool.title = definition.title;
+    if (definition.inputSchema !== undefined) {
+      tool.inputSchema = definition.inputSchema;
+    }
+    if (definition.readOnly) tool.readOnly = true;
+    if (definition.destructive) tool.destructive = true;
+    if (definition.annotations) tool.annotations = definition.annotations;
+    return tool;
   });
+
+/** Register one direct schema-aware tool definition. */
+export function useWebMCP<
+  InputSchema extends StandardSchemaV1 | undefined = undefined,
+  TOutput = unknown,
+  OutputSchema extends StandardSchemaV1 | undefined = undefined,
+>(
+  tool: ToolDefinition<InputSchema, TOutput, OutputSchema>,
+  options?: UseWebMCPOptions,
+): void;
+/** Register one existing plain Tool. */
+export function useWebMCP<TInput, TOutput>(
+  tool: Tool<TInput, TOutput>,
+  options?: UseWebMCPOptions,
+): void;
+/** Register an existing readonly collection of compatible tools. */
+export function useWebMCP<const Tools extends readonly RegistrableTool[]>(
+  tools: Tools,
+  options?: UseWebMCPOptions,
+): void;
 
 /**
  * React hook that registers one or more WebMCP tools on mount and unregisters
  * them on unmount. Registration changes only when discoverable metadata,
- * `enabled`, or `exposedTo` values change; execute callbacks always use the
- * latest committed render.
+ * `enabled`, or `exposedTo` values change; schemas and execute callbacks always
+ * use the latest committed render.
  *
  * On browsers that don't expose `document.modelContext` (or the legacy
  * `navigator.modelContext`), the hook is a no-op.
  */
-export const useWebMCP = (
-  toolOrTools: Tool | readonly Tool[],
+export function useWebMCP(
+  toolOrTools: RegistrableTool | readonly RegistrableTool[],
   options?: UseWebMCPOptions,
-): void => {
+): void {
   const enabled = options?.enabled ?? true;
   const exposedTo = options?.exposedTo;
-  const tools: readonly Tool[] = Array.isArray(toolOrTools)
+  const tools: readonly RegistrableTool[] = Array.isArray(toolOrTools)
     ? toolOrTools
-    : [toolOrTools];
-  const latestExecutors = useRef<readonly Tool["execute"][]>(
-    tools.map((tool) => tool.execute),
+    : [toolOrTools as RegistrableTool];
+  const latestTools = useRef<readonly Tool[]>(
+    tools.map((tool) => normalizeToolDefinition(tool)),
   );
   const activeRegistration = useRef<ActiveRegistration | undefined>(undefined);
 
   useCommitEffect(() => {
-    latestExecutors.current = tools.map((tool) => tool.execute);
+    latestTools.current = tools.map((tool) => normalizeToolDefinition(tool));
   });
 
   useEffect(() => {
@@ -123,7 +158,7 @@ export const useWebMCP = (
 
     const registerOptions: RegisterToolOptions | undefined =
       exposedTo === undefined ? undefined : { exposedTo };
-    const cleanups = wrapTools(tools, latestExecutors).map((tool) =>
+    const cleanups = wrapTools(tools, latestTools).map((tool) =>
       registerTool(tool, registerOptions),
     );
     activeRegistration.current = {
@@ -141,7 +176,7 @@ export const useWebMCP = (
     },
     [],
   );
-};
+}
 
 export type {
   DefineToolOptions,
@@ -149,6 +184,7 @@ export type {
   StandardSchemaV1,
   Tool,
   ToolAnnotations,
+  ToolDefinition,
 } from "../index.js";
 export {
   defineTool,

--- a/packages/webmcp/src/tool.ts
+++ b/packages/webmcp/src/tool.ts
@@ -11,7 +11,7 @@ export interface ToolAnnotations {
   openWorldHint?: boolean;
 }
 
-export interface Tool<TInput = unknown, TOutput = unknown> {
+export interface ToolMetadata {
   name: string;
   /** Optional human-readable title for display in host user interfaces. */
   title?: string;
@@ -23,6 +23,10 @@ export interface Tool<TInput = unknown, TOutput = unknown> {
   destructive?: boolean;
   /** Raw passthrough; merged on top of the shorthand flags. */
   annotations?: ToolAnnotations;
+}
+
+export interface Tool<TInput = unknown, TOutput = unknown>
+  extends ToolMetadata {
   execute: (input: TInput) => Promise<TOutput> | TOutput;
 }
 
@@ -36,7 +40,7 @@ export interface RegisteredToolMetadata {
 
 /** Build the discoverable metadata exactly as it is sent to the WebMCP host. */
 export const toRegisteredToolMetadata = (
-  tool: Tool,
+  tool: ToolMetadata,
 ): RegisteredToolMetadata => {
   const annotations: ToolAnnotations = {
     ...(tool.readOnly ? { readOnlyHint: true } : {}),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -83,9 +83,9 @@ importers:
       sharp:
         specifier: ^0.35.3
         version: 0.35.3(@types/node@26.1.1)
-      valibot:
-        specifier: ^1.4.0
-        version: 1.4.2(typescript@6.0.3)
+      zod:
+        specifier: ^4.4.3
+        version: 4.4.3
     devDependencies:
       '@astrojs/check':
         specifier: ^0.9.10
@@ -3965,14 +3965,6 @@ packages:
 
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
-
-  valibot@1.4.2:
-    resolution: {integrity: sha512-gjdCvJ6d3RyHAneqxMYMW9QMCwYMb3jpOO0IyHZV1bnRHFBHrX3VkIILt5XYR0WhwHiH7Mty8ovuPZ/O3gamrg==}
-    peerDependencies:
-      typescript: '>=5'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
 
   vfile-location@5.0.3:
     resolution: {integrity: sha512-5yXvWDEgqeiYiBe1lbxYF7UMAIm/IcopxMHrMQDq3nvKcjPKIhZklUKL+AE7J7uApI4kwe2snsK+eI6UTj9EHg==}
@@ -8294,10 +8286,6 @@ snapshots:
   url-extras@0.1.0: {}
 
   util-deprecate@1.0.2: {}
-
-  valibot@1.4.2(typescript@6.0.3):
-    optionalDependencies:
-      typescript: 6.0.3
 
   vfile-location@5.0.3:
     dependencies:


### PR DESCRIPTION
## Summary

- accept Standard Schema input and output schemas directly in `registerTool()` and `useWebMCP()`
- infer validated and transformed values in `execute`
- preserve typed input/output validation errors
- share normalization between vanilla and React registration
- keep `defineTool()` as a deprecated compatibility wrapper
- update documentation, demos, and Playground to use the primary API
- standardize first-party WebMCP schemas on Zod 4 and derive native JSON Schema with `z.toJSONSchema()`
- add a user-facing changeset

## Why

Standard Schema support previously lived behind `defineTool()`, creating two definition paths for the same runtime concept. Schema-aware definitions can now use the same registration path as plain tools without adding a validation dependency to the SDK.

The browser-facing `inputSchema` remains explicit. Consumers can derive it from their validation schema while retaining control over the converter and JSON Schema dialect.

## Validation

- `pnpm gate`
- production `build` and `preview`
- Chrome DevTools MCP smoke tests covering:
  - native WebMCP availability
  - home, docs, and Playground tool registration
  - Zod-generated Draft 2020-12 schemas
  - valid and invalid execution
  - React registration and cleanup
  - console and network health

Closes #175
