### PR TITLE
feat(webmcp): expose tool discovery and execution

### DIFF
--- a/.changeset/brave-files-doubt.md
+++ b/.changeset/brave-files-doubt.md
@@ -1,0 +1,6 @@
+---
+"@web-ai-sdk/webmcp": minor
+"@web-ai-sdk/all": minor
+---
+
+Expose WebMCP tool discovery, execution, and reactive retrieval through getTools(), executeTool(), and the useWebMCP() return value.

--- a/apps/site/src/content/docs/guides/meta-package.mdx
+++ b/apps/site/src/content/docs/guides/meta-package.mdx
@@ -32,7 +32,7 @@ import { detect } from "@web-ai-sdk/all/detector";
 import { write } from "@web-ai-sdk/all/writer";
 import { rewrite } from "@web-ai-sdk/all/rewriter";
 import { proofread } from "@web-ai-sdk/all/proofreader";
-import { registerTool } from "@web-ai-sdk/all/webmcp";
+import { executeTool, getTools, registerTool } from "@web-ai-sdk/all/webmcp";
 ```
 
 ```tsx
@@ -48,6 +48,7 @@ import { prompt, summarizer, translator, detector, writer, rewriter, proofreader
 await prompt.ask({ input: "Hello" });
 await summarizer.summarize({ language: "en", input: longText });
 await translator.translate({ input: "Olá", sourceLanguage: "pt", targetLanguage: "en" });
+const tools = await webmcp.getTools();
 ```
 
 Why namespaced and not flat? Names like `isAvailable` and `checkAvailability` appear in every package, so a flat re-export at the root would collide. Namespacing keeps each block's surface intact.

--- a/apps/site/src/content/docs/guides/webmcp.mdx
+++ b/apps/site/src/content/docs/guides/webmcp.mdx
@@ -1,9 +1,9 @@
 ---
 title: WebMCP
-description: web-ai-sdk wrapper to register agent-callable tools on the W3C WebMCP surface (document.modelContext) with AbortSignal-based cleanup.
+description: Register, discover, and execute agent-callable tools on the W3C WebMCP surface through typed vanilla and React SDK APIs.
 ---
 
-Building block for the W3C [WebMCP](https://webmachinelearning.github.io/webmcp/) API exposed at `document.modelContext`. (For backward compatibility with the previous shape of the API, this package also reads from `navigator.modelContext`.) Register agent-callable tools from any framework; the package is vanilla TypeScript / DOM with an optional React adapter shipped as a subpath export. See [useWebMCP](/docs/react/use-web-mcp/) for React.
+Building block for the W3C [WebMCP](https://webmachinelearning.github.io/webmcp/) API exposed at `document.modelContext`. (For backward compatibility with the previous shape of the API, this package also reads from `navigator.modelContext`.) Register, discover, and execute agent-callable tools from any framework; the package is vanilla TypeScript / DOM with an optional React adapter shipped as a subpath export. See [useWebMCP](/docs/react/use-web-mcp/) for React.
 
 Where the Built-in AI APIs make the browser an AI runtime, WebMCP makes your page an agent surface: instead of a visiting agent guessing what your interface elements do, the page declares structured tools the agent can discover and call.
 
@@ -43,6 +43,34 @@ To register many at once, map over the array and combine the cleanups:
 const cleanups = tools.map(registerTool);
 const cleanup = () => cleanups.forEach((c) => c());
 ```
+
+## Discover and execute tools
+
+Use SDK primitives rather than reaching through `document.modelContext` directly. `getTools()` returns the browser-facing metadata for tools exposed to the current document; `executeTool()` accepts one of those returned objects and serializes the JavaScript input value for the native call.
+
+```ts
+import {
+  executeTool,
+  getTools,
+  subscribeToToolChanges,
+} from "@web-ai-sdk/webmcp";
+
+const tools = await getTools();
+const echo = tools.find((tool) => tool.name === "echo_message");
+
+if (echo) {
+  const result = await executeTool(echo, { message: "hello" });
+  console.log(result);
+}
+
+const unsubscribe = subscribeToToolChanges(() => {
+  void getTools().then(renderToolList);
+});
+```
+
+`getTools({ fromOrigins })` can additionally request tools from descendant documents at listed secure origins. Cross-origin tools are returned only when the registering document also exposed them to the caller's origin. The browser returns each `inputSchema` as a serialized JSON string and includes the registering `window` and `origin`.
+
+`executeTool()` returns the native serialized string unchanged; `null` means the tool triggered navigation. It is implemented and publicly documented by Chromium but is not yet in the published WebMCP community-draft IDL, so the SDK marks it experimental.
 
 ## Tool
 
@@ -112,7 +140,7 @@ maintaining a second handwritten definition.
 
 </div>
 
-## Returns
+## Registration cleanup
 
 `registerTool(tool, options?)` returns a cleanup function: `() => void`. Calling it unregisters the tool. Calling it twice is a no-op. On browsers without `document.modelContext` (or the legacy `navigator.modelContext`), the cleanup is itself a no-op.
 
@@ -120,7 +148,7 @@ maintaining a second handwritten definition.
 
 `document.modelContext.registerTool({...}, { signal, exposedTo })` is the spec entry point. (For backward compatibility with the previous shape of the API, this package also reads from `navigator.modelContext`.) The wrapper sits on top with these quality-of-life additions:
 
-- **Feature detection.** On browsers without `document.modelContext` (or the legacy `navigator.modelContext`), every entry point is a no-op so consumer code ships unchanged. `isAvailable()` returns `false`.
+- **Feature detection.** On browsers without `document.modelContext` (or the legacy `navigator.modelContext`), registration and subscriptions are no-ops, discovery resolves to `[]`, and `isAvailable()` returns `false`. Execution rejects with `WebMCPUnavailableError` so missing support is distinct from a `null` navigation result.
 - **Last-writer-wins on duplicate names.** React effect cleanup is asynchronous; a fast re-render can attempt to register `"foo"` before Chrome processed the prior `abort()`. The wrapper detects the resulting duplicate-name error, queues a microtask retry, and tracks ownership so a stale registration can't squat the name.
 - **One AbortController per call.** `registerTool` returns a cleanup function that aborts the underlying controller and unregisters the tool.
 - **Library-neutral validation.** Direct definitions may carry Standard Schema input and output validators. The SDK validates and transforms around `execute`, then strips those SDK-only fields before native registration.
@@ -136,6 +164,14 @@ const cleanup = registerTool(tool, {
 ```
 
 The SDK forwards the array unchanged alongside its internally owned `AbortSignal`. The browser validates each origin and rejects invalid or untrustworthy values. Those asynchronous failures follow the package's existing non-throwing registration posture: they are logged without creating an unhandled rejection. Grant access only to origins that genuinely need it; `exposedTo` is exposure configuration, not an authorization layer.
+
+An in-page agent or inspector requests those cross-origin tools with the complementary discovery option:
+
+```ts
+const tools = await getTools({
+  fromOrigins: ["https://tool-provider.example"],
+});
+```
 
 ## Annotations
 
@@ -171,7 +207,7 @@ A tool is a semantic interface, not just a function: the agent selects tools by 
 
 ## Errors and unavailability
 
-The wrapper never throws on missing API; it's a no-op. The vanilla functions return a no-op cleanup, so consumer code stays declarative:
+Registration and event subscription never throw for a missing API; they return no-op cleanups. Discovery returns an empty list. Tool execution is different because `null` already means that execution triggered a navigation, so missing support rejects with the typed `WebMCPUnavailableError`:
 
 ```ts
 import { registerTool, isAvailable } from "@web-ai-sdk/webmcp";
@@ -183,6 +219,8 @@ if (!isAvailable()) {
 
 registerTool({ ... });
 ```
+
+Native `getTools()` errors remain observable, including invalid or untrustworthy `fromOrigins`, denied permissions policy, and detached-document failures. `executeTool()` also preserves native execution and cancellation failures.
 
 When a direct definition includes `input`, invalid input rejects with
 `ToolValidationError` before `execute` runs. When it includes `output`, an

--- a/apps/site/src/content/docs/packages/all.md
+++ b/apps/site/src/content/docs/packages/all.md
@@ -47,7 +47,7 @@ import { detect } from "@web-ai-sdk/all/detector";
 import { write } from "@web-ai-sdk/all/writer";
 import { rewrite } from "@web-ai-sdk/all/rewriter";
 import { proofread } from "@web-ai-sdk/all/proofreader";
-import { registerTool } from "@web-ai-sdk/all/webmcp";
+import { executeTool, getTools, registerTool } from "@web-ai-sdk/all/webmcp";
 ```
 
 ```tsx
@@ -62,6 +62,7 @@ import { prompt, summarizer, translator, detector, writer, rewriter, proofreader
 
 await prompt.ask({ input: "Hello" });
 await summarizer.summarize({ language: "en", input: document.body.innerText });
+const tools = await webmcp.getTools();
 ```
 
 The root entry namespaces each scoped package because several exports (e.g. `checkAvailability`, `isAvailable`, `defaultCacheKey`) appear in more than one package and would collide on a flat re-export.

--- a/apps/site/src/content/docs/packages/webmcp.md
+++ b/apps/site/src/content/docs/packages/webmcp.md
@@ -10,12 +10,12 @@ This page is synced from [`packages/webmcp/README.md`](https://github.com/obetom
 
 web-ai-sdk building block for the W3C [WebMCP](https://webmachinelearning.github.io/webmcp/) API exposed at `document.modelContext`. (For backward compatibility with the previous shape of the API, this package also reads from `navigator.modelContext`.)
 
-An ergonomic, framework-agnostic adapter over the native browser API, with safe register/unregister cleanup and a feature-detected no-op fallback for non-supporting browsers.
+An ergonomic, framework-agnostic adapter over the native browser API, with safe register/unregister cleanup, typed tool discovery and execution, and progressive fallback behavior for non-supporting browsers.
 
 
 ## Status
 
-WebMCP shipped as an early preview in Chrome 146+ behind `chrome://flags/#enable-webmcp-testing`; a public [origin trial](https://developer.chrome.com/docs/ai/webmcp) opens in Chrome 149. Edge added support in 147+ behind the matching `edge://flags/` toggle. On any browser that doesn't expose `document.modelContext` (or the legacy `navigator.modelContext`), this library is a no-op. Your app stays callable, and no tools get registered. A WebMCP spec update changed `registerTool` to return a Promise (cross-origin iframe tool sharing made registration asynchronous); this adapter normalizes both the legacy synchronous shape and the async shape, so consumer code is unchanged.
+WebMCP shipped as an early preview in Chrome 146+ behind `chrome://flags/#enable-webmcp-testing`; a public [origin trial](https://developer.chrome.com/docs/ai/webmcp) opens in Chrome 149. Edge added support in 147+ behind the matching `edge://flags/` toggle. On browsers without WebMCP, registration is a no-op and discovery returns an empty list; execution rejects with `WebMCPUnavailableError` so a missing capability cannot be confused with a navigation result. A WebMCP spec update changed `registerTool` to return a Promise (cross-origin iframe tool sharing made registration asynchronous); this adapter normalizes both the legacy synchronous shape and the async shape, so consumer code is unchanged.
 
 ## Install
 
@@ -88,7 +88,7 @@ import { z } from "zod"; // Zod 4; other Standard Schema libraries work too
 const SearchPostsInput = z.object({ query: z.string().min(1) });
 
 export function WebMCP({ isSignedIn }: { isSignedIn: boolean }) {
-  useWebMCP(
+  const { tools, status } = useWebMCP(
     {
       name: "search_blog_posts",
       description: "Search published blog posts.",
@@ -105,11 +105,14 @@ export function WebMCP({ isSignedIn }: { isSignedIn: boolean }) {
     },
     { enabled: isSignedIn },
   );
-  return null;
+
+  return <p>{status === "ready" ? `${tools.length} tools` : status}</p>;
 }
 ```
 
-The hook accepts one tool or a readonly array. It registers on mount, unregisters on unmount, and cleans up immediately when `enabled` changes to `false`. Registration follows discoverable metadata and `exposedTo` values rather than object identity, while `execute` always uses the latest committed callback. Inline tool objects, arrays, and options are safe: changing React state alone does not rebuild the registration, but changing a tool's name, title, description, schema, annotations, or exposure does. Memoize tool arrays and large schemas when practical to avoid rebuilding and comparing their metadata on every render; correctness does not depend on memoization.
+`useWebMCP` accepts one tool or a readonly array. It registers on mount, unregisters on unmount, and cleans up immediately when `enabled` changes to `false`. Registration follows discoverable metadata and `exposedTo` values rather than object identity, while `execute` always uses the latest committed callback. Inline tool objects, arrays, and options are safe: changing React state alone does not rebuild the registration, but changing a tool's name, title, description, schema, annotations, or exposure does. Memoize tool arrays and large schemas when practical to avoid rebuilding and comparing their metadata on every render; correctness does not depend on memoization.
+
+The same hook retrieves every tool exposed to the current document and refreshes the returned list after native `toolchange` events. Its `refresh()` method performs an explicit fresh read. Call `useWebMCP({ fromOrigins })` without definitions for retrieval-only use. Memoize `fromOrigins` arrays passed to the hook because they participate in its effect dependencies by reference.
 
 ## API
 
@@ -135,6 +138,66 @@ const cleanup = registerTool(tool, {
 ```
 
 The SDK forwards the array unchanged alongside its internally owned `AbortSignal`. The browser validates each origin and rejects invalid or untrustworthy values; the wrapper preserves its non-throwing registration posture and logs that failure. Exposure is unnecessary for the owning document and should be limited to origins that genuinely need access.
+
+### `getTools(options?): Promise<RegisteredTool[]>`
+
+Discover tools exposed to the current document. The returned metadata is sorted by the browser and includes the registering `window` and `origin`. `inputSchema`, when present, is the browser's serialized JSON Schema string.
+
+```ts
+import { getTools } from "@web-ai-sdk/webmcp";
+
+const sameOriginTools = await getTools();
+const toolsAcrossFrames = await getTools({
+  fromOrigins: ["https://agent.example"],
+});
+```
+
+The browser always includes eligible same-origin tools. `fromOrigins` additionally requests tools from listed secure origins; those tools must also have exposed themselves to the caller's origin. Unsupported browsers resolve to `[]`. Native permission, origin-validation, and document-state errors remain observable as rejected promises.
+
+### `executeTool(tool, input?, options?): Promise<string | null>`
+
+Execute a `RegisteredTool` returned by `getTools()`. Pass the JavaScript input value; the SDK serializes it to the JSON argument string expected by the browser.
+
+```ts
+import { executeTool, getTools } from "@web-ai-sdk/webmcp";
+
+const tools = await getTools();
+const echo = tools.find((tool) => tool.name === "echo_message");
+if (echo) {
+  const result = await executeTool(echo, { message: "hello" });
+  console.log(result);
+}
+```
+
+The native serialized string is returned unchanged. `null` means tool execution triggered a navigation. Pass `{ signal }` to cancel an in-flight call. Unsupported browsers reject with `WebMCPUnavailableError`.
+
+`executeTool()` is experimental: Chromium implements and publicly documents it, but it is not yet present in the published WebMCP community-draft IDL.
+
+### `subscribeToToolChanges(listener): () => void`
+
+Listen for native `toolchange` events and return an idempotent cleanup function:
+
+```ts
+const unsubscribe = subscribeToToolChanges(() => {
+  void getTools().then(renderTools);
+});
+```
+
+On unsupported browsers, subscription and cleanup are no-ops.
+
+### `RegisteredTool`
+
+```ts
+interface RegisteredTool {
+  name: string;
+  title?: string;
+  description: string;
+  inputSchema?: string;
+  window: Window;
+  origin: string;
+  annotations?: ToolAnnotations;
+}
+```
 
 ### `isAvailable(): boolean`
 

--- a/apps/site/src/content/docs/packages/webmcp.md
+++ b/apps/site/src/content/docs/packages/webmcp.md
@@ -112,7 +112,7 @@ export function WebMCP({ isSignedIn }: { isSignedIn: boolean }) {
 
 `useWebMCP` accepts one tool or a readonly array. It registers on mount, unregisters on unmount, and cleans up immediately when `enabled` changes to `false`. Registration follows discoverable metadata and `exposedTo` values rather than object identity, while `execute` always uses the latest committed callback. Inline tool objects, arrays, and options are safe: changing React state alone does not rebuild the registration, but changing a tool's name, title, description, schema, annotations, or exposure does. Memoize tool arrays and large schemas when practical to avoid rebuilding and comparing their metadata on every render; correctness does not depend on memoization.
 
-The same hook retrieves every tool exposed to the current document and refreshes the returned list after native `toolchange` events. Its `refresh()` method performs an explicit fresh read. Call `useWebMCP({ fromOrigins })` without definitions for retrieval-only use. Memoize `fromOrigins` arrays passed to the hook because they participate in its effect dependencies by reference.
+The same hook retrieves every tool exposed to the current document and refreshes the returned list after native `toolchange` events. Its `refresh()` method performs an explicit fresh read. Call `useWebMCP({ fromOrigins })` without definitions for retrieval-only use. Inline `fromOrigins` arrays are safe; discovery restarts only when their values change.
 
 ## API
 

--- a/apps/site/src/content/docs/react/use-web-mcp.mdx
+++ b/apps/site/src/content/docs/react/use-web-mcp.mdx
@@ -1,17 +1,17 @@
 ---
 title: useWebMCP
-description: React adapter for @web-ai-sdk/webmcp. Register WebMCP tools on mount, unregister on unmount, last-writer-wins re-registration.
+description: Register WebMCP tools and reactively retrieve every tool exposed to the current document through one React hook.
 ---
 
 import { WebMCPDemo } from "../../../features/docs/components/WebMCPDemo.tsx";
 
-React adapter for `@web-ai-sdk/webmcp`. Registers WebMCP tools on mount and unregisters them on unmount via an `AbortSignal`. For the conceptual overview see [WebMCP](/docs/guides/webmcp/).
+React adapter for `@web-ai-sdk/webmcp`. `useWebMCP` registers tools with component lifecycle cleanup and returns every tool exposed to the current document, refreshing after native `toolchange` events. For the conceptual overview see [WebMCP](/docs/guides/webmcp/).
 
 ## Live demo
 
 <WebMCPDemo client:only="react" />
 
-Use the invoke controls below to call a registered tool. On browsers with WebMCP enabled the demo asks Chrome's testing surface (`navigator.modelContextTesting.executeTool`) to dispatch the selected live tool.
+Use the invoke controls below to call a registered tool. The demo reads live tools from `useWebMCP()` and dispatches the selected `RegisteredTool` through the SDK's `executeTool()` helper.
 
 ## Usage
 
@@ -22,7 +22,7 @@ import { z } from "zod"; // Zod 4; other Standard Schema libraries work too
 const AddToCartInput = z.object({ sku: z.string().min(1) });
 
 export function AgentTools({ isSignedIn }: { isSignedIn: boolean }) {
-  useWebMCP(
+  const { tools, status } = useWebMCP(
     {
       name: "add_to_cart",
       title: "Add to cart",
@@ -36,7 +36,7 @@ export function AgentTools({ isSignedIn }: { isSignedIn: boolean }) {
     },
     { enabled: isSignedIn },
   );
-  return null; // pure logic; render whatever UI you want elsewhere
+  return <p>{status === "ready" ? `${tools.length} tools` : status}</p>;
 }
 ```
 
@@ -80,6 +80,51 @@ The hook compares discoverable metadata and `exposedTo` values rather than objec
 
 Memoize tool arrays and large schemas when practical to avoid rebuilding and comparing their metadata on every render. Memoization is a performance optimization here, not a correctness requirement.
 
+## Retrieve exposed tools
+
+The hook return always describes the complete browser-facing tool list, not only definitions passed into that hook call. Call `useWebMCP()` without definitions whenever a component needs retrieval only:
+
+```tsx
+import {
+  executeTool,
+  useWebMCP,
+} from "@web-ai-sdk/webmcp/react";
+
+export function ToolInspector() {
+  const { tools, status, error, refresh } = useWebMCP();
+
+  if (status === "unavailable") return <p>WebMCP unavailable</p>;
+  if (status === "loading") return <p>Discovering tools…</p>;
+  if (error) return <p>{error.message}</p>;
+
+  return (
+    <>
+      <ul>
+        {tools.map((tool) => (
+          <li key={`${tool.origin}:${tool.name}`}>
+            <button onClick={() => void executeTool(tool, {})}>
+              {tool.title || tool.name}
+            </button>
+          </li>
+        ))}
+      </ul>
+      <button onClick={() => void refresh()}>Refresh</button>
+    </>
+  );
+}
+```
+
+The status is `"idle" | "loading" | "ready" | "unavailable" | "error"`. `refresh()` resolves to the fresh list as well as updating hook state.
+
+Pass `fromOrigins` to request eligible tools exposed by descendant documents at specific secure origins:
+
+```tsx
+const TRUSTED_ORIGINS = ["https://agent.example"] as const;
+const discovery = useWebMCP({ fromOrigins: TRUSTED_ORIGINS });
+```
+
+The browser always includes eligible same-origin tools. Cross-origin discovery additionally requires the registering document to include the caller in its `exposedTo` option. Memoize render-created `fromOrigins` arrays because they participate in the hook's effect dependencies by reference.
+
 ## Cross-document exposure
 
 Pass `exposedTo` through the hook when descendant documents at other origins should discover the tool:
@@ -114,11 +159,15 @@ Rerendering `SettingsTool` with a new `pane` updates execution immediately witho
 
 ## Cleanup
 
-The hook returns nothing; cleanup is automatic on unmount via `useEffect`'s return value. If you need imperative cleanup (e.g. log out flow), call the vanilla `registerTool` directly per tool and combine the cleanups: `const cleanups = tools.map(registerTool)`.
+Registration cleanup is automatic on unmount via `useEffect`'s return value. If you need imperative cleanup (e.g. log out flow), call the vanilla `registerTool` directly per tool and combine the cleanups: `const cleanups = tools.map(registerTool)`.
+
+The hook removes its `toolchange` subscription on unmount and ignores stale discovery promises. Set `enabled: false` to suspend registration and retrieval and return to `"idle"` state.
 
 ## Errors and unavailability
 
-On browsers without `document.modelContext` (or the legacy `navigator.modelContext`), the hook is a no-op. Render whatever fallback UI you want; nothing breaks.
+On browsers without `document.modelContext` (or the legacy `navigator.modelContext`), registration is a no-op and the hook reports `"unavailable"` with an empty list. Render whatever fallback UI you want; nothing breaks.
+
+Native discovery failures, such as invalid cross-origin filters or denied permissions, produce `status: "error"` and populate `error`; the hook does not reject during render or effects.
 
 Direct definitions with `input` reject with `ToolValidationError` before application code runs when validation fails. Definitions with `output` reject with `ToolOutputValidationError` when the resolved result fails validation. Both schemas may transform values and may validate synchronously or asynchronously. The SDK-only `input` and `output` fields are never forwarded to WebMCP.
 
@@ -129,12 +178,16 @@ Direct definitions with `input` reject with `ToolValidationError` before applica
 ```ts
 import type {
   DefineToolOptions,
+  GetToolsOptions,
+  RegisteredTool,
   RegisterToolOptions,
   StandardSchemaV1,
   Tool,
   ToolAnnotations,
   ToolDefinition,
   UseWebMCPOptions,
+  UseWebMCPReturn,
+  WebMCPStatus,
 } from "@web-ai-sdk/webmcp/react";
 
 interface Tool {
@@ -178,12 +231,40 @@ interface ToolAnnotations {
   openWorldHint?: boolean;         // compatibility
 }
 
+interface RegisteredTool {
+  name: string;
+  title?: string;
+  description: string;
+  inputSchema?: string;
+  window: Window;
+  origin: string;
+  annotations?: ToolAnnotations;
+}
+
+interface GetToolsOptions {
+  fromOrigins?: readonly string[];
+}
+
 interface RegisterToolOptions {
   exposedTo?: readonly string[];
 }
 
-interface UseWebMCPOptions extends RegisterToolOptions {
+type WebMCPStatus =
+  | "idle"
+  | "loading"
+  | "ready"
+  | "unavailable"
+  | "error";
+
+interface UseWebMCPOptions extends GetToolsOptions, RegisterToolOptions {
   enabled?: boolean;
+}
+
+interface UseWebMCPReturn {
+  status: WebMCPStatus;
+  tools: readonly RegisteredTool[];
+  error: Error | null;
+  refresh: () => Promise<readonly RegisteredTool[]>;
 }
 
 declare function useWebMCP(
@@ -192,7 +273,11 @@ declare function useWebMCP(
     | ToolDefinition
     | readonly (Tool | ToolDefinition)[],
   options?: UseWebMCPOptions,
-) => void;
+): UseWebMCPReturn;
+
+declare function useWebMCP(
+  options?: UseWebMCPOptions,
+): UseWebMCPReturn;
 
 // Deprecated compatibility helper. Direct definitions are the primary API.
 /** @deprecated */

--- a/apps/site/src/content/docs/react/use-web-mcp.mdx
+++ b/apps/site/src/content/docs/react/use-web-mcp.mdx
@@ -123,7 +123,7 @@ const TRUSTED_ORIGINS = ["https://agent.example"] as const;
 const discovery = useWebMCP({ fromOrigins: TRUSTED_ORIGINS });
 ```
 
-The browser always includes eligible same-origin tools. Cross-origin discovery additionally requires the registering document to include the caller in its `exposedTo` option. Memoize render-created `fromOrigins` arrays because they participate in the hook's effect dependencies by reference.
+The browser always includes eligible same-origin tools. Cross-origin discovery additionally requires the registering document to include the caller in its `exposedTo` option. Inline `fromOrigins` arrays are safe; the hook refreshes discovery only when their values change.
 
 ## Cross-document exposure
 

--- a/apps/site/src/features/docs/components/WebMCPDemo.tsx
+++ b/apps/site/src/features/docs/components/WebMCPDemo.tsx
@@ -1,25 +1,18 @@
-import { isAvailable, type ToolDefinition } from "@web-ai-sdk/webmcp";
+import {
+  executeTool,
+  isAvailable,
+  type ToolDefinition,
+} from "@web-ai-sdk/webmcp";
 import { useWebMCP } from "@web-ai-sdk/webmcp/react";
 import { useEffect, useState } from "react";
 import { z } from "zod";
 import { UnavailableHint } from "./UnavailableHint.js";
-
-interface ModelContextTesting {
-  // Native Chrome serializes the result to a JSON string before returning.
-  executeTool(name: string, input?: string): Promise<string>;
-}
 
 const ListDemoItemsOutput = z.object({ items: z.array(z.string()) });
 const EchoMessageInput = z.strictObject({
   message: z.string().min(1).max(200),
 });
 const EchoMessageOutput = z.object({ echoed: z.string() });
-
-const getTesting = (): ModelContextTesting | undefined => {
-  if (typeof navigator === "undefined") return undefined;
-  return (navigator as unknown as { modelContextTesting?: ModelContextTesting })
-    .modelContextTesting;
-};
 
 export const WebMCPDemo = () => {
   const [log, setLog] = useState<string[]>([]);
@@ -68,34 +61,34 @@ export const WebMCPDemo = () => {
     >,
   ] as const;
 
-  useWebMCP(tools);
-
-  // The demo registers the `tools` array above via `useWebMCP`, so the
-  // names displayed here are derived directly from what we register, with no
-  // separate `listTools()` read. Avoids races between the registration effect
-  // and a one-shot list read, and behaves identically whether this story
-  // mounts inside the docs Canvas or as a standalone story.
-  const registered = tools.map(({ name, title }) => ({ name, title }));
+  const { tools: discovered, status, error } = useWebMCP(tools);
+  const registered = discovered.filter((tool) =>
+    tools.some((candidate) => candidate.name === tool.name),
+  );
 
   useEffect(() => {
     setAvailable(isAvailable());
   }, []);
 
-  const invoke = async (name: string, input?: string) => {
-    const testing = getTesting();
-    if (!testing) {
-      append(`(no testing surface; cannot invoke ${name})`);
+  const invoke = async (name: string, input: unknown = {}) => {
+    const tool = registered.find((candidate) => candidate.name === name);
+    if (!tool) {
+      append(`(tool is not registered; cannot invoke ${name})`);
       return;
     }
     try {
-      const raw = await testing.executeTool(name, input);
+      const raw = await executeTool(tool, input);
       // executeTool returns a JSON string; re-parse so the rendered output is
       // human-readable instead of double-encoded.
       let pretty: string;
-      try {
-        pretty = JSON.stringify(JSON.parse(raw));
-      } catch {
-        pretty = String(raw);
+      if (raw === null) {
+        pretty = "navigation triggered";
+      } else {
+        try {
+          pretty = JSON.stringify(JSON.parse(raw));
+        } catch {
+          pretty = raw;
+        }
       }
       append(`→ result: ${pretty}`);
     } catch (err) {
@@ -113,6 +106,7 @@ export const WebMCPDemo = () => {
       <p className="demo-muted">
         WebMCP available: <strong>{available ? "yes" : "no"}</strong>
       </p>
+      {error && <p className="demo-muted">Discovery error: {error.message}</p>}
       {!available && (
         <UnavailableHint
           api="WebMCP"
@@ -149,8 +143,8 @@ export const WebMCPDemo = () => {
         <div className="demo-row">
           <button
             type="button"
-            disabled={!getTesting()}
-            onClick={() => invoke("list_demo_items", "{}")}
+            disabled={status !== "ready"}
+            onClick={() => invoke("list_demo_items")}
             className="demo-button demo-button--small"
           >
             list_demo_items
@@ -165,10 +159,8 @@ export const WebMCPDemo = () => {
           />
           <button
             type="button"
-            disabled={!getTesting()}
-            onClick={() =>
-              invoke("echo_message", JSON.stringify({ message: echoInput }))
-            }
+            disabled={status !== "ready"}
+            onClick={() => invoke("echo_message", { message: echoInput })}
             className="demo-button demo-button--small"
           >
             echo_message

--- a/apps/site/src/features/home/components/PackageExplorer.tsx
+++ b/apps/site/src/features/home/components/PackageExplorer.tsx
@@ -81,7 +81,10 @@ const PACKAGE_ROWS: PackageInfo[] = [
         "Last writer wins.",
         "Re-registers on hot reload without duplicate errors.",
       ],
-      ["Spec aligned.", "Wraps document.modelContext verbatim."],
+      [
+        "SDK-first surface.",
+        "Register, discover, and execute without raw browser globals.",
+      ],
     ],
   },
   {

--- a/apps/site/src/features/home/components/WebMCPDemo.test.tsx
+++ b/apps/site/src/features/home/components/WebMCPDemo.test.tsx
@@ -1,0 +1,128 @@
+// @vitest-environment happy-dom
+
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { WebMCPDemo } from "./WebMCPDemo.js";
+
+const mocks = vi.hoisted(() => {
+  const tools = [
+    {
+      name: "get_web_ai_sdk_resources",
+      description: "List SDK resources",
+    },
+    { name: "add_to_cart", description: "Add a SKU to the cart" },
+    { name: "search_orders", description: "Search past orders" },
+  ];
+
+  return {
+    ask: vi.fn(async (_options: { input: string }) => ({ output: "" })),
+    executeTool: vi.fn(async () => '{"ok":true}'),
+    promptAvailable: false,
+    refresh: vi.fn(async () => tools),
+    tools,
+  };
+});
+
+vi.mock("@web-ai-sdk/prompt", () => ({
+  ask: mocks.ask,
+  isAvailable: () => mocks.promptAvailable,
+  PromptUnavailableError: class PromptUnavailableError extends Error {},
+}));
+
+vi.mock("@web-ai-sdk/webmcp", () => ({
+  executeTool: mocks.executeTool,
+  getTools: vi.fn(async () => mocks.tools),
+  isAvailable: () => true,
+}));
+
+vi.mock("@web-ai-sdk/webmcp/react", () => ({
+  useWebMCP: () => ({
+    tools: mocks.tools,
+    status: "ready",
+    error: null,
+    refresh: mocks.refresh,
+  }),
+}));
+
+(
+  globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+let root: Root | undefined;
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  mocks.ask.mockClear();
+  mocks.executeTool.mockClear();
+  mocks.promptAvailable = false;
+  mocks.refresh.mockClear();
+});
+
+afterEach(() => {
+  act(() => root?.unmount());
+  root = undefined;
+  document.body.replaceChildren();
+  vi.useRealTimers();
+});
+
+describe("WebMCPDemo", () => {
+  it("reports the complete discovery count and executes schema-valid cart arguments", async () => {
+    const container = document.createElement("div");
+    document.body.append(container);
+    root = createRoot(container);
+
+    act(() => root?.render(<WebMCPDemo />));
+
+    expect(container.textContent).toContain("2 demo tools registered");
+
+    const runButton = [...container.querySelectorAll("button")].find((button) =>
+      button.textContent?.includes("Run agent"),
+    );
+    expect(runButton).toBeDefined();
+
+    await act(async () => {
+      runButton?.click();
+      await vi.runAllTimersAsync();
+    });
+
+    expect(container.textContent).toContain(
+      "getTools() → 3 tools (2 in this demo)",
+    );
+    expect(mocks.executeTool).toHaveBeenCalledWith(mocks.tools[1], {
+      sku: "MX-200",
+      quantity: 2,
+    });
+  });
+
+  it("gives the on-device router the registered input schema", async () => {
+    mocks.promptAvailable = true;
+    mocks.ask.mockResolvedValue({
+      output:
+        '{"tool":"add_to_cart","args":{"sku":"MX-200","quantity":2},"reason":"Add the requested item."}',
+    });
+    const container = document.createElement("div");
+    document.body.append(container);
+    root = createRoot(container);
+
+    act(() => root?.render(<WebMCPDemo />));
+    const runButton = [...container.querySelectorAll("button")].find((button) =>
+      button.textContent?.includes("Run agent"),
+    );
+
+    await act(async () => {
+      runButton?.click();
+      await vi.runAllTimersAsync();
+    });
+
+    const request = mocks.ask.mock.calls[0]?.[0] as
+      | { input: string }
+      | undefined;
+    expect(request?.input).toContain("input schema:");
+    expect(request?.input).toContain('"quantity"');
+    expect(mocks.executeTool).toHaveBeenCalledWith(mocks.tools[1], {
+      sku: "MX-200",
+      quantity: 2,
+    });
+  });
+});

--- a/apps/site/src/features/home/components/WebMCPDemo.tsx
+++ b/apps/site/src/features/home/components/WebMCPDemo.tsx
@@ -4,6 +4,8 @@ import {
   PromptUnavailableError,
 } from "@web-ai-sdk/prompt";
 import {
+  executeTool,
+  getTools,
   isAvailable as isWebMcpAvailable,
   type StandardSchemaV1,
 } from "@web-ai-sdk/webmcp";
@@ -126,19 +128,6 @@ type TraceEvent =
   | { kind: "result"; text: string }
   | { kind: "call"; tool: string; args: unknown; reason: string };
 
-interface ToolTestingSurface {
-  listTools: () => Array<{ name: string }>;
-  executeTool: (name: string, input?: string) => Promise<string>;
-}
-
-const getTestingSurface = (): ToolTestingSurface | null => {
-  if (typeof navigator === "undefined") return null;
-  return (
-    (navigator as unknown as { modelContextTesting?: ToolTestingSurface })
-      .modelContextTesting ?? null
-  );
-};
-
 export const WebMCPDemo = () => {
   const [enabledIds, setEnabledIds] = useState<Set<string>>(
     () => new Set(TOOL_SPECS.filter((t) => t.on).map((t) => t.id)),
@@ -168,23 +157,31 @@ export const WebMCPDemo = () => {
       ...(spec.destructive ? { destructive: true } : {}),
       execute:
         spec.id === "open_settings"
-          ? async () => ({
-              ok: true,
-              // Only the actually-registered tools. A disabled tool is not
-              // in the model context at all, so listing it here would be
-              // inaccurate.
-              registered: TOOL_SPECS.filter((t) => enabledIds.has(t.id)).map(
-                (t) => ({
-                  name: t.name,
-                  title: t.title,
-                  description: t.desc,
-                }),
-              ),
-            })
+          ? async () => {
+              const registered = await getTools();
+              return {
+                ok: true,
+                registered: registered
+                  .filter((tool) =>
+                    TOOL_SPECS.some(
+                      (candidate) => candidate.name === tool.name,
+                    ),
+                  )
+                  .map(({ name, title, description }) => ({
+                    name,
+                    title,
+                    description,
+                  })),
+              };
+            }
           : spec.execute,
     }));
   }, [enabledIds]);
-  useWebMCP(tools);
+  const {
+    tools: discoveredTools,
+    status: discoveryStatus,
+    refresh: refreshDiscoveredTools,
+  } = useWebMCP(tools);
 
   const toggle = (id: string) =>
     setEnabledIds((prev) => {
@@ -214,12 +211,21 @@ export const WebMCPDemo = () => {
       await new Promise((r) => setTimeout(r, delay));
     };
 
-    const enabledCount = enabledIds.size;
-    const enabledSpecs = TOOL_SPECS.filter((t) => enabledIds.has(t.id));
+    const discovered = await refreshDiscoveredTools();
+    const discoveredDemoTools = discovered.filter((tool) =>
+      TOOL_SPECS.some((candidate) => candidate.name === tool.name),
+    );
+    const discoveredNames = new Set(
+      discoveredDemoTools.map(({ name }) => name),
+    );
+    const enabledCount = discoveredDemoTools.length;
+    const enabledSpecs = TOOL_SPECS.filter((tool) =>
+      discoveredNames.has(tool.name),
+    );
     await push(
       {
         kind: "step",
-        text: `document.modelContext.listTools() → ${enabledCount} tool${enabledCount === 1 ? "" : "s"}`,
+        text: `getTools() → ${enabledCount} tool${enabledCount === 1 ? "" : "s"}`,
       },
       200,
     );
@@ -364,26 +370,19 @@ Reply with ONLY valid JSON of the shape {"tool":"name_or_null","args":{},"reason
       280,
     );
 
-    // Invoke the tool via the testing surface when available, otherwise
-    // synthesize the result locally so the trace still resolves.
-    let resultText = "{ ok: true }";
-    const testing = getTestingSurface();
-    if (testing) {
+    let resultText = "null";
+    const registeredTool = discoveredDemoTools.find(
+      (tool) => tool.name === candidate.name,
+    );
+    if (!registeredTool) {
+      resultText = `error: ${candidate.name} is no longer registered`;
+    } else {
       try {
-        const raw = await testing.executeTool(
-          candidate.name,
-          JSON.stringify(chosenArgs),
-        );
-        resultText = typeof raw === "string" ? raw : JSON.stringify(raw);
+        const raw = await executeTool(registeredTool, chosenArgs);
+        resultText = raw ?? "navigation triggered";
       } catch (err) {
         resultText = `error: ${(err as Error)?.message ?? "unknown"}`;
       }
-    } else {
-      // No testing surface; fall back to invoking the *live* registered
-      // execute so open_settings still reports the real registration state.
-      const live = tools.find((t) => t.name === candidate.name);
-      const exec = live?.execute ?? candidate.execute;
-      resultText = JSON.stringify(await exec(chosenArgs));
     }
     await push(
       { kind: "result", text: `↳ ${candidate.name}(...) → ${resultText}` },
@@ -393,7 +392,9 @@ Reply with ONLY valid JSON of the shape {"tool":"name_or_null","args":{},"reason
     setRunning(false);
   };
 
-  const registeredCount = enabledIds.size;
+  const registeredCount = discoveredTools.filter((tool) =>
+    TOOL_SPECS.some((candidate) => candidate.name === tool.name),
+  ).length;
 
   return (
     <div className={card}>
@@ -403,7 +404,8 @@ Reply with ONLY valid JSON of the shape {"tool":"name_or_null","args":{},"reason
           registerTool() · agentic
         </span>
         <span>
-          {registeredCount} tool{registeredCount === 1 ? "" : "s"} registered
+          {discoveryStatus === "loading" ? "…" : registeredCount} tool
+          {registeredCount === 1 ? "" : "s"} registered
         </span>
       </div>
       <div className={cardBody}>

--- a/apps/site/src/features/home/components/WebMCPDemo.tsx
+++ b/apps/site/src/features/home/components/WebMCPDemo.tsx
@@ -60,7 +60,7 @@ interface ToolSpec {
 
 const AddToCartInput = z.strictObject({
   sku: z.string().min(1).describe("The product SKU to add"),
-  qty: z.number().int().min(1).describe("Units to add").optional(),
+  quantity: z.number().int().min(1).describe("Units to add").optional(),
 });
 
 const TOOL_SPECS: readonly ToolSpec[] = [
@@ -218,14 +218,15 @@ export const WebMCPDemo = () => {
     const discoveredNames = new Set(
       discoveredDemoTools.map(({ name }) => name),
     );
-    const enabledCount = discoveredDemoTools.length;
+    const discoveredCount = discovered.length;
+    const demoToolCount = discoveredDemoTools.length;
     const enabledSpecs = TOOL_SPECS.filter((tool) =>
       discoveredNames.has(tool.name),
     );
     await push(
       {
         kind: "step",
-        text: `getTools() → ${enabledCount} tool${enabledCount === 1 ? "" : "s"}`,
+        text: `getTools() → ${discoveredCount} tool${discoveredCount === 1 ? "" : "s"} (${demoToolCount} in this demo)`,
       },
       200,
     );
@@ -250,7 +251,12 @@ export const WebMCPDemo = () => {
         260,
       );
       const toolBlock = enabledSpecs
-        .map((t) => `- ${t.name}: ${t.desc}`)
+        .map((tool) => {
+          const schema = tool.inputSchema
+            ? JSON.stringify(tool.inputSchema)
+            : "no input schema";
+          return `- ${tool.name}: ${tool.desc}\n  input schema: ${schema}`;
+        })
         .join("\n");
       const agentInput = `Registered tools:
 ${toolBlock}
@@ -341,7 +347,7 @@ Reply with ONLY valid JSON of the shape {"tool":"name_or_null","args":{},"reason
       candidate = matched;
       chosenArgs =
         matched.id === "add_to_cart"
-          ? { sku: "MX-200", qty: 2 }
+          ? { sku: "MX-200", quantity: 2 }
           : matched.id === "search_orders"
             ? { since: "last-tuesday" }
             : matched.id === "open_settings"
@@ -404,7 +410,7 @@ Reply with ONLY valid JSON of the shape {"tool":"name_or_null","args":{},"reason
           registerTool() · agentic
         </span>
         <span>
-          {discoveryStatus === "loading" ? "…" : registeredCount} tool
+          {discoveryStatus === "loading" ? "…" : registeredCount} demo tool
           {registeredCount === 1 ? "" : "s"} registered
         </span>
       </div>
@@ -414,7 +420,7 @@ Reply with ONLY valid JSON of the shape {"tool":"name_or_null","args":{},"reason
         )}
         <DownloadNotice progress={progress} />
         <fieldset className={fieldset}>
-          <legend className={fieldLegend}>registered tools</legend>
+          <legend className={fieldLegend}>demo tools</legend>
           <ul className={toolList}>
             {TOOL_SPECS.map((t) => {
               const on = enabledIds.has(t.id);

--- a/apps/site/src/features/playground/Playground.tsx
+++ b/apps/site/src/features/playground/Playground.tsx
@@ -10,8 +10,8 @@ import { useActivityLog } from "./lib/useActivityLog.js";
 import { useAgentThreads } from "./lib/useAgentThreads.js";
 import { useConversationAgent } from "./lib/useConversationAgent.js";
 import { usePlaygroundLayout } from "./lib/usePlaygroundLayout.js";
+import { usePlaygroundWebMCPTools } from "./lib/usePlaygroundWebMCPTools.js";
 import { usePromptReadiness } from "./lib/usePromptReadiness.js";
-import { useWebMCPTools } from "./lib/useWebMCPTools.js";
 
 export function Playground() {
   const layout = usePlaygroundLayout();
@@ -96,15 +96,16 @@ export function Playground() {
     };
   }, [modeMenuOpen]);
 
-  const { available: webmcpAvailable } = useWebMCPTools({
-    threads,
-    activeThread,
-    ops,
-    send,
-    newSession,
-    busy,
-    pushActivity,
-  });
+  const { available: webmcpAvailable, registeredTools: webmcpTools } =
+    usePlaygroundWebMCPTools({
+      threads,
+      activeThread,
+      ops,
+      send,
+      newSession,
+      busy,
+      pushActivity,
+    });
 
   const submitDraft = () => {
     if (!draft.trim() || busy) return;
@@ -233,6 +234,7 @@ export function Playground() {
           promptReadiness={promptReadiness}
           summarizerOn={summarizerOn}
           webmcpAvailable={webmcpAvailable}
+          webmcpToolCount={webmcpTools.length}
           events={eventsLog}
           onHide={layout.hideRuntime}
         />

--- a/apps/site/src/features/playground/README.md
+++ b/apps/site/src/features/playground/README.md
@@ -51,7 +51,7 @@ feature.
 | `lib/useConversationAgent.ts` | Active model session, run ownership, turn completion, and generated titles |
 | `lib/usePlaygroundLayout.ts` | Responsive panel state, sidebar geometry, and resize behavior |
 | `lib/usePromptReadiness.ts` | Optimistic Prompt API capability probing and download polling |
-| `lib/useWebMCPTools.ts` | WebMCP tools that control the Playground |
+| `lib/usePlaygroundWebMCPTools.ts` | WebMCP tools that control the Playground |
 | `lib/useStickToBottom.ts` | User-aware transcript following |
 | `experimental/agent/` | Agent planning and execution runtime |
 | `experimental/playground/` | Modes, tool catalog, low-level renderers, and contextual examples |

--- a/apps/site/src/features/playground/components/RuntimePanel.tsx
+++ b/apps/site/src/features/playground/components/RuntimePanel.tsx
@@ -9,6 +9,7 @@ interface Props {
   promptReadiness: PromptReadiness;
   summarizerOn: boolean;
   webmcpAvailable: boolean;
+  webmcpToolCount: number;
   events: ActivityEvent[];
   onHide: () => void;
 }
@@ -19,6 +20,7 @@ export function RuntimePanel({
   promptReadiness,
   summarizerOn,
   webmcpAvailable,
+  webmcpToolCount,
   events,
   onHide,
 }: Props) {
@@ -58,7 +60,7 @@ export function RuntimePanel({
                 },
                 {
                   label: "WebMCP",
-                  detail: "Conversation controls for browser agents",
+                  detail: `${webmcpToolCount} conversation control${webmcpToolCount === 1 ? "" : "s"} exposed to browser agents`,
                   state: webmcpAvailable ? "ready" : "unavailable",
                 },
               ]}

--- a/apps/site/src/features/playground/experimental/agent/tools/registry.ts
+++ b/apps/site/src/features/playground/experimental/agent/tools/registry.ts
@@ -2,18 +2,12 @@
  * Kit-side tool registry. Doubles as the bridge to `@web-ai-sdk/webmcp`:
  * an app can register a tool once with `registerAgentTool(...)` and the
  * registry will optionally also surface it to external agents through
- * WebMCP (`navigator.modelContext`).
+ * WebMCP (`document.modelContext`).
  *
- * The native WebMCP API does NOT expose enumeration, so this registry is
- * the only source of truth for "all tools available to the in-page agent
- * AND visible to external agents." If you need a fan-out to extensions
- * like Cursor / Claude / the Chrome agent, register through this layer.
- *
- * SDK FOLLOW-UP (sdk/.ideas/agent-prototype-followups.md, Phase 7a):
- * `@web-ai-sdk/webmcp` already owns every registration that flows
- * through `registerTool`. The plan adds `getRegisteredTools()` +
- * `subscribeRegisteredTools()` so this `ToolRegistry` becomes a thin
- * re-export instead of a parallel source of truth.
+ * `@web-ai-sdk/webmcp` exposes native discovery through `getTools()` and the
+ * `useWebMCP()` return value. This registry remains the source of executable
+ * `AgentTool` instances for the playground's in-page planner; WebMCP discovery
+ * returns browser-facing metadata, not the planner's application callbacks.
  */
 
 import {

--- a/apps/site/src/features/playground/experimental/playground/presets.ts
+++ b/apps/site/src/features/playground/experimental/playground/presets.ts
@@ -65,7 +65,7 @@ export const MODES: [AgentMode, ...AgentMode[]] = [
       "You orchestrate the browser's Built-in Web AI APIs and must demonstrate the specialized tools instead of silently replacing them with model knowledge. For translation requests, ALWAYS call `translate_text` for every requested target language; never translate in prose yourself. When the source language is not explicit, call `detect_language` first, then use its top language code as `sourceLanguage` for the translation call(s). After detection, multiple target translations may run in parallel. For requests to summarize supplied text, ALWAYS call `summarize_text`. Report an unavailable/error tool result honestly instead of fabricating the operation.",
     tools: [summarizeTool, translateTool, detectLanguageTool, clockNowTool],
     examples: [
-      'Summarize: "WebMCP exposes browser-page tools to AI agents via navigator.modelContext, mirroring the Model Context Protocol pattern for the web."',
+      'Summarize: "WebMCP exposes browser-page tools to AI agents via document.modelContext, mirroring the Model Context Protocol pattern for the web."',
       "Detect the language of 'こんにちは', then translate it to English and Portuguese.",
       "It's almost lunchtime. What's the current time?",
     ],
@@ -82,7 +82,7 @@ export const MODES: [AgentMode, ...AgentMode[]] = [
       "Fetch https://api.github.com/repos/obetomuniz/web-ai-sdk and tell me how many stars it has.",
       "Summarize https://betomuniz.com/blog/who-owns-the-surface and https://betomuniz.com/blog/the-quiet-ai-war-inside-your-browser",
       "What time is it in Tokyo right now?",
-      'Summarize: "WebMCP exposes browser-page tools to AI agents via navigator.modelContext, mirroring the Model Context Protocol pattern for the web."',
+      'Summarize: "WebMCP exposes browser-page tools to AI agents via document.modelContext, mirroring the Model Context Protocol pattern for the web."',
     ],
   },
   {

--- a/apps/site/src/features/playground/lib/usePlaygroundWebMCPTools.test.ts
+++ b/apps/site/src/features/playground/lib/usePlaygroundWebMCPTools.test.ts
@@ -1,11 +1,11 @@
 import { registerTool } from "@web-ai-sdk/webmcp";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { MODES } from "../experimental/playground/presets.js";
 import type { AgentThread } from "./agentThreads.js";
 import {
   createPlaygroundWebMCPTools,
   type PlaygroundWebMCPContext,
-} from "./useWebMCPTools.js";
+} from "./usePlaygroundWebMCPTools.js";
 
 const conversation: AgentThread = {
   id: "conversation-1",
@@ -50,9 +50,13 @@ type PlaygroundToolDefinition = ReturnType<
 
 const pendingCleanups: Array<() => void> = [];
 
+beforeEach(() => {
+  vi.stubGlobal("document", {});
+});
+
 function registerPlaygroundTools(context: PlaygroundWebMCPContext) {
   const registered = new Map<string, RegisteredTool>();
-  Object.defineProperty(navigator, "modelContext", {
+  Object.defineProperty(document, "modelContext", {
     value: {
       registerTool: (tool: RegisteredTool) => {
         registered.set(tool.name, tool);
@@ -83,10 +87,11 @@ function findDefinition(
 
 afterEach(() => {
   for (const cleanup of pendingCleanups.splice(0)) cleanup();
-  Object.defineProperty(navigator, "modelContext", {
+  Object.defineProperty(document, "modelContext", {
     value: undefined,
     configurable: true,
   });
+  vi.unstubAllGlobals();
 });
 
 describe("createPlaygroundWebMCPTools", () => {

--- a/apps/site/src/features/playground/lib/usePlaygroundWebMCPTools.ts
+++ b/apps/site/src/features/playground/lib/usePlaygroundWebMCPTools.ts
@@ -303,11 +303,16 @@ export function createPlaygroundWebMCPTools(args: PlaygroundWebMCPContext) {
   ] as const;
 }
 
-export function useWebMCPTools(args: PlaygroundWebMCPContext) {
+export function usePlaygroundWebMCPTools(args: PlaygroundWebMCPContext) {
   const available = isWebMCPAvailable();
   const tools = createPlaygroundWebMCPTools(args);
 
-  useWebMCP(tools);
+  const discovery = useWebMCP(tools);
 
-  return { available };
+  return {
+    available,
+    registeredTools: discovery.tools.filter((registered) =>
+      tools.some((definition) => definition.name === registered.name),
+    ),
+  };
 }

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -40,7 +40,7 @@ import { detect } from "@web-ai-sdk/all/detector";
 import { write } from "@web-ai-sdk/all/writer";
 import { rewrite } from "@web-ai-sdk/all/rewriter";
 import { proofread } from "@web-ai-sdk/all/proofreader";
-import { registerTool } from "@web-ai-sdk/all/webmcp";
+import { executeTool, getTools, registerTool } from "@web-ai-sdk/all/webmcp";
 ```
 
 ```tsx
@@ -55,6 +55,7 @@ import { prompt, summarizer, translator, detector, writer, rewriter, proofreader
 
 await prompt.ask({ input: "Hello" });
 await summarizer.summarize({ language: "en", input: document.body.innerText });
+const tools = await webmcp.getTools();
 ```
 
 The root entry namespaces each scoped package because several exports (e.g. `checkAvailability`, `isAvailable`, `defaultCacheKey`) appear in more than one package and would collide on a flat re-export.

--- a/packages/sdk/src/index.test.ts
+++ b/packages/sdk/src/index.test.ts
@@ -21,6 +21,8 @@ describe("web-ai-sdk root namespace", () => {
     expect(typeof sdk.prompt.ask).toBe("function");
     expect(typeof sdk.prompt.createSession).toBe("function");
     expect(typeof sdk.webmcp.registerTool).toBe("function");
+    expect(typeof sdk.webmcp.getTools).toBe("function");
+    expect(typeof sdk.webmcp.executeTool).toBe("function");
     expect(typeof sdk.webmcp.defineTool).toBe("function");
     expect(typeof sdk.summarizer.summarize).toBe("function");
     expect(typeof sdk.translator.translate).toBe("function");
@@ -36,6 +38,8 @@ describe("web-ai-sdk per-package subpaths", () => {
     expect(typeof promptSubpath.ask).toBe("function");
     expect(typeof promptSubpath.createSession).toBe("function");
     expect(typeof webmcpSubpath.registerTool).toBe("function");
+    expect(typeof webmcpSubpath.getTools).toBe("function");
+    expect(typeof webmcpSubpath.executeTool).toBe("function");
     expect(typeof webmcpSubpath.defineTool).toBe("function");
     expect(typeof summarizerSubpath.summarize).toBe("function");
     expect(typeof translatorSubpath.translate).toBe("function");

--- a/packages/webmcp/README.md
+++ b/packages/webmcp/README.md
@@ -2,13 +2,13 @@
 
 web-ai-sdk building block for the W3C [WebMCP](https://webmachinelearning.github.io/webmcp/) API exposed at `document.modelContext`. (For backward compatibility with the previous shape of the API, this package also reads from `navigator.modelContext`.)
 
-An ergonomic, framework-agnostic adapter over the native browser API, with safe register/unregister cleanup and a feature-detected no-op fallback for non-supporting browsers.
+An ergonomic, framework-agnostic adapter over the native browser API, with safe register/unregister cleanup, typed tool discovery and execution, and progressive fallback behavior for non-supporting browsers.
 
 **Docs:** <https://web-ai-sdk.dev/docs/guides/webmcp/> · **React:** [`useWebMCP`](https://web-ai-sdk.dev/docs/react/use-web-mcp/)
 
 ## Status
 
-WebMCP shipped as an early preview in Chrome 146+ behind `chrome://flags/#enable-webmcp-testing`; a public [origin trial](https://developer.chrome.com/docs/ai/webmcp) opens in Chrome 149. Edge added support in 147+ behind the matching `edge://flags/` toggle. On any browser that doesn't expose `document.modelContext` (or the legacy `navigator.modelContext`), this library is a no-op. Your app stays callable, and no tools get registered. A WebMCP spec update changed `registerTool` to return a Promise (cross-origin iframe tool sharing made registration asynchronous); this adapter normalizes both the legacy synchronous shape and the async shape, so consumer code is unchanged.
+WebMCP shipped as an early preview in Chrome 146+ behind `chrome://flags/#enable-webmcp-testing`; a public [origin trial](https://developer.chrome.com/docs/ai/webmcp) opens in Chrome 149. Edge added support in 147+ behind the matching `edge://flags/` toggle. On browsers without WebMCP, registration is a no-op and discovery returns an empty list; execution rejects with `WebMCPUnavailableError` so a missing capability cannot be confused with a navigation result. A WebMCP spec update changed `registerTool` to return a Promise (cross-origin iframe tool sharing made registration asynchronous); this adapter normalizes both the legacy synchronous shape and the async shape, so consumer code is unchanged.
 
 ## Install
 
@@ -81,7 +81,7 @@ import { z } from "zod"; // Zod 4; other Standard Schema libraries work too
 const SearchPostsInput = z.object({ query: z.string().min(1) });
 
 export function WebMCP({ isSignedIn }: { isSignedIn: boolean }) {
-  useWebMCP(
+  const { tools, status } = useWebMCP(
     {
       name: "search_blog_posts",
       description: "Search published blog posts.",
@@ -98,11 +98,14 @@ export function WebMCP({ isSignedIn }: { isSignedIn: boolean }) {
     },
     { enabled: isSignedIn },
   );
-  return null;
+
+  return <p>{status === "ready" ? `${tools.length} tools` : status}</p>;
 }
 ```
 
-The hook accepts one tool or a readonly array. It registers on mount, unregisters on unmount, and cleans up immediately when `enabled` changes to `false`. Registration follows discoverable metadata and `exposedTo` values rather than object identity, while `execute` always uses the latest committed callback. Inline tool objects, arrays, and options are safe: changing React state alone does not rebuild the registration, but changing a tool's name, title, description, schema, annotations, or exposure does. Memoize tool arrays and large schemas when practical to avoid rebuilding and comparing their metadata on every render; correctness does not depend on memoization.
+`useWebMCP` accepts one tool or a readonly array. It registers on mount, unregisters on unmount, and cleans up immediately when `enabled` changes to `false`. Registration follows discoverable metadata and `exposedTo` values rather than object identity, while `execute` always uses the latest committed callback. Inline tool objects, arrays, and options are safe: changing React state alone does not rebuild the registration, but changing a tool's name, title, description, schema, annotations, or exposure does. Memoize tool arrays and large schemas when practical to avoid rebuilding and comparing their metadata on every render; correctness does not depend on memoization.
+
+The same hook retrieves every tool exposed to the current document and refreshes the returned list after native `toolchange` events. Its `refresh()` method performs an explicit fresh read. Call `useWebMCP({ fromOrigins })` without definitions for retrieval-only use. Memoize `fromOrigins` arrays passed to the hook because they participate in its effect dependencies by reference.
 
 ## API
 
@@ -128,6 +131,66 @@ const cleanup = registerTool(tool, {
 ```
 
 The SDK forwards the array unchanged alongside its internally owned `AbortSignal`. The browser validates each origin and rejects invalid or untrustworthy values; the wrapper preserves its non-throwing registration posture and logs that failure. Exposure is unnecessary for the owning document and should be limited to origins that genuinely need access.
+
+### `getTools(options?): Promise<RegisteredTool[]>`
+
+Discover tools exposed to the current document. The returned metadata is sorted by the browser and includes the registering `window` and `origin`. `inputSchema`, when present, is the browser's serialized JSON Schema string.
+
+```ts
+import { getTools } from "@web-ai-sdk/webmcp";
+
+const sameOriginTools = await getTools();
+const toolsAcrossFrames = await getTools({
+  fromOrigins: ["https://agent.example"],
+});
+```
+
+The browser always includes eligible same-origin tools. `fromOrigins` additionally requests tools from listed secure origins; those tools must also have exposed themselves to the caller's origin. Unsupported browsers resolve to `[]`. Native permission, origin-validation, and document-state errors remain observable as rejected promises.
+
+### `executeTool(tool, input?, options?): Promise<string | null>`
+
+Execute a `RegisteredTool` returned by `getTools()`. Pass the JavaScript input value; the SDK serializes it to the JSON argument string expected by the browser.
+
+```ts
+import { executeTool, getTools } from "@web-ai-sdk/webmcp";
+
+const tools = await getTools();
+const echo = tools.find((tool) => tool.name === "echo_message");
+if (echo) {
+  const result = await executeTool(echo, { message: "hello" });
+  console.log(result);
+}
+```
+
+The native serialized string is returned unchanged. `null` means tool execution triggered a navigation. Pass `{ signal }` to cancel an in-flight call. Unsupported browsers reject with `WebMCPUnavailableError`.
+
+`executeTool()` is experimental: Chromium implements and publicly documents it, but it is not yet present in the published WebMCP community-draft IDL.
+
+### `subscribeToToolChanges(listener): () => void`
+
+Listen for native `toolchange` events and return an idempotent cleanup function:
+
+```ts
+const unsubscribe = subscribeToToolChanges(() => {
+  void getTools().then(renderTools);
+});
+```
+
+On unsupported browsers, subscription and cleanup are no-ops.
+
+### `RegisteredTool`
+
+```ts
+interface RegisteredTool {
+  name: string;
+  title?: string;
+  description: string;
+  inputSchema?: string;
+  window: Window;
+  origin: string;
+  annotations?: ToolAnnotations;
+}
+```
 
 ### `isAvailable(): boolean`
 

--- a/packages/webmcp/README.md
+++ b/packages/webmcp/README.md
@@ -105,7 +105,7 @@ export function WebMCP({ isSignedIn }: { isSignedIn: boolean }) {
 
 `useWebMCP` accepts one tool or a readonly array. It registers on mount, unregisters on unmount, and cleans up immediately when `enabled` changes to `false`. Registration follows discoverable metadata and `exposedTo` values rather than object identity, while `execute` always uses the latest committed callback. Inline tool objects, arrays, and options are safe: changing React state alone does not rebuild the registration, but changing a tool's name, title, description, schema, annotations, or exposure does. Memoize tool arrays and large schemas when practical to avoid rebuilding and comparing their metadata on every render; correctness does not depend on memoization.
 
-The same hook retrieves every tool exposed to the current document and refreshes the returned list after native `toolchange` events. Its `refresh()` method performs an explicit fresh read. Call `useWebMCP({ fromOrigins })` without definitions for retrieval-only use. Memoize `fromOrigins` arrays passed to the hook because they participate in its effect dependencies by reference.
+The same hook retrieves every tool exposed to the current document and refreshes the returned list after native `toolchange` events. Its `refresh()` method performs an explicit fresh read. Call `useWebMCP({ fromOrigins })` without definitions for retrieval-only use. Inline `fromOrigins` arrays are safe; discovery restarts only when their values change.
 
 ## API
 

--- a/packages/webmcp/package.json
+++ b/packages/webmcp/package.json
@@ -66,7 +66,7 @@
   "keywords": [
     "webmcp",
     "model-context-protocol",
-    "navigator-modelcontext",
+    "document-modelcontext",
     "agent-tools",
     "web-ai",
     "building-block",

--- a/packages/webmcp/src/index.test.ts
+++ b/packages/webmcp/src/index.test.ts
@@ -183,6 +183,18 @@ describe("tool discovery and execution", () => {
     );
   });
 
+  it("normalizes explicitly undefined input to an empty object", async () => {
+    const tool = discoveredTool();
+    const executeNativeTool = vi.fn(async () => "ok");
+    setModelContext("document", {
+      registerTool: vi.fn(),
+      executeTool: executeNativeTool,
+    });
+
+    await expect(executeTool(tool, undefined)).resolves.toBe("ok");
+    expect(executeNativeTool).toHaveBeenCalledWith(tool, "{}", undefined);
+  });
+
   it("rejects execution when the native capability is unavailable", async () => {
     await expect(executeTool(discoveredTool())).rejects.toBeInstanceOf(
       WebMCPUnavailableError,

--- a/packages/webmcp/src/index.test.ts
+++ b/packages/webmcp/src/index.test.ts
@@ -2,14 +2,19 @@ import { afterEach, describe, expect, expectTypeOf, it, vi } from "vitest";
 import {
   type DefineToolOptions,
   defineTool,
+  executeTool,
+  getTools,
   isAvailable,
+  type RegisteredTool,
   type RegisterToolOptions,
   registerTool,
   type StandardSchemaV1,
+  subscribeToToolChanges,
   type Tool,
   type ToolDefinition,
   ToolOutputValidationError,
   ToolValidationError,
+  WebMCPUnavailableError,
 } from "./index.js";
 
 interface RegisteredCall {
@@ -125,6 +130,82 @@ describe("feature detection", () => {
 
     expect(onDoc.registerTool).toHaveBeenCalledTimes(1);
     expect(onNav.registerTool).not.toHaveBeenCalled();
+  });
+});
+
+describe("tool discovery and execution", () => {
+  const discoveredTool = (): RegisteredTool => ({
+    name: "echo",
+    title: "Echo",
+    description: "Echo a value.",
+    inputSchema: '{"type":"object"}',
+    window,
+    origin: window.location.origin,
+    annotations: { readOnlyHint: true },
+  });
+
+  it("returns an empty list when discovery is unavailable", async () => {
+    await expect(getTools()).resolves.toEqual([]);
+  });
+
+  it("forwards discovery options and preserves native metadata", async () => {
+    const tool = discoveredTool();
+    const getNativeTools = vi.fn(async () => [tool]);
+    setModelContext("document", {
+      registerTool: vi.fn(),
+      getTools: getNativeTools,
+    });
+
+    await expect(
+      getTools({ fromOrigins: ["https://agent.example"] }),
+    ).resolves.toEqual([tool]);
+    expect(getNativeTools).toHaveBeenCalledWith({
+      fromOrigins: ["https://agent.example"],
+    });
+  });
+
+  it("serializes input and forwards execution options", async () => {
+    const tool = discoveredTool();
+    const executeNativeTool = vi.fn(async () => '{"echoed":"hello"}');
+    setModelContext("document", {
+      registerTool: vi.fn(),
+      executeTool: executeNativeTool,
+    });
+    const controller = new AbortController();
+
+    await expect(
+      executeTool(tool, { message: "hello" }, { signal: controller.signal }),
+    ).resolves.toBe('{"echoed":"hello"}');
+    expect(executeNativeTool).toHaveBeenCalledWith(
+      tool,
+      '{"message":"hello"}',
+      { signal: controller.signal },
+    );
+  });
+
+  it("rejects execution when the native capability is unavailable", async () => {
+    await expect(executeTool(discoveredTool())).rejects.toBeInstanceOf(
+      WebMCPUnavailableError,
+    );
+  });
+
+  it("subscribes to tool changes and returns idempotent cleanup", () => {
+    const events = new EventTarget();
+    setModelContext("document", {
+      registerTool: vi.fn(),
+      addEventListener: events.addEventListener.bind(events),
+      removeEventListener: events.removeEventListener.bind(events),
+    });
+    const listener = vi.fn();
+    const cleanup = subscribeToToolChanges(listener);
+
+    events.dispatchEvent(new Event("toolchange"));
+    expect(listener).toHaveBeenCalledOnce();
+
+    cleanup();
+    cleanup();
+    events.dispatchEvent(new Event("toolchange"));
+    expect(listener).toHaveBeenCalledOnce();
   });
 });
 

--- a/packages/webmcp/src/index.ts
+++ b/packages/webmcp/src/index.ts
@@ -34,7 +34,7 @@ export {
 } from "./definition.js";
 export type { Tool, ToolAnnotations } from "./tool.js";
 
-interface RegisteredTool extends RegisteredToolMetadata {
+interface NativeToolDefinition extends RegisteredToolMetadata {
   execute: (input: unknown) => Promise<unknown> | unknown;
 }
 
@@ -51,11 +51,43 @@ interface NativeRegisterToolOptions extends RegisterToolOptions {
   signal?: AbortSignal;
 }
 
+/** Origins whose descendant documents should be queried for exposed tools. */
+export interface GetToolsOptions {
+  fromOrigins?: readonly string[];
+}
+
+/** Metadata returned by the native WebMCP discovery surface. */
+export interface RegisteredTool {
+  name: string;
+  title?: string;
+  description: string;
+  /** The browser returns the registered JSON Schema as a serialized string. */
+  inputSchema?: string;
+  /** Window belonging to the document that registered the tool. */
+  window: Window;
+  /** Serialized origin of the document that registered the tool. */
+  origin: string;
+  annotations?: import("./tool.js").ToolAnnotations;
+}
+
+/** Options forwarded to native tool execution. */
+export interface ExecuteToolOptions {
+  signal?: AbortSignal;
+}
+
 interface ModelContext {
   registerTool: (
-    def: RegisteredTool,
+    def: NativeToolDefinition,
     options?: NativeRegisterToolOptions,
   ) => Promise<void> | void;
+  getTools?: (options?: GetToolsOptions) => Promise<RegisteredTool[]>;
+  executeTool?: (
+    tool: RegisteredTool,
+    inputArguments: string,
+    options?: ExecuteToolOptions,
+  ) => Promise<string | null>;
+  addEventListener?: EventTarget["addEventListener"];
+  removeEventListener?: EventTarget["removeEventListener"];
 }
 
 interface HostWithModelContext {
@@ -80,10 +112,77 @@ const getModelContext = (): ModelContext | undefined => {
 /** Whether the current environment exposes the WebMCP API. */
 export const isAvailable = (): boolean => getModelContext() !== undefined;
 
-const toRegistered = (tool: Tool): RegisteredTool => {
+const toRegistered = (tool: Tool): NativeToolDefinition => {
   return {
     ...toRegisteredToolMetadata(tool),
-    execute: tool.execute as RegisteredTool["execute"],
+    execute: tool.execute as NativeToolDefinition["execute"],
+  };
+};
+
+/**
+ * Discover the tools exposed to the current document.
+ *
+ * Returns an empty array when WebMCP discovery is unavailable. Native
+ * permission, origin-validation, and document-state failures are preserved.
+ */
+export const getTools = async (
+  options?: GetToolsOptions,
+): Promise<RegisteredTool[]> => {
+  const mc = getModelContext();
+  if (!mc?.getTools) return [];
+  return mc.getTools(options);
+};
+
+/** Raised when the current host cannot execute discovered WebMCP tools. */
+export class WebMCPUnavailableError extends Error {
+  override readonly name = "WebMCPUnavailableError";
+}
+
+/**
+ * Execute a tool returned by `getTools()`.
+ *
+ * The SDK accepts the JavaScript input value and serializes it to the JSON
+ * string required by the native API. The native serialized result is returned
+ * unchanged; `null` means execution triggered a navigation.
+ *
+ * @experimental Tool execution is implemented and publicly documented by
+ * Chromium but is not yet present in the published WebMCP community draft.
+ */
+export const executeTool = async (
+  tool: RegisteredTool,
+  input: unknown = {},
+  options?: ExecuteToolOptions,
+): Promise<string | null> => {
+  const mc = getModelContext();
+  if (!mc?.executeTool) {
+    throw new WebMCPUnavailableError(
+      "WebMCP tool execution is unavailable in this browser.",
+    );
+  }
+
+  const inputArguments = JSON.stringify(input);
+  if (inputArguments === undefined) {
+    throw new TypeError("WebMCP tool input must be JSON-serializable.");
+  }
+  return mc.executeTool(tool, inputArguments, options);
+};
+
+/**
+ * Subscribe to changes in the tools exposed to the current document.
+ * Returns an idempotent no-op cleanup when the event surface is unavailable.
+ */
+export const subscribeToToolChanges = (
+  listener: (event: Event) => void,
+): (() => void) => {
+  const mc = getModelContext();
+  if (!mc?.addEventListener || !mc.removeEventListener) return () => {};
+
+  mc.addEventListener("toolchange", listener);
+  let disposed = false;
+  return () => {
+    if (disposed) return;
+    disposed = true;
+    mc.removeEventListener?.("toolchange", listener);
   };
 };
 
@@ -120,7 +219,7 @@ const trackOwnership = (controller: AbortController, name: string): void => {
  */
 const callRegister = (
   mc: ModelContext,
-  registered: RegisteredTool,
+  registered: NativeToolDefinition,
   controller: AbortController,
   options?: RegisterToolOptions,
 ): Promise<void> => {
@@ -156,7 +255,7 @@ const callRegister = (
  */
 const registerOne = async (
   mc: ModelContext,
-  registered: RegisteredTool,
+  registered: NativeToolDefinition,
   controller: AbortController,
   options?: RegisterToolOptions,
 ): Promise<boolean> => {

--- a/packages/webmcp/src/react/index.test.tsx
+++ b/packages/webmcp/src/react/index.test.tsx
@@ -1,4 +1,4 @@
-import { renderHook } from "@testing-library/react";
+import { act, renderHook, waitFor } from "@testing-library/react";
 import { type ReactNode, StrictMode, useLayoutEffect } from "react";
 import { afterEach, describe, expect, expectTypeOf, it, vi } from "vitest";
 import type { StandardSchemaV1, Tool, ToolDefinition } from "../index.js";
@@ -261,7 +261,7 @@ describe("useWebMCP", () => {
     expect(registerTool).not.toHaveBeenCalled();
 
     rerender({ enabled: true });
-    expect(toJSON).toHaveBeenCalledOnce();
+    expect(toJSON).toHaveBeenCalled();
     expect(registerTool).toHaveBeenCalledOnce();
     unmount();
   });
@@ -578,5 +578,93 @@ describe("useWebMCP", () => {
       const { unmount } = renderHook(() => useWebMCP(tools));
       unmount();
     }).not.toThrow();
+  });
+});
+
+describe("useWebMCP discovery", () => {
+  const discoveredTool = () => ({
+    name: "echo",
+    title: "Echo",
+    description: "Echo a value.",
+    inputSchema: '{"type":"object"}',
+    window,
+    origin: window.location.origin,
+    annotations: { readOnlyHint: true },
+  });
+
+  const installDiscoverySurface = () => {
+    const events = new EventTarget();
+    const tools = [discoveredTool()];
+    const getTools = vi.fn(async () => tools);
+    setModelContext("document", {
+      registerTool: vi.fn(),
+      getTools,
+      addEventListener: events.addEventListener.bind(events),
+      removeEventListener: events.removeEventListener.bind(events),
+    });
+    return { events, getTools, tools };
+  };
+
+  it("reports unavailable with an empty list when WebMCP is missing", async () => {
+    const { result } = renderHook(() => useWebMCP());
+
+    await waitFor(() => expect(result.current.status).toBe("unavailable"));
+    expect(result.current.tools).toEqual([]);
+    expect(result.current.error).toBeNull();
+  });
+
+  it("retrieves tools and forwards origin filters", async () => {
+    const { getTools, tools } = installDiscoverySurface();
+    const fromOrigins = ["https://agent.example"] as const;
+    const { result } = renderHook(() => useWebMCP({ fromOrigins }));
+
+    await waitFor(() => expect(result.current.status).toBe("ready"));
+    expect(result.current.tools).toEqual(tools);
+    expect(getTools).toHaveBeenCalledWith({ fromOrigins });
+  });
+
+  it("keeps discovery idle while disabled and starts after enabling", async () => {
+    const { getTools } = installDiscoverySurface();
+    const { result, rerender } = renderHook(
+      ({ enabled }) => useWebMCP({ enabled }),
+      { initialProps: { enabled: false } },
+    );
+
+    expect(result.current.status).toBe("idle");
+    expect(result.current.tools).toEqual([]);
+    expect(getTools).not.toHaveBeenCalled();
+
+    rerender({ enabled: true });
+    await waitFor(() => expect(result.current.status).toBe("ready"));
+    expect(getTools).toHaveBeenCalledOnce();
+  });
+
+  it("refreshes after tool changes and exposes manual refresh", async () => {
+    const { events, getTools, tools } = installDiscoverySurface();
+    const { result, unmount } = renderHook(() => useWebMCP());
+    await waitFor(() => expect(result.current.status).toBe("ready"));
+
+    act(() => events.dispatchEvent(new Event("toolchange")));
+    await waitFor(() => expect(getTools).toHaveBeenCalledTimes(2));
+
+    await expect(result.current.refresh()).resolves.toEqual(tools);
+    expect(getTools).toHaveBeenCalledTimes(3);
+
+    unmount();
+    events.dispatchEvent(new Event("toolchange"));
+    expect(getTools).toHaveBeenCalledTimes(3);
+  });
+
+  it("reports discovery failures without rejecting the component", async () => {
+    const failure = new DOMException("Denied", "NotAllowedError");
+    setModelContext("document", {
+      registerTool: vi.fn(),
+      getTools: vi.fn(async () => Promise.reject(failure)),
+    });
+    const { result } = renderHook(() => useWebMCP());
+
+    await waitFor(() => expect(result.current.status).toBe("error"));
+    expect(result.current.error).toBe(failure);
+    expect(result.current.tools).toEqual([]);
   });
 });

--- a/packages/webmcp/src/react/index.test.tsx
+++ b/packages/webmcp/src/react/index.test.tsx
@@ -623,6 +623,32 @@ describe("useWebMCP discovery", () => {
     expect(getTools).toHaveBeenCalledWith({ fromOrigins });
   });
 
+  it("treats content-equivalent inline origin filters as stable", async () => {
+    const { getTools } = installDiscoverySurface();
+    let renderCount = 0;
+    const { result, rerender } = renderHook(
+      ({ origin }: { origin: string }) => {
+        renderCount += 1;
+        if (renderCount > 10) {
+          throw new Error("inline fromOrigins caused a render loop");
+        }
+        return useWebMCP({ fromOrigins: [origin] });
+      },
+      { initialProps: { origin: "https://agent.example" } },
+    );
+
+    await waitFor(() => expect(result.current.status).toBe("ready"), {
+      timeout: 250,
+    });
+    expect(getTools).toHaveBeenCalledOnce();
+
+    rerender({ origin: "https://other.example" });
+    await waitFor(() => expect(getTools).toHaveBeenCalledTimes(2));
+    expect(getTools).toHaveBeenLastCalledWith({
+      fromOrigins: ["https://other.example"],
+    });
+  });
+
   it("keeps discovery idle while disabled and starts after enabling", async () => {
     const { getTools } = installDiscoverySurface();
     const { result, rerender } = renderHook(

--- a/packages/webmcp/src/react/index.ts
+++ b/packages/webmcp/src/react/index.ts
@@ -167,8 +167,8 @@ export function useWebMCP(options?: UseWebMCPOptions): UseWebMCPReturn;
  * native `toolchange` events and can also be triggered with `refresh()`.
  *
  * Call with options only to retrieve tools without registering definitions.
- * `fromOrigins` participates in the discovery effect dependency list by
- * reference; callers should memoize arrays created during render.
+ * Discovery restarts when `fromOrigins` values change, not when an equivalent
+ * array is recreated during render.
  */
 export function useWebMCP(
   toolOrToolsOrOptions?:
@@ -192,6 +192,8 @@ export function useWebMCP(
   const latestTools = useRef<readonly Tool[]>(
     definitions.map((tool) => normalizeToolDefinition(tool)),
   );
+  const latestFromOrigins = useRef(fromOrigins);
+  const fromOriginsKey = stableStringify(fromOrigins);
   const registrationKey = enabled
     ? getRegistrationKey(definitions, exposedTo)
     : "disabled";
@@ -211,6 +213,7 @@ export function useWebMCP(
     latestTools.current = definitions.map((tool) =>
       normalizeToolDefinition(tool),
     );
+    latestFromOrigins.current = fromOrigins;
   });
 
   useEffect(() => {
@@ -258,8 +261,12 @@ export function useWebMCP(
 
     setState((current) => ({ ...current, status: "loading", error: null }));
     try {
+      const currentFromOrigins =
+        fromOriginsKey === "" ? undefined : latestFromOrigins.current;
       const tools = await getTools(
-        fromOrigins === undefined ? undefined : { fromOrigins },
+        currentFromOrigins === undefined
+          ? undefined
+          : { fromOrigins: currentFromOrigins },
       );
       if (requestId.current === currentRequest) {
         setState({ status: "ready", tools, error: null });
@@ -272,7 +279,7 @@ export function useWebMCP(
       }
       return [];
     }
-  }, [enabled, fromOrigins]);
+  }, [enabled, fromOriginsKey]);
 
   useEffect(() => {
     void refresh();

--- a/packages/webmcp/src/react/index.ts
+++ b/packages/webmcp/src/react/index.ts
@@ -1,16 +1,46 @@
-import { useEffect, useLayoutEffect, useRef } from "react";
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from "react";
 import {
   normalizeToolDefinition,
   type RegistrableTool,
   type StandardSchemaV1,
   type ToolDefinition,
 } from "../definition.js";
-import { type RegisterToolOptions, registerTool } from "../index.js";
+import {
+  type GetToolsOptions,
+  getTools,
+  isAvailable,
+  type RegisteredTool,
+  type RegisterToolOptions,
+  registerTool,
+  subscribeToToolChanges,
+} from "../index.js";
 import { type Tool, toRegisteredToolMetadata } from "../tool.js";
 
-export interface UseWebMCPOptions extends RegisterToolOptions {
-  /** Whether the tools should currently be registered. Defaults to `true`. */
+export interface UseWebMCPOptions extends RegisterToolOptions, GetToolsOptions {
+  /** Whether registration and discovery are active. Defaults to `true`. */
   enabled?: boolean;
+}
+
+export type WebMCPStatus =
+  | "idle"
+  | "loading"
+  | "ready"
+  | "unavailable"
+  | "error";
+
+export interface UseWebMCPReturn {
+  status: WebMCPStatus;
+  /** Every tool exposed to the document, not only definitions passed in. */
+  tools: readonly RegisteredTool[];
+  error: Error | null;
+  /** Re-read the currently exposed tools and return the fresh list. */
+  refresh: () => Promise<readonly RegisteredTool[]>;
 }
 
 interface ActiveRegistration {
@@ -97,6 +127,16 @@ const wrapTools = (
     return tool;
   });
 
+const isToolInput = (
+  value: unknown,
+): value is RegistrableTool | readonly RegistrableTool[] =>
+  Array.isArray(value) ||
+  (typeof value === "object" &&
+    value !== null &&
+    "name" in value &&
+    "description" in value &&
+    "execute" in value);
+
 /** Register one direct schema-aware tool definition. */
 export function useWebMCP<
   InputSchema extends StandardSchemaV1 | undefined = undefined,
@@ -105,60 +145,88 @@ export function useWebMCP<
 >(
   tool: ToolDefinition<InputSchema, TOutput, OutputSchema>,
   options?: UseWebMCPOptions,
-): void;
+): UseWebMCPReturn;
 /** Register one existing plain Tool. */
 export function useWebMCP<TInput, TOutput>(
   tool: Tool<TInput, TOutput>,
   options?: UseWebMCPOptions,
-): void;
+): UseWebMCPReturn;
 /** Register an existing readonly collection of compatible tools. */
 export function useWebMCP<const Tools extends readonly RegistrableTool[]>(
   tools: Tools,
   options?: UseWebMCPOptions,
-): void;
+): UseWebMCPReturn;
+/** Retrieve exposed tools without registering definitions. */
+export function useWebMCP(options?: UseWebMCPOptions): UseWebMCPReturn;
 
 /**
- * React hook that registers one or more WebMCP tools on mount and unregisters
- * them on unmount. Registration changes only when discoverable metadata,
- * `enabled`, or `exposedTo` values change; schemas and execute callbacks always
- * use the latest committed render.
+ * Register WebMCP tools with React lifecycle cleanup and retrieve every tool
+ * exposed to the current document. Registration changes only when discoverable
+ * metadata, `enabled`, or `exposedTo` values change; schemas and execute
+ * callbacks always use the latest committed render. Discovery refreshes after
+ * native `toolchange` events and can also be triggered with `refresh()`.
  *
- * On browsers that don't expose `document.modelContext` (or the legacy
- * `navigator.modelContext`), the hook is a no-op.
+ * Call with options only to retrieve tools without registering definitions.
+ * `fromOrigins` participates in the discovery effect dependency list by
+ * reference; callers should memoize arrays created during render.
  */
 export function useWebMCP(
-  toolOrTools: RegistrableTool | readonly RegistrableTool[],
-  options?: UseWebMCPOptions,
-): void {
+  toolOrToolsOrOptions?:
+    | RegistrableTool
+    | readonly RegistrableTool[]
+    | UseWebMCPOptions,
+  maybeOptions?: UseWebMCPOptions,
+): UseWebMCPReturn {
+  const hasToolInput = isToolInput(toolOrToolsOrOptions);
+  const options = hasToolInput
+    ? maybeOptions
+    : (toolOrToolsOrOptions as UseWebMCPOptions | undefined);
   const enabled = options?.enabled ?? true;
   const exposedTo = options?.exposedTo;
-  const tools: readonly RegistrableTool[] = Array.isArray(toolOrTools)
-    ? toolOrTools
-    : [toolOrTools as RegistrableTool];
+  const fromOrigins = options?.fromOrigins;
+  const definitions: readonly RegistrableTool[] = hasToolInput
+    ? Array.isArray(toolOrToolsOrOptions)
+      ? toolOrToolsOrOptions
+      : [toolOrToolsOrOptions as RegistrableTool]
+    : [];
   const latestTools = useRef<readonly Tool[]>(
-    tools.map((tool) => normalizeToolDefinition(tool)),
+    definitions.map((tool) => normalizeToolDefinition(tool)),
   );
+  const registrationKey = enabled
+    ? getRegistrationKey(definitions, exposedTo)
+    : "disabled";
   const activeRegistration = useRef<ActiveRegistration | undefined>(undefined);
+  const requestId = useRef(0);
+  const [state, setState] = useState<{
+    status: WebMCPStatus;
+    tools: readonly RegisteredTool[];
+    error: Error | null;
+  }>(() => ({
+    status: !enabled ? "idle" : isAvailable() ? "loading" : "unavailable",
+    tools: [],
+    error: null,
+  }));
 
   useCommitEffect(() => {
-    latestTools.current = tools.map((tool) => normalizeToolDefinition(tool));
+    latestTools.current = definitions.map((tool) =>
+      normalizeToolDefinition(tool),
+    );
   });
 
   useEffect(() => {
-    if (!enabled) {
+    if (!enabled || definitions.length === 0) {
       activeRegistration.current?.cleanup();
       activeRegistration.current = undefined;
       return;
     }
 
-    const registrationKey = getRegistrationKey(tools, exposedTo);
     if (activeRegistration.current?.key === registrationKey) return;
 
     activeRegistration.current?.cleanup();
 
     const registerOptions: RegisterToolOptions | undefined =
       exposedTo === undefined ? undefined : { exposedTo };
-    const cleanups = wrapTools(tools, latestTools).map((tool) =>
+    const cleanups = wrapTools(definitions, latestTools).map((tool) =>
       registerTool(tool, registerOptions),
     );
     activeRegistration.current = {
@@ -176,10 +244,61 @@ export function useWebMCP(
     },
     [],
   );
+
+  const refresh = useCallback(async (): Promise<readonly RegisteredTool[]> => {
+    const currentRequest = ++requestId.current;
+    if (!enabled) {
+      setState({ status: "idle", tools: [], error: null });
+      return [];
+    }
+    if (!isAvailable()) {
+      setState({ status: "unavailable", tools: [], error: null });
+      return [];
+    }
+
+    setState((current) => ({ ...current, status: "loading", error: null }));
+    try {
+      const tools = await getTools(
+        fromOrigins === undefined ? undefined : { fromOrigins },
+      );
+      if (requestId.current === currentRequest) {
+        setState({ status: "ready", tools, error: null });
+      }
+      return tools;
+    } catch (err) {
+      const error = err instanceof Error ? err : new Error(String(err));
+      if (requestId.current === currentRequest) {
+        setState({ status: "error", tools: [], error });
+      }
+      return [];
+    }
+  }, [enabled, fromOrigins]);
+
+  useEffect(() => {
+    void refresh();
+    if (!enabled || !isAvailable()) {
+      return () => {
+        requestId.current += 1;
+      };
+    }
+
+    const unsubscribe = subscribeToToolChanges(() => {
+      void refresh();
+    });
+    return () => {
+      requestId.current += 1;
+      unsubscribe();
+    };
+  }, [enabled, refresh]);
+
+  return { ...state, refresh };
 }
 
 export type {
   DefineToolOptions,
+  ExecuteToolOptions,
+  GetToolsOptions,
+  RegisteredTool,
   RegisterToolOptions,
   StandardSchemaV1,
   Tool,
@@ -188,6 +307,10 @@ export type {
 } from "../index.js";
 export {
   defineTool,
+  executeTool,
+  getTools,
+  subscribeToToolChanges,
   ToolOutputValidationError,
   ToolValidationError,
+  WebMCPUnavailableError,
 } from "../index.js";


### PR DESCRIPTION
## Summary

- expose `getTools()`, `executeTool()`, and `subscribeToToolChanges()` through `@web-ai-sdk/webmcp`
- return reactive discovery state from `useWebMCP()` while preserving its registration lifecycle
- update package docs, the homepage, docs demo, and playground to consume the SDK APIs
- clarify that the homepage filters discovery to its two demo tools
- fix the `add_to_cart` schema and give the on-device router each tool’s input schema

## Why

Consumers previously needed to access `document.modelContext` directly to discover and execute tools. React consumers also had to implement discovery state, event subscriptions, refresh behavior, race handling, and cleanup themselves.

The homepage additionally presented its demo-scoped count as the complete discovery result and used `qty` where the invoked tool expected `quantity`.

## Impact

Vanilla consumers can discover and execute tools without reaching into the native API. React consumers can register a tool and retrieve every tool exposed to the document in one call:

```tsx
const { tools, status, error, refresh } = useWebMCP(tool);
```

Existing registration-only calls remain compatible when the return value is ignored.

## Validation

- WebMCP tests: 80 passed
- site tests: 62 passed
- site typecheck: passed
- Biome checks: passed
- production build: passed
- Chrome DevTools MCP smoke test confirmed all three discovered tools and successful `add_to_cart` execution
