### PR TITLE
docs: add production guidance and simplify the documentation experience

### DIFF
--- a/.agents/agents.md
+++ b/.agents/agents.md
@@ -1,325 +1,144 @@
-# .agents/agents.md
+# AGENTS.md
 
-This file is the single source of truth for **any AI agent** (Cursor, Claude Code, Copilot, Devin, etc.) working on this repository. Read it once at the start of a session, then keep it open as a reference.
+Repository-specific rules for coding agents. The root `AGENTS.md` symlinks to
+this file.
 
-The root `AGENTS.md` is a compatibility symlink to this file for tools that still discover only the older AGENTS.md convention.
+## Read first
 
-For human-facing context see the root [`README.md`](../README.md) and [`CONTRIBUTING.md`](../CONTRIBUTING.md), plus one README per package under `packages/<name>/README.md`. For the visual identity (colour, type, surfaces) that any UI change must follow, see [`DESIGN.md`](../DESIGN.md).
+- [`README.md`](../README.md): product and package overview.
+- [`CONTRIBUTING.md`](../CONTRIBUTING.md): governance, capability adoption,
+  changesets, and releases.
+- [`DESIGN.md`](../DESIGN.md): visual identity for every UI change.
+- `packages/<name>/README.md`: public contract for one package.
 
----
+Keep this file focused on agent constraints. Put human guidance in the files
+above.
 
-## 1. What this is
+## Principles
 
-**`web-ai-sdk`** is a small monorepo of building blocks for the Web AI surface. Each package is framework-agnostic by default and ships a React subpath adapter; future Vue / Svelte adapters slot in the same way.
+- Choose the smallest implementation that fully meets the current requirement.
+- Keep one package responsible for one browser capability.
+- Keep core wrappers thin. They own lifecycle and ergonomics, not product policy.
+- Use project dependencies before adding code or packages. Core wrappers must
+  keep zero runtime dependencies.
+- Preserve public API behavior unless the task explicitly changes it. Document
+  breaking changes and migrations.
+- Use only public sources for published capability claims, flags, versions, and
+  timelines.
 
-| Package                 | Wraps                                                  | Status     |
-| ----------------------- | ------------------------------------------------------ | ---------- |
-| `@web-ai-sdk/webmcp`    | `document.modelContext` (W3C WebMCP)                   | Ported     |
-| `@web-ai-sdk/translator`| `Translator` (Web Built-in AI Translator API)       | Ported     |
-| `@web-ai-sdk/summarizer`| `Summarizer` (Web Built-in AI Summarizer API)       | Ported     |
-| `@web-ai-sdk/prompt`    | `LanguageModel` (Web Built-in AI Prompt API)        | New        |
-| `@web-ai-sdk/detector`  | `LanguageDetector` (Web Built-in AI Language Detection API) | New |
-| `@web-ai-sdk/writer`    | `Writer` (Web Built-in AI Writer API)               | New        |
-| `@web-ai-sdk/rewriter`  | `Rewriter` (Web Built-in AI Rewriter API)           | New        |
-| `@web-ai-sdk/proofreader`| `Proofreader` (Web Built-in AI Proofreader API)    | New        |
-| `@web-ai-sdk/all`       | meta-package; re-exports the others above under one install | New     |
+## Architecture
 
-One private workspace app lives under `apps/site`: an Astro marketing site with Starlight docs mounted at `/docs/` and live React demos. Run `pnpm dev` after `pnpm build:packages`.
+This is a strict TypeScript and pnpm monorepo. Wrapper packages live in
+`packages/`. The Astro site, Starlight docs, Playground, and demos live in
+`apps/site/`.
 
-Each package exposes:
+Each wrapper exposes:
 
-- **Vanilla** (`@web-ai-sdk/<pkg>`); TS/DOM only, zero framework deps.
-- **React** (`@web-ai-sdk/<pkg>/react`); small hook adapter that wraps the vanilla core. `react` is an optional peer dep.
+- `@web-ai-sdk/<name>`: framework-agnostic core.
+- `@web-ai-sdk/<name>/react`: optional React hook adapter.
 
-Lifecycle layer on purpose. Each package only manages session lifetime, cleanup, feature detection, and the gnarly bits (safe register/unregister in webmcp, delta-vs-cumulative chunk smoothing in prompt/summarizer, etc.). Framework adapters, polyfills, and UI primitives are opt-in subpaths, not bundled into the core packages.
+### Core wrappers
 
-### Scope rule
+- Wrap one native capability. Do not compose SDK packages in a wrapper.
+- Do not render UI, walk application DOM, or add third-party runtimes.
+- Keep selectors and root elements configurable when an API accepts them.
+- Make cleanup functions idempotent.
+- Make feature detection safe. `isAvailable()` returns `false`, and
+  `checkAvailability()` returns `null`, when the API cannot run.
+- High-level vanilla functions may throw a typed unavailability error. React
+  hooks expose an `"unavailable"` state instead.
+- Preserve structured native results when their metadata matters.
+- Make session reuse safe and clearable. Evict rejected creation promises.
+- Cache only with complete, lossless keys and semantically valid reuse.
 
-Decision heuristic for new code: *if it bonds two SDK packages, walks the DOM, or needs a third-party runtime, it doesn't belong in an SDK wrapper.* Higher-level compositions (block-level DOM translation, article skeleton extraction, detect-then-summarize chains) are consumer-code territory; the SDK ships primitives only.
+The vanilla core is the source of truth. React adapters are hooks, not
+components, and must not duplicate core logic. Keep effect dependencies honest.
 
-The bias is toward *less* code over time, not more. This is the same trajectory mature utility libraries follow as the platform catches up (lodash → native methods, moment/date-fns → `Temporal`): own only the lifecycle and ergonomics the raw API leaves rough, and let the wrapper thin out as the Web AI APIs stabilize. When in doubt about whether something belongs, default to leaving it out.
+Before adding a capability, apply the adoption policy in
+[`CONTRIBUTING.md`](../CONTRIBUTING.md#capability-adoption-policy). Tracked
+capabilities stay as issues. Preview, Trial, and Stable capabilities may become
+packages when public evidence is sufficient.
 
-Full rules in [`CONTRIBUTING.md` § Governance](../CONTRIBUTING.md#governance); user-facing version at [`apps/site/src/content/docs/architecture.mdx`](../apps/site/src/content/docs/architecture.mdx) ([web-ai-sdk.dev/docs/architecture/](https://web-ai-sdk.dev/docs/architecture/)).
+## Code
 
----
+- Do not introduce `any` without an explicit reason in a comment.
+- Use `import type` for type-only imports.
+- Respect strict mode, `verbatimModuleSyntax`, and `noUncheckedIndexedAccess`.
+- Do not use relative imports across package boundaries. Import published
+  `@web-ai-sdk/*` exports.
+- Use `.js` suffixes for relative subpath imports inside packages.
+- Add tests beside the source. Cover core behavior before React lifecycle.
+- Do not hand-edit `pnpm-lock.yaml`, generated `dist/`, or `node_modules/`.
+- Create changesets through `pnpm changeset`. Do not hand-curate generated
+  changeset files.
 
-## 2. Stack & runtime
+## Documentation and copy
 
-- **TypeScript** strict, ESM (`"type": "module"`), `verbatimModuleSyntax`.
-- **pnpm 10** workspaces (declared in `pnpm-workspace.yaml`).
-- **tsup** for builds; emits ESM + CJS + `.d.ts` from `src/index.ts` and `src/react/index.ts`.
-- **Vitest + happy-dom** for tests.
-- **Biome** for lint + format (one tool, scoped to `packages/**` and `apps/**` `.ts`/`.tsx`). No ESLint, no Prettier.
-- **Changesets** for versioning + publishing.
-- **Node** `>= 22.12.0` (declared in `engines`; `.nvmrc` pins Node 24 for local dev).
-- **Corepack** provisions the right pnpm version automatically from `package.json#packageManager`. No extra tooling required.
+Apply these rules to public docs, package READMEs, home copy, demos, Playground
+guidance, user-facing help and errors, and maintainer documentation.
 
----
+Use a house style inspired by Simplified Technical English. Do not claim formal
+STE compliance.
 
-## 3. Folder map
-
-```
-.
-├── packages/
-│   ├── webmcp/
-│   │   ├── src/
-│   │   │   ├── index.ts          # vanilla core
-│   │   │   ├── index.test.ts
-│   │   │   └── react/
-│   │   │       ├── index.ts      # React hook
-│   │   │       └── index.test.tsx
-│   │   ├── package.json
-│   │   ├── tsconfig.json
-│   │   ├── tsup.config.ts
-│   │   ├── vitest.config.ts
-│   │   └── README.md
-│   ├── translator/               # same shape; adds api.ts + cache.ts
-│   ├── summarizer/               # same shape; adds skeleton.ts + cache.ts
-│   ├── prompt/                   # same shape; adds api.ts + cache.ts
-│   ├── detector/                 # same shape; adds api.ts + cache.ts
-│   ├── writer/                   # same shape; adds api.ts + cache.ts
-│   ├── rewriter/                 # same shape; adds api.ts + cache.ts
-│   ├── proofreader/              # same shape; adds api.ts + cache.ts
-│   └── sdk/                      # @web-ai-sdk/all meta-package; re-exports the eight above
-├── apps/
-│   └── site/                     # Astro site + Starlight docs
-├── .changeset/
-├── .github/workflows/            # CI gate + release + Pages deploy
-├── .nvmrc                        # pins Node 24 for local dev
-├── biome.json                    # lint + format
-├── package.json                  # workspace root + every pnpm script (incl. "packageManager" → pnpm@10.34.3)
-├── pnpm-workspace.yaml
-├── tsconfig.base.json            # shared compiler options
-├── README.md                     # human onboarding entry point
-├── CONTRIBUTING.md               # contribution flow
-├── DESIGN.md                     # visual identity source of truth (Noir / Dark)
-├── .agents/
-│   └── agents.md                 # ← you are here
-└── AGENTS.md                     # compatibility symlink
-```
-
-Package layout is intentionally uniform; open one package, you've seen them all.
-
----
-
-## 4. Commands
-
-All workflow commands are pnpm scripts in `package.json`.
-
-| Task                              | Command                    |
-| --------------------------------- | -------------------------- |
-| Watch site + docs                | `pnpm dev`                 |
-| Watch wrapper packages            | `pnpm dev:packages`        |
-| Watch meta-package                | `pnpm dev:sdk`             |
-| Boot unified app (`:5173`)        | `pnpm site`                |
-| Build everything                  | `pnpm build`               |
-| Build every package               | `pnpm build:packages`      |
-| Build the app                     | `pnpm build:apps`          |
-| Lint + format audit               | `pnpm lint`                |
-| Auto-fix lint + format            | `pnpm lint:fix`            |
-| Format only (write)               | `pnpm format`              |
-| Format audit only                 | `pnpm format:check`        |
-| `tsc --noEmit` everywhere         | `pnpm typecheck`           |
-| Vitest across packages            | `pnpm test`                |
-| Full quality gate                 | `pnpm gate`                |
-| Create a changeset                | `pnpm changeset`           |
-| Apply pending changesets          | `pnpm version-packages`    |
-| Publish via Changesets            | `pnpm release`             |
-| Build Pages artifact              | `pnpm pages:build`         |
-| Preview combined Pages locally    | `pnpm pages:preview`       |
-| Remove the local `_site/`         | `pnpm pages:clean`         |
-
-**Run before any commit:** `pnpm gate`.
-
----
-
-## 5. Conventions (the rules to follow)
-
-### TypeScript
-
-- **No `any`.** Reintroducing it should be intentional and commented.
-- **Type-only imports** with `import type { ... }`.
-- **`verbatimModuleSyntax`**; write the imports the way they'll compile; no implicit elision.
-- **`noUncheckedIndexedAccess`** is on; array/index access is `T | undefined`.
-- **No relative imports across package boundaries.** Each package is self-contained; cross-package usage goes through `@web-ai-sdk/*` published exports.
-- **Subpath imports inside a package** use `.js` suffix (`from "../index.js"`); required by ESM resolution under `moduleResolution: "Bundler"` for the published shape.
-
-### Capability adoption gate
-
-Before scaffolding a wrapper, classify it as Tracked, Preview, Trial, Stable, or Retired using [`CONTRIBUTING.md` § Capability adoption policy](../CONTRIBUTING.md#capability-adoption-policy).
-
-- Tracked capabilities stay as issues. Only Preview, Trial, or Stable capabilities may become packages.
-- Preview requires an authoritative public source, public instructions sufficient to run and document the implementation, a cohesive capability boundary, material lifecycle value beyond types, zero runtime dependencies, deterministic tests, and deliberate unsupported-browser behavior.
-- Published issues, PRs, READMEs, docs, demos, changelogs, and release notes must rely entirely on public sources. Never link, quote, paraphrase, or disclose versions, flags, behavior, or timelines learned only from confidential, restricted, or private-preview material. If the public evidence is insufficient, keep the capability Tracked.
-- Record the stage and exact public setup requirements in the package README and browser-support docs. Preview and Trial packages remain `0.x`; Stable browser support does not automatically make the package `1.0`.
-- Do not copy capability-specific conveniences mechanically. Session reuse must be safe and clearable; rejected creation promises must be evicted. Result caching requires a complete key, lossless serialization, and semantically valid reuse, including a compatibility discriminator when outputs depend on one. Preserve structured native results when their metadata matters.
-- When a capability is withdrawn or replaced, deprecate it with migration guidance instead of silently repurposing the package.
-
-### Core package contract
-
-These rules apply to the API-wrapper packages (`@web-ai-sdk/prompt`, `webmcp`, `summarizer`, `translator`, `detector`, `writer`, `rewriter`, `proofreader`). Future packages with a different role (UI primitives, polyfills, etc.) sit at different layers and get their own rules.
-
-- **No UI components in the core wrappers.** A core package may never render DOM. The React adapter is a hook, not a component. UI primitives would ship as a separate `@web-ai-sdk/ui` package, not bolted into a wrapper.
-- **Feature-detection helpers never throw.** `isAvailable()` returns `false` and `checkAvailability()` returns `null` when the native API cannot be used. High-level vanilla execution may throw a package-specific typed unavailability error; React hooks absorb it into an `"unavailable"` state. Registration-style APIs may instead return an idempotent no-op cleanup when that preserves their natural call shape.
-- **Configurable selectors / roots.** Don't hardcode page-specific assumptions; every selector or root element an SDK helper accepts must be overridable via the API.
-- **Cleanup must be idempotent.** Returning a cleanup function from `register*` / `start*` is the universal lifecycle. Calling it twice must not throw.
-
-### React adapter shape
-
-- Hook-only. Consumers render the button / tooltip / card themselves.
-- The hook wraps the vanilla core; do not duplicate logic.
-- Effect deps must be honest. If the hook accepts an array, document that callers should memoize it.
-
-### Annotations
-
-- WebMCP exposes shorthand flags (`readOnly`, `destructive`) that translate to spec annotations (`readOnlyHint`, `destructiveHint`) under the hood. Raw `annotations` passthrough merges on top, so consumers can still set `idempotentHint` / `openWorldHint` directly.
-
-### Files & docs
-
-- **One package = one job.** Don't add cross-package helpers in this monorepo without a clear reason; copy small utilities instead.
-- **READMEs are user-facing.** Show install, the smallest possible vanilla example, the smallest possible React example, then the API surface.
-- Don't write design docs unless the user asks. Conventions live here; package-specific decisions live in the package README.
-
-### Documentation style
-
-Use a house style inspired by [ASD-STE100 Simplified Technical English](https://www.asd-ste100.org/about_STE.html). Do not claim formal STE compliance.
-
-- Aim for 25 words or fewer in a prose sentence. Split sentences that contain more than one claim or action.
-- Use active voice and direct verbs. Use the imperative form for instructions.
-- Use one term for one concept. Do not alternate between synonyms for variety.
-- State behavior before rationale. Put conditions and exceptions next to the behavior they modify.
+- Aim for 25 words or fewer per prose sentence.
+- Use active voice, direct verbs, and imperative instructions.
+- Use one term for one concept.
+- State behavior before rationale. Keep conditions next to the behavior.
 - Replace hype, metaphors, and rhetorical claims with concrete behavior.
-- Keep paragraphs short. Use a list or table only when it makes comparison or scanning easier.
-- Preserve API names and required technical terms. Define an uncommon term at first use.
+- Do not use em dashes.
+- Keep paragraphs short. Use lists and tables only when they improve scanning.
+- Preserve exact API names. Define uncommon technical terms once.
 
-### Docs reliability
+Treat examples as public API:
 
-- Treat docs examples as part of the public API. When editing or reviewing docs, verify option names, result shapes, hook return values, and helper export names against the actual exported TypeScript interfaces and runtime tests.
-- After API renames, audit stale docs terms across READMEs and docs pages. Common drift patterns in this repo include `prompt()` vs `ask()`, `prompt` vs `input`, `onChunk` vs `onUpdate`, `response` / `summary` vs `output`, top-level detector `language` vs `output.language`, `is*Available()` aliases vs `isAvailable()`, and removed cache factories vs `cache: "session" | "local"`.
-- Package READMEs are the source for generated package docs under `apps/site/src/content/docs/packages/*.md`, but those pages are checked in. If you fix a README drift, update the matching checked-in package docs page in the same change or regenerate it.
-- Changelog migration snippets are historical; don't "fix" old before/after examples unless they are inaccurate for the release they describe.
-- After docs changes, run `pnpm --filter @web-ai-sdk-apps/site typecheck`. Biome may intentionally ignore Markdown docs, so don't treat "no files processed" as validation.
+- Verify names, options, results, and hook returns against TypeScript exports and
+  tests.
+- Update a package README and its checked-in page under
+  `apps/site/src/content/docs/packages/` together.
+- Do not rewrite historical changelog migration examples unless they were wrong
+  for that release.
+- Run `pnpm --filter @web-ai-sdk-apps/site typecheck` after docs changes.
 
-### Home page styling (`apps/site`)
+## Site UI
 
-The marketing site uses **Tailwind CSS v4**. Full guardrails: [`apps/site/README.md`](../apps/site/README.md). Visual identity (colour semantics, typography, surfaces, motion) is governed by [`DESIGN.md`](../DESIGN.md); follow it for any UI change.
+- Follow [`DESIGN.md`](../DESIGN.md) for color, type, surfaces, and motion.
+- Use Tailwind first on the home page. Reuse utilities from
+  `apps/site/src/shared/ui.ts`.
+- Keep `apps/site/src/styles/home.css` limited to tokens, resets, variables, and
+  keyframes.
+- Do not add static inline styles to React components. Inline styles are only
+  for dynamic values.
+- Keep conflicting state classes mutually exclusive.
+- Consolidate nearby one-off utilities when editing mixed legacy components.
 
-- **Tailwind first.** New UI goes through `src/shared/ui.ts` (composed utilities), not new `.css` files or raw CSS in components.
-- **`src/styles/home.css` is bootstrap only** — `@theme` tokens, layout CSS variables, keyframes, and minimal `@layer base` resets. No component-level rules.
-- **No inline CSS in React** except dynamic values (e.g. progress bar width). Static `<style>` / inline `style=` belongs only in standalone static files such as `public/404.html`.
-- **State classes must be mutually exclusive** when Tailwind utilities conflict (tabs, chips, buttons).
-- The codebase is still **partially mixed** (some inline Tailwind in components not yet in `ui.ts`); consolidate when editing, don't add more one-offs.
+See [`apps/site/README.md`](../apps/site/README.md) for complete site rules.
 
----
+## Commands
 
-## 6. Common tasks (cookbook)
+Use scripts from [`package.json`](../package.json). Common commands:
 
-### Add a new tool / wrapper package
+- `pnpm dev`: watch the site and docs.
+- `pnpm build`: build packages and apps.
+- `pnpm gate`: run lint, build, typecheck, and tests.
 
-1. Confirm the capability has reached Preview, Trial, or Stable under the capability adoption gate. Keep Tracked capabilities as issues.
-2. `cp -r packages/<closest-template> packages/<new>` and rename in `package.json`, `tsup.config.ts`, `tsconfig.json`.
-3. Replace `src/index.ts` / `src/api.ts` / `src/react/index.ts` with the real wrapper. Keep the core package contract (§ 5).
-4. Add Vitest tests next to each source file.
-5. Write `README.md` matching the existing structure (status / install / vanilla / React / API / errors / license).
-6. Add the new package's docs MDX pages under `apps/site/src/content/docs/guides/<name>.mdx` and `apps/site/src/content/docs/react/use-<name>.mdx`, plus a docs demo component under `apps/site/src/features/docs/components/`, plus a sidebar entry in `apps/site/astro.config.mjs`. Add a corresponding static row and React demo island to `apps/site/src/pages/index.astro`.
-7. `pnpm install` at the repo root (picks up the new workspace package).
-8. `pnpm changeset` to record the new package for the next release.
-9. `pnpm gate` to verify everything is wired up.
+Run focused checks while iterating. Build before typecheck because the site
+consumes package output. Run `pnpm gate` before any commit.
 
-Note: a brand-new package's **first** publish must be done locally; CI can't create it. See [Cut a release](#cut-a-release).
+## Git and workspace safety
 
-### Add a React-only feature to an existing package
-
-1. Land the logic in `src/index.ts` first. The vanilla core is the source of truth.
-2. Add the hook in `src/react/index.ts` as a thin wrapper.
-3. Add tests for both layers; vanilla covers behavior, React covers lifecycle.
-
-### Add a new dev dep to a single package
-
-`cd packages/<pkg> && pnpm add -D <pkg>`; pnpm hoists shared deps automatically. Don't add per-package devDependencies that already exist at the root.
-
-### Cut a release
-
-Releases are automated by the [`changesets/action`](.github/workflows/release.yml) and publish through **npm Trusted Publishing (OIDC)** — there is intentionally no `NPM_TOKEN` secret in the workflow.
-
-1. `pnpm changeset` and pick the bump kind for each touched package; commit the generated markdown.
-2. Open a PR. When it merges to `main`, the release workflow opens (or updates) a **"chore: version packages"** PR that runs `pnpm version-packages` (bumps versions, writes CHANGELOGs, consumes the changesets).
-3. Merge the "Version Packages" PR. That triggers `pnpm release` (`pnpm build:packages && changeset publish`), publishing every package whose version isn't yet on npm. `changeset publish` is idempotent, so re-runs are safe.
-
-**The first publish of a brand-new package must be done locally — CI cannot create it.** OIDC Trusted Publishing can't authenticate a package that doesn't exist yet (you can't configure a Trusted Publisher before the package exists), and a CI npm token can't *create* a new package in the `@web-ai-sdk` org either (npm returns a masked `404 Not Found` on the initial `PUT`). So the very first publish of each new package is manual:
-
-```sh
-npm login                 # as a @web-ai-sdk org member (handles 2FA)
-pnpm build:packages
-cd packages/<new> && npm publish --access public --provenance=false
-```
-
-Provenance is disabled for that first manual publish because it requires CI/OIDC; subsequent CI releases generate it. Once the package exists, set up a Trusted Publisher for it at `npmjs.com/package/@web-ai-sdk/<new>/access` (point it at this repo + `release.yml`), and every future version publishes automatically via the workflow above. This is why pre-existing packages release through CI with no token, while a new package's `0.x.0` debut is hand-published.
-
----
-
-## 7. Don't-touch zones
-
-| Path / file       | Why                                                                            |
-| ----------------- | ------------------------------------------------------------------------------ |
-| `pnpm-lock.yaml`  | Only update via `pnpm install` / `pnpm add`. Don't hand-edit.                  |
-| `dist/`           | Build output. Never commit.                                                    |
-| `node_modules/`   | Obvious.                                                                       |
-| `.changeset/*.md` | Generated by `pnpm changeset`; keep, but don't hand-curate after the fact.    |
-
----
-
-## 8. Quality gates
-
-A change is "ready" when **all four** of these pass:
-
-```bash
-pnpm lint        # 0 errors  (Biome; lint + format audit across packages and apps)
-pnpm build       # ✓ Complete (packages + apps); must run before typecheck because apps consume the built dist
-pnpm typecheck   # 0 errors  (per-package tsc --noEmit, apps included)
-pnpm test        # all green (Vitest + happy-dom)
-```
-
-Or in one shot: `pnpm gate`.
-
----
-
-## 9. Glossary
-
-- **Tool**; In WebMCP, a named, agent-callable function with a description, optional JSON Schema input, and an `execute` handler. Registered with `document.modelContext.registerTool`.
-- **Core package / lifecycle layer**; A package that ships logic, types, and session lifecycle but no DOM / no styles / no rendering primitives. The eight API-wrapper packages are all core packages. Future packages with a different role (UI primitives, polyfills) sit at different layers.
-- **Subpath export**; A package entry exposed under a path like `@web-ai-sdk/webmcp/react`. Configured via `package.json#exports`. Lets one install ship multiple framework adapters that tree-shake independently.
-- **Feature-detected no-op**; The pattern this monorepo uses everywhere: if the underlying browser API is absent, the wrapper returns a no-op cleanup / `undefined` / similar, so consumer code can ship without polyfills or branching.
-
----
-
-## 10. Boundaries
-- Never run git push without explicit approval in the same message.
-- Never create or merge PRs unless I explicitly ask in that turn.
-- Never run git commit until you have shown me the exact commit message and I approve it. Show it first for approval before any non-read-only actions are taken, including branch creation.
-- Force-push is only allowed with explicit approval to update a PR already on main (e.g., `git push --force-with-lease origin <branch>`).
-- Never rebase or delete branches without explicit approval.
-- Do not add `Co-authored-by:` trailers or agent attribution in commits.
-- Always confirm PR title and description before opening a PR; show them to me for approval first.
-- Never run `git commit --amend` without explicit approval.
-
-## 11. Work in the session's tree — never create worktrees
-
-The goal: every change stays visible to the tools bound to this repo — editors, git GUIs, and the coding agent itself. **Isolation is fine; invisibility is not.**
-
-This applies to **any** agent, skill, GUI, or automation touching this repo — regardless of its default isolation behaviour.
-
-> **Why:** the workspace bound to this session — whatever tool it is — tracks a **single working tree**: the one checkout it was opened on. A `git worktree` is a *separate* directory with its own checkout, so changes made there are **real but invisible** to that workspace (its git view shows "working tree clean"), and the branch gets locked to that folder (selecting it elsewhere errors with *"already used by worktree"*). A `.worktrees/` subdir is inside the repo path but is still a separate working tree — being "in the repo path" does NOT make it visible.
-
-- **The rule: edit the session's bound working tree, in place, on a dedicated branch.** `git switch -c <type>/<scope>-<slug>` from HEAD and edit the checked-out tree directly. Every change then shows live in the workspace's git view. This covers single-branch work, which is essentially all work.
-- **Do NOT create a worktree — by any mechanism.** This is a hard rule for every agent, skill, skill variant, subagent, and automation. It bans both:
-  - raw `git worktree add` (and any `$TMPDIR` / out-of-repo scratch checkout), and
-  - a skill's built-in "isolation/worktree" mode. `/improve` and its variants default to `isolation: "worktree"`; that default is **overridden to in-place execution here**. Do not opt back into it.
-  - Rationale: a worktree you create is a separate checkout the session is **not** bound to, so the work is invisible and the branch gets locked. (The restriction is on *creation*: a worktree the human has already set up and switched the session into is fine to edit and manage normally.)
-- **Need a parallel branch? Hand it back to me.** If a task genuinely requires a second branch checked out at the same time, **stop and tell me** — creating worktrees is my call, done through my tool's own worktree feature so the session is actually bound to it. Never improvise one yourself.
-- **Start from a clean working tree.** If uncommitted changes are present, stop and ask me to commit or stash before beginning work.
-- **Never merge, push, or commit to `main` directly** — leave the branch for me to review and merge.
-- **Review branches in-tree** (`git diff --stat main..<branch>`, re-run any acceptance criteria).
-- When searching (`glob`/`grep`), scope to `packages/` and `apps/` — don't recurse into `.worktrees/` (any existing worktrees there would duplicate results).
-
-The test this section enforces: if the workspace bound to this session can't see your changes — because they're in a worktree (anywhere, `.worktrees/` included) or under `$TMPDIR` — that's the failure mode. Edit the tree the session is already bound to.
+- Work only in the session's current working tree. Never create a worktree,
+  including through a skill, subagent, temporary directory, or `.worktrees/`.
+- Do not overwrite or hide existing changes. If unexpected changes exist before
+  work starts, stop and ask the user to commit or stash them.
+- Use a dedicated branch. Never commit, merge, or push directly to `main`.
+- Before branch creation or another non-read-only git action, show the intended
+  commit message and get approval.
+- Never commit until the user approves the exact commit message.
+- Never push without explicit approval in the same message.
+- Never create or merge a PR unless the user asks in that turn. Show the PR
+  title and description for approval first.
+- Never rebase, delete branches, or amend commits without explicit approval.
+- Force-push only with explicit approval to update an existing PR.
+- Do not add agent attribution or `Co-authored-by:` trailers.
+- If parallel work needs another branch, stop and ask the user to create the
+  workspace through their tool.

--- a/.agents/agents.md
+++ b/.agents/agents.md
@@ -180,6 +180,18 @@ These rules apply to the API-wrapper packages (`@web-ai-sdk/prompt`, `webmcp`, `
 - **READMEs are user-facing.** Show install, the smallest possible vanilla example, the smallest possible React example, then the API surface.
 - Don't write design docs unless the user asks. Conventions live here; package-specific decisions live in the package README.
 
+### Documentation style
+
+Use a house style inspired by [ASD-STE100 Simplified Technical English](https://www.asd-ste100.org/about_STE.html). Do not claim formal STE compliance.
+
+- Aim for 25 words or fewer in a prose sentence. Split sentences that contain more than one claim or action.
+- Use active voice and direct verbs. Use the imperative form for instructions.
+- Use one term for one concept. Do not alternate between synonyms for variety.
+- State behavior before rationale. Put conditions and exceptions next to the behavior they modify.
+- Replace hype, metaphors, and rhetorical claims with concrete behavior.
+- Keep paragraphs short. Use a list or table only when it makes comparison or scanning easier.
+- Preserve API names and required technical terms. Define an uncommon term at first use.
+
 ### Docs reliability
 
 - Treat docs examples as part of the public API. When editing or reviewing docs, verify option names, result shapes, hook return values, and helper export names against the actual exported TypeScript interfaces and runtime tests.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,13 +7,13 @@ Thanks for considering a contribution. This file is the human-facing entry point
 ```sh
 git clone https://github.com/obetomuniz/web-ai-sdk.git
 cd web-ai-sdk
-pnpm install     # Node 24 from .nvmrc + pnpm 9.15.0 from Corepack
+pnpm install     # Node 24 from .nvmrc + pnpm 10.34.3 from Corepack
 pnpm gate        # lint + build + typecheck + test
 ```
 
 If `pnpm gate` passes, your local environment matches CI.
 
-If you don't already have Node, install it once (via [nvm](https://github.com/nvm-sh/nvm), [fnm](https://github.com/Schniz/fnm), [Volta](https://volta.sh/), `brew`, or whatever you prefer); it'll respect `.nvmrc`. Corepack ships with Node 16.13+ and provisions the right `pnpm` version from `package.json` automatically.
+Install Node with a version manager or package manager. This repository uses the version in `.nvmrc`. Corepack reads the pnpm version from `package.json`.
 
 ## Project shape
 
@@ -30,6 +30,12 @@ See the [README "Repo layout" section](./README.md#repo-layout) for the full tre
 3. **Run `pnpm gate`.** It runs Biome, builds packages and apps, typechecks every workspace, and runs every test. CI runs the same gate, so a clean local gate equals a passing PR.
 4. **Add a changeset** if you're shipping a user-facing change. `pnpm changeset` opens an interactive picker. Skip this for docs-only or internal changes.
 5. **Open a PR** against `main`. The CI workflow will rerun the gate; the release workflow opens a "Version Packages" PR when there are pending changesets to publish.
+
+## Writing documentation
+
+Use the documentation rules in [`.agents/agents.md`](./.agents/agents.md#documentation-style). They apply to public docs, READMEs, demos, home copy, and maintainer guidance.
+
+The style is inspired by Simplified Technical English, but the project does not claim formal compliance. Prefer short sentences, direct verbs, consistent terms, and concrete behavior.
 
 ## Governance
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,126 +1,121 @@
 # Contributing to web-ai-sdk
 
-Thanks for considering a contribution. This file is the human-facing entry point. For deeper conventions and the rules every change should follow, see [`.agents/agents.md`](./.agents/agents.md); the same rules apply whether you or an AI agent wrote the patch.
+This guide covers setup, change workflow, and SDK governance. Repository rules
+in [`.agents/agents.md`](./.agents/agents.md) apply to human and agent-authored
+changes.
 
-## TL;DR
+## Setup
 
 ```sh
 git clone https://github.com/obetomuniz/web-ai-sdk.git
 cd web-ai-sdk
-pnpm install     # Node 24 from .nvmrc + pnpm 10.34.3 from Corepack
-pnpm gate        # lint + build + typecheck + test
+pnpm install
+pnpm gate
 ```
 
-If `pnpm gate` passes, your local environment matches CI.
+Use the Node version in `.nvmrc`. Corepack reads the pnpm version from
+`package.json`. `pnpm gate` runs the same checks as CI.
 
-Install Node with a version manager or package manager. This repository uses the version in `.nvmrc`. Corepack reads the pnpm version from `package.json`.
+Published packages live in `packages/`. The Astro site and Starlight docs live
+in `apps/site/`. Run `pnpm run` to list all workflows.
 
-## Project shape
+## Change workflow
 
-- `packages/<name>/`: the published packages. Each is independently versioned (Changesets) and has its own `README.md`, tests, and per-package `package.json`.
-- `apps/site/`: the Astro marketing site with Starlight docs mounted at `/docs/`. Home page code lives under `src/pages/`, docs content under `src/content/docs/`, and docs demo components under `src/features/docs/components/`. Styling guardrails: [`apps/site/README.md`](./apps/site/README.md).
-- `package.json` scripts: every workflow command (build, test, lint, docs, site, gate, pages, release) is a pnpm script. `pnpm run` lists them.
+1. Change one package or app at a time when possible.
+2. Add tests beside package source as `*.test.ts` or `*.test.tsx`.
+3. Follow the [documentation style](./.agents/agents.md#documentation-and-copy)
+   for docs, READMEs, demos, home copy, and maintainer guidance.
+4. Run focused checks while iterating.
+5. Add a changeset for a user-facing package change. Skip changesets for docs
+   and internal-only changes.
+6. Run `pnpm gate` before committing.
+7. Open a PR against `main`.
 
-See the [README "Repo layout" section](./README.md#repo-layout) for the full tree.
+## SDK rules
 
-## Making a change
+- One package wraps one browser capability.
+- Core wrappers have no runtime dependencies. `@web-ai-sdk/all` may depend on
+  the wrapper packages it re-exports.
+- `react` is the only allowed optional peer dependency.
+- Published wrapper packages do not import from each other. Application code
+  composes capabilities.
+- The framework-agnostic entry is the source of truth. `/react` is a thin hook
+  adapter in the same package.
+- Defaults may manage sessions, caches, streams, and cleanup within one
+  capability. Users must be able to disable or replace optional behavior.
+- Do not break public behavior without migration guidance and an appropriate
+  changeset.
 
-1. **Pick a package or app.** Library bugs live under `packages/<name>/src/`. Docs improvements live under `apps/site/src/content/docs/`. Marketing tweaks live under `apps/site/src/`.
-2. **Add or update tests** when you touch package source. Tests live next to source as `*.test.ts` / `*.test.tsx`. Use `pnpm --filter @web-ai-sdk/<name> test` to focus on one package.
-3. **Run `pnpm gate`.** It runs Biome, builds packages and apps, typechecks every workspace, and runs every test. CI runs the same gate, so a clean local gate equals a passing PR.
-4. **Add a changeset** if you're shipping a user-facing change. `pnpm changeset` opens an interactive picker. Skip this for docs-only or internal changes.
-5. **Open a PR** against `main`. The CI workflow will rerun the gate; the release workflow opens a "Version Packages" PR when there are pending changesets to publish.
-
-## Writing documentation
-
-Use the documentation rules in [`.agents/agents.md`](./.agents/agents.md#documentation-style). They apply to public docs, READMEs, demos, home copy, and maintainer guidance.
-
-The style is inspired by Simplified Technical English, but the project does not claim formal compliance. Prefer short sentences, direct verbs, consistent terms, and concrete behavior.
-
-## Governance
-
-These rules define what belongs in `@web-ai-sdk/*` and what doesn't. They're the load-bearing constraints behind the [Architecture](./apps/site/src/content/docs/architecture.mdx) page; if you're proposing a change to the SDK surface, read both.
-
-1. **No runtime dependencies in any `@web-ai-sdk/*` package.** `package.json` `dependencies` must be empty or absent. The one explicit exception is the meta-package `@web-ai-sdk/all`, which depends on the eight wrapper packages as workspace deps so a single install ships the suite.
-2. **No `peerDependencies` except an optional `react` peer.** The `/react` subpath adapter is the only published surface allowed to peer on a framework. No Vue / Svelte / Solid / etc. peers; those would each be a new subpath on the same package, not a new package.
-3. **One package = one cohesive capability.** If you can't describe a package in one sentence without "and," it's two packages. The capability can originate from an official Built-in AI API (`LanguageModel`, `Summarizer`, `Translator`, `Detector`), an adjacent web standard (`WebMCP`, and likely `WebGPU` / `WebNN` in the future), or, rarely, a zero-dep SDK-authored primitive with no platform equivalent yet.
-4. **No SDK package may import from another published `@web-ai-sdk/*` package.** Composition across capabilities is the future kit's job by definition, not the SDK's. The meta-package is exempt because re-exporting is its only job.
-5. **Vanilla trunk + `/react` adapter as subpath.** A package's `src/index.ts` is the source of truth. `src/react/index.ts` is a thin wrapper. There is no `@web-ai-sdk/*-react` package and there shouldn't be.
-6. **Ergonomic defaults are allowed inside a package** (warm session pools, opt-in result caches, stream normalization), as long as they're scoped to that one capability and the user can override or disable them.
-
-For the time being these rules are enforced by review, not by CI. If you open a PR that adds `dependencies` or non-`react` `peerDependencies` to a `@web-ai-sdk/*` wrapper, expect to be asked to remove them or to land the work in the future kit instead. Shared infrastructure across packages (feature detection, stream normalization, error classes) will live in a private `@web-ai-sdk/internal` package the first time it's actually needed; until then, copy small helpers between packages rather than designing the shared layer upfront.
+See [Architecture](./apps/site/src/content/docs/architecture.mdx) for the public
+description of these boundaries.
 
 ## Capability adoption policy
 
-New browser capabilities enter the SDK according to evidence, not a target date. Classify a proposal before scaffolding a package:
+Classify a capability before creating a package.
 
-| Stage | Evidence | Repository treatment |
-| --- | --- | --- |
-| **Tracked** | An authoritative public proposal exists, but there is no publicly documentable implementation or the API shape is too incomplete to wrap responsibly. | Track the capability in an issue. Do not scaffold or publish a package. |
-| **Preview** | Maintainers can run the capability from public instructions, the execution and lifecycle shape is coherent, and a wrapper adds material value. Flags and preview browsers are acceptable. | An experimental `0.x` package may ship with a prominent status notice and exact public setup requirements. |
-| **Trial** | The capability is available through a public developer or origin trial. | Keep the package `0.x`, expand real-browser coverage and demos, and document trial constraints. |
-| **Stable** | At least one stable browser exposes the capability without an opt-in flag or trial token. | Mark browser support stable. A `1.0` package release remains a separate decision based on the wrapper's own API stability. |
-| **Retired** | The proposal is withdrawn, replaced, or no longer implementable. | Deprecate instead of silently repurposing the package, and publish migration guidance when a successor exists. |
+| Stage | Repository treatment |
+| --- | --- |
+| **Tracked** | Keep it as an issue. Public information is not sufficient for a package. |
+| **Preview** | An experimental `0.x` package may ship from runnable public instructions. Document required flags or preview browsers. |
+| **Trial** | Keep the package `0.x`. Document public trial limits and expand browser coverage. |
+| **Stable** | Mark stable browser support. Package `1.0` remains a separate API decision. |
+| **Retired** | Deprecate the package and document migration. Do not silently repurpose it. |
 
-### Admission gates
+A capability must pass every gate before moving from Tracked to Preview:
 
-A capability must satisfy every gate before it moves from Tracked to Preview:
+1. An authoritative public source provides enough information to run and
+   document it.
+2. The capability has one cohesive package boundary.
+3. The wrapper adds lifecycle value beyond types.
+4. It remains framework-agnostic, deterministic in tests, and free of runtime
+   dependencies.
+5. Unsupported environments have explicit behavior.
+6. Persistence, DOM traversal, cross-capability workflows, and unrelated
+   algorithms stay outside the wrapper.
 
-1. **Public evidence:** an authoritative explainer, specification, or browser-vendor document describes the capability, and public instructions are sufficient to test and document it.
-2. **Cohesive boundary:** it maps to one browser capability and fits the one-package rule.
-3. **Material wrapper value:** the package owns a real lifecycle or ergonomics gap such as feature detection, availability, session reuse, cleanup, abort handling, error normalization, or stream normalization. Types alone are not enough.
-4. **Contract fit:** it can remain framework-agnostic, zero-runtime-dependency, testable without the real browser implementation, and independently usable without importing another SDK package.
-5. **Progressive enhancement:** unsupported environments have a deliberate, documented behavior.
-6. **Honest scope:** result caching, persistence, DOM traversal, cross-capability composition, and helper algorithms are included only when they independently satisfy the SDK's scope rules.
+Published issues, PRs, docs, demos, changelogs, and releases must rely on public
+sources. Never disclose details from confidential or restricted previews. Keep
+the capability Tracked when public evidence is insufficient.
 
-Published artifacts must stand entirely on public sources. Confidential, restricted, or private-preview material may inform an internal go/no-go discussion, but it must never be linked, quoted, paraphrased, or used to disclose non-public versions, flags, behavior, or timelines in issues, PRs, READMEs, docs, demos, changelogs, or release notes. If public evidence is insufficient, the capability remains Tracked.
+An admitted package normally includes:
 
-### Integration contract
+- native lookup, types, availability checks, and instance ownership;
+- a public vanilla API with package-specific errors;
+- a thin React hook;
+- vanilla and React lifecycle tests;
+- a package README, site guides, a demo, and browser-support details;
+- meta-package exports and a changeset.
 
-An admitted wrapper normally includes:
+Do not copy ergonomics mechanically from another package. Reuse sessions only
+when it is safe. Evict rejected creation promises. Cache results only with a
+complete key and lossless serialization. Preserve native result metadata when
+it affects compatibility or lifecycle.
 
-- `src/api.ts`: native types, global lookup, `isAvailable()`, `checkAvailability()`, and native instance ownership.
-- `src/index.ts`: the vanilla high-level operation, public result types, and package-specific errors.
-- `src/react/index.ts`: a thin hook over the vanilla operation with honest effect dependencies.
-- Vanilla and React lifecycle tests, a package README, site guides and demo, browser-support documentation, meta-package exports, and a changeset.
+## First package release
 
-Unavailability behavior is consistent by entry-point role:
+CI can update an existing npm package but cannot create a new one. Publish the
+first version locally as an npm organization member:
 
-- Detection and probe helpers do not throw: `isAvailable()` returns `false`, and `checkAvailability()` returns `null`, when the native API cannot be used.
-- High-level vanilla execution may throw a package-specific typed unavailability error so callers can branch explicitly.
-- React hooks absorb that error and expose an `"unavailable"` state.
-- Registration-style APIs may instead return an idempotent no-op cleanup when that preserves their natural call shape.
+```sh
+npm login
+pnpm build:packages
+cd packages/<new>
+npm publish --access public --provenance=false
+```
 
-Capability-specific ergonomics are not copied mechanically from the nearest package:
-
-- Cache native sessions only when reuse is safe. Bound or explicitly clear the cache, destroy evicted instances, and remove rejected creation promises so later calls can retry.
-- Add result caching only when every output-shaping input can be keyed, the output has a lossless serialization, and serving a stored result remains semantically valid. Include a version or compatibility discriminator when the capability's outputs depend on one.
-- Preserve structured native results when their metadata carries compatibility or lifecycle meaning.
-- Add download monitoring, streaming, or abort forwarding only when the native capability supports it or the wrapper can describe its weaker semantics precisely.
-
-Promotion between stages is a documentation and support decision, not automatically a breaking release. Breaking wrapper changes still follow Changesets and the package's current semantic-versioning contract.
-
-## Adding a new package
-
-1. Confirm the capability has reached Preview, Trial, or Stable under the adoption policy above. A Tracked capability stays as an issue.
-2. Copy an existing package whose shape matches what you need (`prompt` if you want streaming + session cache + opt-in result cache, `webmcp` if you want an AbortSignal registry, `translator` if you want DOM-walking).
-3. Mirror the file layout: `src/api.ts` (adapter over the global, feature-detected), `src/index.ts` (public API + typed unavailability error), `src/react/index.ts` (thin hook adapter), `src/*.test.ts` (vanilla tests), `src/react/index.test.tsx` (React hook tests). Optional: `src/cache.ts` only when the capability meets the result-cache gate above.
-4. Add the package to the Pages docs (`apps/site/src/content/docs/guides/<name>.mdx`, `apps/site/src/content/docs/react/use-<name>.mdx`, plus a demo component) and to the home page's package row.
-5. Add a changeset.
-6. Run `pnpm gate`.
-7. **Publish the first version locally.** A brand-new package can't be created by CI (OIDC Trusted Publishing needs the package to already exist, and a CI token can't create new `@web-ai-sdk` packages — npm returns a masked `404`). Do the initial publish by hand: `npm login`, `pnpm build:packages`, then `cd packages/<new> && npm publish --access public --provenance=false`. After that, set up a Trusted Publisher for it on npm and CI handles every later version.
-
-See [`.agents/agents.md` § "Add a new tool / wrapper package"](./.agents/agents.md#add-a-new-tool--wrapper-package) and [§ "Cut a release"](./.agents/agents.md#cut-a-release) for the full conventions.
+Then configure npm Trusted Publishing for the package and `release.yml`.
+Changesets handles later releases.
 
 ## Reporting bugs
 
 [Open an issue](https://github.com/obetomuniz/web-ai-sdk/issues) with:
 
-- A short repro (StackBlitz, CodeSandbox, or a minimal repo).
-- Browser + version (`chrome://version` or `edge://version`).
-- Which package + which API surface (`@web-ai-sdk/summarizer`, the vanilla `summarize()` call, etc).
-- For unavailability errors: paste the relevant `chrome://on-device-internals` or `edge://on-device-internals` state.
+- a minimal reproduction;
+- browser and version;
+- package and API entry;
+- relevant `chrome://on-device-internals` or
+  `edge://on-device-internals` state for availability problems.
 
 ## License
 
-Contributions are licensed under [MIT](./LICENSE), the same as the project.
+Contributions use the project [MIT license](./LICENSE).

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -45,96 +45,89 @@ shadows:
 
 # DESIGN.md
 
-This is the source of truth for the web-ai-sdk visual identity. It is written
-for humans and AI agents making UI changes in this repository.
+This file defines the production visual system. Humans and agents must follow
+it for UI changes.
 
-Production ships one static skin: **Noir / Dark**. The dev-only Tone Lab in
-`apps/site/src/shared/themes.ts` can test alternate token sets, but production
-must keep the baked Noir / Dark defaults unless the design system changes.
+Production uses **Noir / Dark**. The dev-only Tone Lab in
+`apps/site/src/shared/themes.ts` may test other tokens. Do not ship those tokens
+without a design-system change.
 
-## Identity
+## Principles
 
-web-ai-sdk should feel precise, quiet, local-first, and technical. The product
-wraps native browser AI primitives, so the interface should read as a thin
-instrument panel rather than a heavy SaaS dashboard.
+- Use neutral surfaces and white interaction signals.
+- Reserve color for success, warning, and error.
+- Create hierarchy with type, spacing, and surface depth.
+- Keep motion subtle and functional.
+- Prefer clear controls over decoration.
 
-Use white as the primary signal. Colour is reserved for semantic status:
-success, warning, and error.
-
-## Color Semantics
+## Color
 
 - `bg` is the page background.
-- `surface`, `surface2`, and `surface3` create depth through fills.
-- `hairline` and `hairline2` are for recessed controls and internal structure.
-- `fg`, `fg2`, `fg3`, and `fg4` are text hierarchy.
-- `accent`, `accentBright`, `accentDim`, `accentSoft`, and `accentLine` are the
-  white interaction ramp.
-- `ok`, `warn`, and `err` are semantic and should not be repurposed for brand
-  decoration.
+- `surface`, `surface2`, and `surface3` create depth.
+- `hairline` and `hairline2` define recessed controls and internal structure.
+- `fg` through `fg4` define text hierarchy.
+- `accent` tokens define the white interaction ramp.
+- `ok`, `warn`, and `err` are status colors. Do not use them as decoration.
 
-Avoid orange, blue brand glows, and large ambient colour fields. The only page
-glow should be a subtle neutral background glow.
+Avoid colored brand glows and large ambient color fields. Use only a subtle
+neutral page glow.
 
-## Typography
+## Type
 
-- Display: Space Grotesk for headings.
-- Body: Geist for prose and UI.
-- Mono: IBM Plex Mono for code, labels, eyebrows, and the wordmark.
-- Headings should be tight and calm, with small negative tracking.
-- Code and terminal-inspired UI should prioritize readability over strict
-  monochrome styling.
+- Use Space Grotesk for headings.
+- Use Geist for prose and controls.
+- Use IBM Plex Mono for code, labels, eyebrows, and the wordmark.
+- Use tight heading line height and small negative tracking.
+- Keep syntax highlighting colorful enough to scan.
 
-## Surfaces And Elevation
+## Surfaces and interaction
 
-- Cards and panels use elevation, not outer borders.
+- Use elevation instead of outer borders on cards and panels.
 - Never use inner shadows.
-- Inputs, textareas, selects, code pills, and output boxes are recessed:
-  darker fill plus hairline.
-- Hover should lighten surfaces or move arrows subtly. Avoid blurry halos.
-- Focus and active states should be crisp rings or crisp border changes.
+- Recess inputs, code pills, and output boxes with a darker fill and hairline.
+- Use a light surface change or small arrow movement on hover.
+- Use crisp rings or border changes for focus and active states.
+- Avoid blurry interaction halos.
+
+Primary actions use a white fill, dark text, and pill radius. Ghost actions use
+a transparent fill, muted border, and foreground text. Small demo controls may
+use a smaller radius but must keep the same focus treatment.
 
 ## Motion
 
-- Use an underscore caret as the brand signature.
-- Motion should be subtle and functional: streaming text, small arrow nudges,
-  scroll reveal, button press, shader movement.
+- Use the underscore caret as the brand signature.
+- Use motion for state changes, streaming, reveal, and direct feedback.
 - Respect `prefers-reduced-motion`.
-- WebGL effects must no-op when unsupported, pause off-screen, and cap DPR.
+- Make unsupported WebGL effects no-op. Pause them off-screen and cap DPR.
 
-## Components
+## Layout and components
 
-- Primary CTA: white fill, dark text, pill radius.
-- Ghost CTA: transparent or background fill, muted border, foreground text.
-- Small demo controls may use smaller radius, but should keep the same recessed
-  and focus language.
-- Section anchors use `id`, `sectionAnchor`, and `data-section` for scroll spy.
-- Use mutually exclusive classes for stateful variants. Do not compose active
-  and inactive utility sets if they conflict.
-- Keep syntax highlighting colourful enough to parse quickly. Noir does not
-  require monochrome code.
+- Section anchors use `id` and `sectionAnchor`. Outer sections use
+  `data-section` for scroll spy.
+- Use mutually exclusive classes for state variants.
+- Do not combine active and inactive utilities when they conflict.
+- Keep visible structure aligned to the page grid.
 
 ## Accessibility
 
-- Text and surface pairings must pass WCAG AA.
-- `fg4` is intentionally brighter than a purely decorative grey so metadata
-  remains readable on deep surfaces.
-- Decorative controls and shortcuts should be hidden from the accessibility
-  tree when they do not add information.
-- Maintain heading order and landmark structure.
+- Text and surface combinations must pass WCAG AA.
+- Keep `fg4` readable on deep surfaces.
+- Hide decorative controls and shortcuts from the accessibility tree.
+- Preserve heading order, landmarks, keyboard access, and visible focus.
 
-## Implementation Map
+## Files
 
-- Home page tokens: `apps/site/src/styles/home.css`
+- Tokens and base styles: `apps/site/src/styles/home.css`
 - Shared Tailwind compositions: `apps/site/src/shared/ui.ts`
 - Dev-only token derivation: `apps/site/src/shared/themes.ts`
-- Home page React islands: `apps/site/src/features/home/components/`
-- Docs styling: `apps/site/src/features/docs/styles/`
-- Brand assets: `apps/site/public/favicon.svg`, `apps/site/public/og-image.png`
+- Home components: `apps/site/src/features/home/components/`
+- Docs styles: `apps/site/src/features/docs/styles/`
+- Brand assets: `apps/site/public/favicon.svg` and
+  `apps/site/public/og-image.png`
 - OG image generator: `apps/site/scripts/build-og-image.mjs`
 
-## Writing Rules
+## Copy and comments
 
-- Do not use em dashes in copy, comments, or docs.
-- Prefer short, direct technical prose.
-- Comments should explain intent, constraints, or non-obvious behavior, not
-  restate the code.
+Follow the [documentation style](./.agents/agents.md#documentation-and-copy).
+Do not use em dashes. Comments should explain intent, constraints, or
+non-obvious behavior instead of restating code.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **web-ai-sdk is a TypeScript SDK for the Web AI surface.**
 
-Use Prompt, Writer, Rewriter, Proofreader, Translator, Summarizer, Language Detector, and WebMCP with a stable, typed, composable interface, instead of wiring up each experimental browser API by hand.
+Use Prompt, Writer, Rewriter, Proofreader, Translator, Summarizer, Language Detector, and WebMCP with a stable, typed, composable interface, instead of wiring up each browser API by hand.
 
 ```ts
 import { ask } from "@web-ai-sdk/prompt";
@@ -16,7 +16,7 @@ A small, focused monorepo of framework-agnostic packages that smooth over the gn
 
 ## Why this exists
 
-The Web AI surface is promising but still early and shifting. Every app that touches it re-implements the same lifecycle: feature-detect, wait for model availability, create and reuse sessions, stream chunks, abort cleanly, and fall back when the capability is missing. web-ai-sdk owns that layer so you build against one stable, typed surface rather than coupling your whole app to today's experimental API shape. The wrappers feature-detect and no-op when a browser lacks the API, so the same code ships everywhere.
+The Web AI surface is promising but still early and shifting. Every app that touches it re-implements the same lifecycle: feature-detect, wait for model availability, create and reuse sessions, stream chunks, abort cleanly, and fall back when the capability is missing. web-ai-sdk owns that layer so you build against one stable, typed surface rather than coupling your whole app to today's experimental API shape. The wrappers feature-detect and expose deliberate unavailable behavior, so the same code can ship with a useful fallback.
 
 The SDK is per-capability because the Web ships more than one AI surface. Six specialized built-ins (Translator, Summarizer, Writer, Rewriter, Proofreader, Language Detector) each carry option spaces a single text-model abstraction cannot express, and WebMCP (`document.modelContext`) is an agent surface rather than a model at all. That breadth is the point, not an accident. One package per capability, and the model abstraction is one of them rather than the whole product.
 
@@ -25,6 +25,8 @@ The SDK is per-capability because the Web ships more than one AI surface. Six sp
 **`web-ai-sdk`** ships one package per browser capability. Zero runtime dependencies. Written in TypeScript. That's it. The SDK tracks a moving browser spec and intentionally stays out of the way of *how* you build an app.
 
 All model output is untrusted. The SDK strips selected non-printing control characters; that cleanup does **not** make HTML or Markdown safe. Use React interpolation or `textContent` for plain text. If you convert model Markdown or HTML into rendered HTML, keep raw HTML disabled and sanitize the complete accumulated output before inserting it into the DOM—never sanitize and concatenate individual stream chunks, because malicious syntax can span updates.
+
+Before shipping, use the [Production checklist](./apps/site/src/content/docs/production-checklist.mdx) for intent-driven preparation, task-relevant text extraction, session lifetime, progress, reversible edits, and expiring caches.
 
 Compositions that bond multiple primitives (block-level DOM translation,
 article-aware summarization, detect-then-summarize chains) are
@@ -37,7 +39,7 @@ See [`apps/site/src/content/docs/architecture.mdx`](./apps/site/src/content/docs
 | ------------------------------------------------ | ---------------------------------------------- | ------------------------------------------------------------------------- |
 | [`@web-ai-sdk/webmcp`](./packages/webmcp)            | `document.modelContext` (W3C WebMCP)           | Safe register/unregister, shorthand annotations, `useWebMCP` hook         |
 | [`@web-ai-sdk/translator`](./packages/translator)    | Web Built-in `Translator`                   | String-mode translation, pair-cached sessions, opt-in result caching       |
-| [`@web-ai-sdk/summarizer`](./packages/summarizer)    | Web Built-in `Summarizer`                   | Skeleton extraction, sessionStorage caching, streaming chunks             |
+| [`@web-ai-sdk/summarizer`](./packages/summarizer)    | Web Built-in `Summarizer`                   | Session reuse, opt-in result caching, streaming chunks                     |
 | [`@web-ai-sdk/prompt`](./packages/prompt)            | Web Built-in `LanguageModel` (Prompt API)   | System prompt + sampling, session reuse, streaming, result cache          |
 | [`@web-ai-sdk/detector`](./packages/detector)        | Web Built-in `LanguageDetector`             | Confidence thresholds, bias hints, session reuse, `useDetector` hook      |
 | [`@web-ai-sdk/writer`](./packages/writer)            | Web Built-in `Writer`                       | Tone/format/length, session reuse, streaming, `useWriter` hook            |
@@ -51,11 +53,11 @@ Each package ships:
 
 ## Build for the agentic web
 
-The browser is becoming both an AI runtime and an agent surface. The Built-in AI wrappers (Prompt, Summarizer, Translator, and friends) cover the runtime half: local model capabilities behind one typed interface. [`@web-ai-sdk/webmcp`](./packages/webmcp) covers the agent half: structured, agent-callable tools your page exposes to visiting agents. Feature detection and no-op fallbacks keep the same code shipping everywhere, so neither half is a hard requirement — see [Browser support](./apps/site/src/content/docs/browser-support.mdx) for what's available where.
+The browser is becoming both an AI runtime and an agent surface. The Built-in AI wrappers (Prompt, Summarizer, Translator, and friends) cover the runtime half: local model capabilities behind one typed interface. [`@web-ai-sdk/webmcp`](./packages/webmcp) covers the agent half: structured, agent-callable tools your page exposes to visiting agents. Feature detection and explicit unavailable paths keep the same code shipping with a fallback, so neither half is a hard requirement — see [Browser support](./apps/site/src/content/docs/browser-support.mdx) for what's available where.
 
 ## Why composable
 
-Browsers are shipping Web AI APIs behind flags. The shape changes; the lifecycle is similar across them: feature-detect, lazily create a session, stream chunks, cache results, clean up. Those concerns are framework-agnostic and worth sharing.
+Browsers are shipping Web AI APIs at different maturity levels. The shape changes; the lifecycle is similar across them: feature-detect, lazily create a session, stream chunks, cache results, clean up. Those concerns are framework-agnostic and worth sharing.
 
 **We ship that lifecycle layer.** Framework adapters, polyfills, UI primitives stay optional subpaths so they don't constrain your design system, framework, or styling stack. Pick the layers you need; skip the rest.
 
@@ -97,7 +99,7 @@ pnpm build:packages  # build packages so workspace consumers can resolve them
 pnpm dev             # site at http://localhost:5173/, docs at /docs/
 ```
 
-For the AI APIs to actually run, open a supporting browser. On Chrome, Summarizer/Translator/Detector are stable in 138+ and Prompt is stable in 148+ (no flags); the Writing Assistance APIs (Writer, Rewriter, Proofreader) are developer/origin trials behind their own `chrome://flags/` toggles; WebMCP needs `chrome://flags/#enable-webmcp-testing` through Chrome 148 and joins a public origin trial in Chrome 149. On Edge, only Summarizer is in stable (138+ default-on); Prompt, Translator, Detector, and WebMCP are developer previews in Canary/Dev behind their respective `edge://flags/` toggles. On Windows the four Built-in AI APIs (Prompt, Summarizer, Translator, Detector) work reliably once flagged; macOS sees higher refusal rates from the Phi-4-mini safety pipeline for Prompt and Summarizer. WebMCP on Edge remains rough on both platforms. See [Browser support](./apps/site/src/content/docs/browser-support.mdx) for the per-package matrix and exact flag names.
+For the AI APIs to run, open a supporting browser. Chrome's [current status table](https://developer.chrome.com/docs/ai/built-in-apis) documents Summarizer, Translator, and Language Detector as stable from 138 and Prompt as stable from 148. Writer, Rewriter, and Proofreader currently carry Chrome's **Developer trial** label; their older public origin-trial milestone windows have ended. WebMCP has a [Chrome origin trial from 149](https://developer.chrome.com/docs/ai/webmcp). Microsoft documents Summarizer and the writing APIs in its [Writing Assistance guide](https://learn.microsoft.com/en-us/microsoft-edge/web-platform/writing-assistance-apis), Translator and Language Detector in the [Edge 148 release notes](https://learn.microsoft.com/en-us/microsoft-edge/web-platform/release-notes/148), and Prompt plus WebMCP origin trials in the [Edge 150 release notes](https://learn.microsoft.com/en-us/microsoft-edge/web-platform/release-notes/150). See [Browser support](./apps/site/src/content/docs/browser-support.mdx) for current flags and capability-specific model and hardware requirements.
 
 ## Repo layout
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **web-ai-sdk is a TypeScript SDK for the Web AI surface.**
 
-Use Prompt, Writer, Rewriter, Proofreader, Translator, Summarizer, Language Detector, and WebMCP with a stable, typed, composable interface, instead of wiring up each browser API by hand.
+Use typed lifecycle wrappers for Prompt, Writer, Rewriter, Proofreader, Translator, Summarizer, Language Detector, and WebMCP.
 
 ```ts
 import { ask } from "@web-ai-sdk/prompt";
@@ -10,28 +10,27 @@ import { ask } from "@web-ai-sdk/prompt";
 const { output } = await ask({ input: "Summarize this page in one sentence." });
 ```
 
-A small, focused monorepo of framework-agnostic packages that smooth over the gnarly bits of the new `document.modelContext`, `Translator`, `Summarizer`, `LanguageModel`, `LanguageDetector`, `Writer`, `Rewriter`, and `Proofreader` browser APIs (feature detection, session caching, streaming, lifecycle, and control-character cleanup) without bringing any UI along.
-
-> If you're exploring AI in the browser, a [star on GitHub](https://github.com/obetomuniz/web-ai-sdk) helps others find web-ai-sdk.
+Each package wraps one browser capability. It handles feature detection, sessions, streaming, abort signals, and cleanup. It does not render UI.
 
 ## Why this exists
 
-The Web AI surface is promising but still early and shifting. Every app that touches it re-implements the same lifecycle: feature-detect, wait for model availability, create and reuse sessions, stream chunks, abort cleanly, and fall back when the capability is missing. web-ai-sdk owns that layer so you build against one stable, typed surface rather than coupling your whole app to today's experimental API shape. The wrappers feature-detect and expose deliberate unavailable behavior, so the same code can ship with a useful fallback.
+Browser AI APIs have similar lifecycle requirements. Applications must detect support, create sessions, stream results, abort work, and clean up resources.
 
-The SDK is per-capability because the Web ships more than one AI surface. Six specialized built-ins (Translator, Summarizer, Writer, Rewriter, Proofreader, Language Detector) each carry option spaces a single text-model abstraction cannot express, and WebMCP (`document.modelContext`) is an agent surface rather than a model at all. That breadth is the point, not an accident. One package per capability, and the model abstraction is one of them rather than the whole product.
+`web-ai-sdk` handles that lifecycle. Each wrapper also exposes an unavailable state for fallback UI.
+
+The SDK uses one package per capability. Each built-in has different options and result types. WebMCP exposes page tools instead of generating text.
 
 ## What it is
 
-**`web-ai-sdk`** ships one package per browser capability. Zero runtime dependencies. Written in TypeScript. That's it. The SDK tracks a moving browser spec and intentionally stays out of the way of *how* you build an app.
+`web-ai-sdk` ships TypeScript packages with no runtime dependencies. Application code controls rendering, persistence, and cross-capability workflows.
 
-All model output is untrusted. The SDK strips selected non-printing control characters; that cleanup does **not** make HTML or Markdown safe. Use React interpolation or `textContent` for plain text. If you convert model Markdown or HTML into rendered HTML, keep raw HTML disabled and sanitize the complete accumulated output before inserting it into the DOM—never sanitize and concatenate individual stream chunks, because malicious syntax can span updates.
+Treat all model output as untrusted. Control-character cleanup does not make HTML or Markdown safe.
+
+Use React interpolation or `textContent` for plain text. Sanitize complete formatted output before rendering it. Do not sanitize stream chunks separately.
 
 Before shipping, use the [Production checklist](./apps/site/src/content/docs/production-checklist.mdx) for intent-driven preparation, task-relevant text extraction, session lifetime, progress, reversible edits, and expiring caches.
 
-Compositions that bond multiple primitives (block-level DOM translation,
-article-aware summarization, detect-then-summarize chains) are
-deliberately out of scope — the SDK wraps one capability per package;
-composition is your code.
+The SDK does not walk the DOM or compose capabilities. Application code owns article extraction and detect-then-summarize flows.
 
 See [`apps/site/src/content/docs/architecture.mdx`](./apps/site/src/content/docs/architecture.mdx) (rendered at [`web-ai-sdk.dev/docs/architecture/`](https://web-ai-sdk.dev/docs/architecture/)) for the full model.
 
@@ -51,21 +50,21 @@ Each package ships:
 - **Vanilla** entry (`@web-ai-sdk/<pkg>`): TypeScript / DOM only, zero framework deps.
 - **React** entry (`@web-ai-sdk/<pkg>/react`): small hook adapter wrapping the vanilla core. `react` is an optional peer dep.
 
-## Build for the agentic web
+## Browser AI and WebMCP
 
-The browser is becoming both an AI runtime and an agent surface. The Built-in AI wrappers (Prompt, Summarizer, Translator, and friends) cover the runtime half: local model capabilities behind one typed interface. [`@web-ai-sdk/webmcp`](./packages/webmcp) covers the agent half: structured, agent-callable tools your page exposes to visiting agents. Feature detection and explicit unavailable paths keep the same code shipping with a fallback, so neither half is a hard requirement — see [Browser support](./apps/site/src/content/docs/browser-support.mdx) for what's available where.
+The Built-in AI packages wrap local browser capabilities. [`@web-ai-sdk/webmcp`](./packages/webmcp) registers page tools for compatible agents.
 
-## Why composable
+All packages use feature detection. See [Browser support](./apps/site/src/content/docs/browser-support.mdx) for current availability.
 
-Browsers are shipping Web AI APIs at different maturity levels. The shape changes; the lifecycle is similar across them: feature-detect, lazily create a session, stream chunks, cache results, clean up. Those concerns are framework-agnostic and worth sharing.
+## Scope
 
-**We ship that lifecycle layer.** Framework adapters, polyfills, UI primitives stay optional subpaths so they don't constrain your design system, framework, or styling stack. Pick the layers you need; skip the rest.
+The core packages handle browser API lifecycles. They do not include UI, polyfills, DOM traversal, or cross-capability orchestration.
 
-This is the same shape mature utility libraries converge on as the platform catches up (lodash → native methods, moment/date-fns → `Temporal`): a thin shim over a native primitive that gets *thinner* as the primitive stabilizes. See [Architecture § Lineage](./apps/site/src/content/docs/architecture.mdx) for the full reasoning.
+React hooks ship as optional subpaths. See [Architecture](./apps/site/src/content/docs/architecture.mdx) for the complete boundaries.
 
 ## Install
 
-Pick the building blocks you need, or grab the whole suite in one install:
+Install one package or all eight:
 
 ```sh
 pnpm add @web-ai-sdk/webmcp        # one block
@@ -99,7 +98,7 @@ pnpm build:packages  # build packages so workspace consumers can resolve them
 pnpm dev             # site at http://localhost:5173/, docs at /docs/
 ```
 
-For the AI APIs to run, open a supporting browser. Chrome's [current status table](https://developer.chrome.com/docs/ai/built-in-apis) documents Summarizer, Translator, and Language Detector as stable from 138 and Prompt as stable from 148. Writer, Rewriter, and Proofreader currently carry Chrome's **Developer trial** label; their older public origin-trial milestone windows have ended. WebMCP has a [Chrome origin trial from 149](https://developer.chrome.com/docs/ai/webmcp). Microsoft documents Summarizer and the writing APIs in its [Writing Assistance guide](https://learn.microsoft.com/en-us/microsoft-edge/web-platform/writing-assistance-apis), Translator and Language Detector in the [Edge 148 release notes](https://learn.microsoft.com/en-us/microsoft-edge/web-platform/release-notes/148), and Prompt plus WebMCP origin trials in the [Edge 150 release notes](https://learn.microsoft.com/en-us/microsoft-edge/web-platform/release-notes/150). See [Browser support](./apps/site/src/content/docs/browser-support.mdx) for current flags and capability-specific model and hardware requirements.
+The demos require a browser that supports the selected API. See [Browser support](./apps/site/src/content/docs/browser-support.mdx) for versions, flags, trials, and hardware requirements.
 
 ## Repo layout
 
@@ -145,7 +144,7 @@ Toolchain: Node 24 (pinned in `.nvmrc`) + pnpm 10.34.3 (pinned via `package.json
 
 ## Roadmap
 
-Directional, not a commitment. The bias is toward owning only the lifecycle and ergonomics the raw APIs leave rough, and thinning out as the Web AI APIs stabilize.
+This roadmap is not a release commitment. New work must stay within the lifecycle scope.
 
 - Cloud / custom-provider fallback for unsupported browsers
 - More browser compatibility helpers

--- a/apps/site/README.md
+++ b/apps/site/README.md
@@ -1,66 +1,50 @@
-# @web-ai-sdk-apps/site
+# Site
 
-Marketing site and live demos for **web-ai-sdk**. Astro static output with Starlight docs mounted at `/docs/`, deployed at the GitHub Pages root (`web-ai-sdk.dev`).
+Astro site for `web-ai-sdk`. It contains the home page, Starlight docs at
+`/docs/`, the Playground, and live React demos.
 
 ```sh
-pnpm build:packages # build packages first (demos import SDK dist)
-pnpm site        # http://localhost:5173 and /docs/
+pnpm build:packages
+pnpm site # http://localhost:5173
 ```
 
-Brand tokens and type stack (Noir / Dark): [`DESIGN.md`](../../DESIGN.md).
+Build packages first because the demos import their generated output.
 
----
+## Styling
 
-## Styling guardrails
+Follow the root [`DESIGN.md`](../../DESIGN.md).
 
-The site is on **Tailwind CSS v4** (`@tailwindcss/vite` through Astro). Treat utility classes as the default styling surface; avoid growing new hand-written CSS.
+The home page uses Tailwind CSS v4:
 
-### Do
+- Add shared patterns to `src/shared/ui.ts` first.
+- Keep `src/styles/home.css` limited to tokens, layout variables, keyframes, and
+  base resets.
+- Use local Tailwind utilities only for one-off layout details.
+- Use mutually exclusive class sets for conflicting states.
+- Use inline styles only for dynamic values that Tailwind cannot know.
+- Do not add component stylesheets or static `<style>` blocks to home React
+  components.
+- Consolidate nearby legacy utility strings when editing a mixed component.
 
-| Layer | Role |
-| ----- | ---- |
-| `src/shared/ui.ts` | Composed Tailwind class strings shared across sections and demos. **Add new UI patterns here first.** |
-| `src/styles/home.css` | Tailwind entry only: `@theme` design tokens, layout CSS variables (`--nav-height`, `--section-py`, `--gutter`), `@keyframes`, and minimal `@layer base` resets via `@apply`. |
-| `src/pages/index.astro` | Static marketing HTML and React island placement. Keep copy, layout, and SEO metadata here. |
-| React components | Import from `ui.ts`. One-off layout tweaks may use inline Tailwind utilities in JSX when they are truly local. |
+Docs styles live under `src/features/docs/styles/`. Do not apply home-page CSS
+constraints mechanically to Starlight components.
 
-**Patterns**
+`public/404.html` is standalone and may use plain CSS. Do not copy its patterns
+into bundled components.
 
-- Prefer **mutually exclusive** class sets for state (e.g. `chipActive : chip`, `tabActive : tab`). Do not merge a shared base with an active variant when utilities conflict in CSS order.
-- Section nav anchors: `id` + `sectionAnchor` on headings; `data-section` on the outer `<section>` for scroll spy.
-- Dynamic values only: `style={{ width: \`${pct}%\` }}` (or similar) when the value cannot be a static utility.
+## Structure
 
-### Don't
+- `src/pages/index.astro`: home sections, metadata, and island placement.
+- `src/shared/ui.ts`: shared Tailwind compositions.
+- `src/styles/home.css`: tokens and base layer.
+- `src/features/home/components/`: home React islands.
+- `src/features/docs/`: docs components and styles.
+- `src/features/playground/README.md`: Playground architecture and invariants.
 
-- **No new `.css` files** under `src/` (no `components.css`, no page-level stylesheets).
-- **No raw CSS in React** (`style={{ color: '…' }}`, `<style>` tags in components).
-- **No `innerHTML` styling hooks** — use Tailwind utilities or `ui.ts` exports.
-- **Don't reintroduce** legacy token aliases (`--bg`, `--surface`, …) unless a standalone static file needs them.
+Home section anchors use `id` and `sectionAnchor`. Add `data-section` to the
+outer section for scroll spy.
 
-### Allowed exceptions (outside the React bundle)
+## Verification
 
-These files intentionally stay plain HTML/CSS because they run without JavaScript or outside the bundled React islands:
-
-- `public/404.html` — standalone error page
-
-Do not copy patterns from those files into `src/`.
-
-### Current state (mixed)
-
-The Tailwind migration removed `styles.css` (~1,500 lines). Some components still carry **inline Tailwind strings** not yet moved into `ui.ts` (`StarWidget`, notice bars in `shared.tsx`, `InstallPill`, etc.). That is acceptable short-term; **new work should go through `ui.ts`**, and drive-by edits should consolidate nearby inline utilities when touching a file.
-
-Docs styles live separately under `src/features/docs/styles`; these site guardrails apply to the marketing page and home React islands.
-
----
-
-## Layout files
-
-| File | Purpose |
-| ---- | ------- |
-| `src/shared/ui.ts` | Shared Tailwind compositions |
-| `src/styles/home.css` | Theme + base layer |
-| `src/pages/index.astro` | Static page sections, nav, metadata, and island hydration |
-| `src/features/home/components/ScrollSpy.tsx` | Nav highlight + reveal animations |
-| `src/features/playground/README.md` | Playground architecture, decisions, and maintenance invariants |
-
-Run `pnpm gate` before committing site changes.
+Run `pnpm gate` before committing site changes. Use a production build and
+preview for responsive layout checks.

--- a/apps/site/astro.config.mjs
+++ b/apps/site/astro.config.mjs
@@ -57,6 +57,7 @@ export default defineConfig({
       disable404Route: true,
       components: {
         Head: "./src/features/docs/components/Head.astro",
+        SocialIcons: "./src/features/docs/components/SocialIcons.astro",
       },
       favicon: "/favicon.svg",
       head: [
@@ -159,7 +160,6 @@ export default defineConfig({
         {
           label: "Start",
           items: [
-            { label: "Playground", link: "/playground/" },
             { label: "Why web-ai-sdk", slug: "docs/why-web-ai-sdk" },
             { label: "Browser support", slug: "docs/browser-support" },
             {

--- a/apps/site/astro.config.mjs
+++ b/apps/site/astro.config.mjs
@@ -162,6 +162,10 @@ export default defineConfig({
             { label: "Playground", link: "/playground/" },
             { label: "Why web-ai-sdk", slug: "docs/why-web-ai-sdk" },
             { label: "Browser support", slug: "docs/browser-support" },
+            {
+              label: "Production checklist",
+              slug: "docs/production-checklist",
+            },
             { label: "Architecture", slug: "docs/architecture" },
           ],
         },

--- a/apps/site/src/content/docs/architecture.mdx
+++ b/apps/site/src/content/docs/architecture.mdx
@@ -87,7 +87,7 @@ The SDK is allowed to be ergonomic *within a single capability*. Examples that l
 
 - **Warm LRU session pool.** `ask()` reuses `LanguageModel.create()` results across same-shape callers. Cold start drops to sub-second. The pool size is fixed at a sensible default; if you need fine-grained eviction control, use `createSession()` and own the lifecycle yourself.
 - **Optional result cache.** `ask()` accepts a `cache` option that memoizes responses by `(input, systemPrompt, samplingMode / temperature / topK)`. Off by default; pass `"session"` / `"local"` for the matching web-storage shortcut, or supply your own `{ get, set }` backend.
-- **Delta-vs-cumulative stream normalization.** Chrome emits delta chunks; some Edge backends emit cumulative buffers. The wrapper smooths this so `onUpdate` always sees the cumulative buffer and `sendStreaming()` always yields deltas.
+- **Delta-vs-cumulative stream normalization.** Browser implementations may expose delta chunks or cumulative buffers. The wrapper smooths this so `onUpdate` always sees the cumulative buffer and `sendStreaming()` always yields deltas.
 
 These are **ergonomic defaults**, not opinions about *how* you build an app. They each:
 

--- a/apps/site/src/content/docs/architecture.mdx
+++ b/apps/site/src/content/docs/architecture.mdx
@@ -3,11 +3,11 @@ title: Architecture
 description: How web-ai-sdk is organized. One package per browser capability, zero runtime dependencies, vanilla trunk with optional React adapters.
 ---
 
-`web-ai-sdk` is intentionally narrow. This page explains how the packages are organized, which decisions live inside the SDK and which are left to consumer code, and how to reason about adding a new capability.
+`web-ai-sdk` has a narrow scope. This page defines package boundaries and the rules for adding a capability.
 
 ## One package per browser capability
 
-Each `@web-ai-sdk/*` package wraps a single cohesive web capability relevant to in-browser AI:
+Each `@web-ai-sdk/*` package wraps one browser capability:
 
 | Package | Wraps |
 | --- | --- |
@@ -21,49 +21,45 @@ Each `@web-ai-sdk/*` package wraps a single cohesive web capability relevant to 
 | [`@web-ai-sdk/proofreader`](/docs/guides/proofreader/) | `Proofreader` |
 | [`@web-ai-sdk/all`](/docs/guides/meta-package/) | Meta-package; re-exports the wrappers above |
 
-The capability can originate from an official Built-in AI API (`LanguageModel`, `Summarizer`, `Translator`, `LanguageDetector`, `Writer`, `Rewriter`, `Proofreader`), from an adjacent web standard (`WebMCP` today; `WebGPU` and `WebNN` are likely candidates as their on-device AI uses crystallize), or, rarely, from a zero-dependency SDK-authored primitive with no platform equivalent yet. The rules below are what define an SDK package, not the origin of the underlying capability.
+**One package = one capability.** If a package has two independent jobs, split it.
 
-The structural rule is mechanical: **one package = one cohesive capability**. If the description of a package needs the word "and" to be honest about its scope, it's probably two packages.
+The built-in APIs have different options and result types. WebMCP is an agent interface, not a model. A single model abstraction cannot represent these differences.
 
-This is forced by shape, not just taste. The specialized built-ins carry option surfaces (target language, tone, length, confidence thresholds, per-issue offsets) that a single text-model abstraction cannot express, and WebMCP is an agent surface rather than a model. One capability per package is the only honest boundary.
-
-No SDK package imports from another published SDK package. Composition across capabilities (running a Prompt session over a tool registered with WebMCP, for example) is something you write in your application code.
+Published SDK packages do not import from each other. Application code composes capabilities when needed.
 
 ## When a capability enters the SDK
 
-Capabilities enter the SDK according to public evidence and wrapper value, not a calendar date:
+Public evidence and wrapper value determine when a capability enters the SDK:
 
 | Stage | SDK treatment |
 | --- | --- |
-| **Tracked** | An authoritative proposal exists, but the capability cannot yet be responsibly implemented and documented from public information. Track it in an issue; do not publish a package. |
-| **Preview** | Public instructions expose a runnable, coherent capability with a material lifecycle or ergonomics gap. An experimental `0.x` package may ship, even when a preview browser or flag is required. |
+| **Tracked** | A public proposal exists, but public information is not sufficient for an implementation. Track it in an issue. |
+| **Preview** | Public instructions expose a runnable capability. A lifecycle wrapper adds clear value. An experimental `0.x` package can ship. |
 | **Trial** | A public developer or origin trial is available. Keep the package `0.x` while expanding browser coverage and demos. |
-| **Stable** | A stable browser exposes the capability without a flag or trial token. Mark support stable; package `1.0` is a separate API-stability decision. |
+| **Stable** | A stable browser exposes the capability without a flag or token. Package `1.0` remains a separate decision. |
 | **Retired** | The proposal is withdrawn or replaced. Deprecate the package and document migration rather than repurposing it. |
 
-Moving from Tracked to Preview requires all of the following:
+Preview requires all of these conditions:
 
-- an authoritative public explainer, specification, or browser-vendor document and enough public information to test the capability;
+- an authoritative public source with enough information to test the capability;
 - one cohesive package boundary;
-- meaningful lifecycle value beyond types, such as feature detection, availability, session reuse, cleanup, abort handling, or stream normalization;
+- lifecycle value beyond types, such as feature detection, session reuse, cleanup, abort handling, or stream normalization;
 - zero runtime dependencies, deterministic tests, and a deliberate unsupported-browser behavior;
-- a narrow surface that does not pull persistence, cross-capability composition, or unrelated algorithms into the wrapper.
+- no persistence, cross-capability composition, or unrelated algorithms.
 
-Public packages and their issues, PRs, docs, demos, changelogs, and release notes must be supportable entirely from public sources. Confidential or restricted preview material is never published or used to reveal non-public versions, flags, behavior, or timelines. When public evidence is insufficient, the capability stays Tracked.
+All published claims must use public sources. Do not publish confidential preview details. Keep the capability Tracked when public evidence is not sufficient.
 
-Preview and Trial describe browser maturity, not lower quality expectations. Experimental packages still ship the standard vanilla API, React adapter, tests, status documentation, and meta-package integration. The complete contributor checklist lives in [CONTRIBUTING.md](https://github.com/obetomuniz/web-ai-sdk/blob/main/CONTRIBUTING.md#capability-adoption-policy).
+Preview and Trial describe browser maturity. They do not reduce package quality requirements. See the [contributor checklist](https://github.com/obetomuniz/web-ai-sdk/blob/main/CONTRIBUTING.md#capability-adoption-policy).
 
 ## Zero-dependency policy
 
-Every `@web-ai-sdk/*` package ships with **no runtime dependencies and no peer dependencies**. The one exception is `react`, which is declared as an *optional* peer for the `/react` subpath adapter only.
+Each `@web-ai-sdk/*` package has no runtime dependencies. `react` is the only allowed optional peer dependency.
 
-This is policy, not aspiration. The reasoning:
+- The browser APIs already change often. Dependencies add another source of change.
+- Transitive dependencies add security and maintenance risk.
+- Installing one wrapper should not install unrelated libraries.
 
-- The Web AI surface is still evolving. The SDK tracks a moving spec; we don't want to also be tracking a moving dependency graph.
-- A wrapper that introduces transitive dependencies imports their security surface, their breaking changes, and their abandonment risk. We don't think a `LanguageModel` wrapper should ever pull in a logging library or a polyfill.
-- Zero deps means a `pnpm add @web-ai-sdk/prompt` adds exactly one entry to your lockfile.
-
-When something useful really does need a third-party runtime (say, an IndexedDB-backed memory store or a JSON-RPC transport for a remote MCP server), it doesn't belong here.
+Features that need a third-party runtime belong outside these core wrappers.
 
 ## Vanilla trunk, React adapter as a subpath
 
@@ -77,38 +73,29 @@ import { ask, createSession } from "@web-ai-sdk/prompt";
 import { usePrompt, useSession } from "@web-ai-sdk/prompt/react";
 ```
 
-The vanilla trunk is the source of truth. The React adapter is a thin layer that wires the vanilla core into hook lifecycles. There is no standalone `@web-ai-sdk/prompt-react` package, and there won't be. Splitting along a framework boundary would force two release cadences for one capability.
+The vanilla entry is the source of truth. The React entry connects the vanilla API to hook lifecycles. Both entries ship in one package.
 
-If a different framework adapter ever ships, it will follow the same shape: `@web-ai-sdk/<pkg>/<framework>` as a subpath, with the framework declared as an optional peer.
+Future framework adapters must use a subpath such as `@web-ai-sdk/<pkg>/<framework>`. The framework must be an optional peer.
 
-## Ergonomic defaults vs. opinions
+## Defaults and application policy
 
-The SDK is allowed to be ergonomic *within a single capability*. Examples that live inside `@web-ai-sdk/prompt`:
+The SDK can provide defaults within one capability. For example, Prompt provides:
 
-- **Warm LRU session pool.** `ask()` reuses `LanguageModel.create()` results across same-shape callers. Cold start drops to sub-second. The pool size is fixed at a sensible default; if you need fine-grained eviction control, use `createSession()` and own the lifecycle yourself.
-- **Optional result cache.** `ask()` accepts a `cache` option that memoizes responses by `(input, systemPrompt, samplingMode / temperature / topK)`. Off by default; pass `"session"` / `"local"` for the matching web-storage shortcut, or supply your own `{ get, set }` backend.
-- **Delta-vs-cumulative stream normalization.** Browser implementations may expose delta chunks or cumulative buffers. The wrapper smooths this so `onUpdate` always sees the cumulative buffer and `sendStreaming()` always yields deltas.
+- **Session reuse.** `ask()` reuses compatible base sessions. Use `createSession()` when you need direct lifecycle control.
+- **Optional result caching.** Pass `"session"`, `"local"`, or a custom `{ get, set }` cache. Caching is off by default.
+- **Stream normalization.** `onUpdate` receives cumulative text. `sendStreaming()` yields deltas.
 
-These are **ergonomic defaults**, not opinions about *how* you build an app. They each:
+Each default:
 
-- live entirely inside one capability,
-- can be overridden, disabled, or replaced,
-- and would otherwise be reimplemented by every consumer.
+- stays within one capability;
+- can be disabled or replaced;
+- handles lifecycle code that consumers would otherwise repeat.
 
-What you won't find in the SDK is anything that bonds multiple capabilities together, walks the DOM, or needs a runtime dependency. Those concerns live in consumer code — anything you'd want to compose is yours to write.
-
-## Lineage: thin shims over platform primitives
-
-This shape isn't novel, and that's the point. The most durable JS utility libraries trend toward becoming thin layers over a platform primitive, then shrink as the platform absorbs their surface:
-
-- **lodash** ceded most of its surface to native array and object methods.
-- **moment** is superseded by the `Temporal` proposal; **date-fns** is now [reorienting to be "Temporal-first"](https://x.com/kossnocorp/status/2056306289480020338): document where `Temporal` replaces a function outright, map the gaps it can't cover, and ship the rest as functions that operate directly on `Temporal` objects.
-
-`web-ai-sdk` starts from that endpoint instead of migrating toward it. The Web AI APIs are the primitive; the SDK only owns the lifecycle and ergonomics the primitive leaves rough (feature detection, session reuse, stream smoothing, safe cleanup). As the APIs stabilize, the right outcome is for this layer to get *thinner*, not fatter. If a capability graduates to needing nothing but the raw API, the corresponding wrapper has done its job.
+The SDK does not compose capabilities, walk the DOM, render UI, or add runtime dependencies. Application code owns those concerns.
 
 ## Summary
 
-The SDK in one line: **one package per browser capability, zero runtime deps, lifecycle layer only.**
+The SDK has one package per browser capability. Each package has no runtime dependencies and handles lifecycle only.
 
 | In scope for the SDK | Out of scope |
 | --- | --- |
@@ -117,4 +104,4 @@ The SDK in one line: **one package per browser capability, zero runtime deps, li
 | Ergonomic defaults inside one capability (LRU cache, stream smoothing) | Walks or mutates the DOM beyond what the platform API does |
 | Zero runtime dependencies | Anything that needs a third-party runtime dependency |
 
-New web capabilities (Built-in AI, WebGPU, WebNN, or adjacent standards) land in the SDK as new packages. Reusable usage patterns that compose multiple capabilities are consumer-code territory.
+New browser capabilities can become new packages after they pass the adoption policy. Application code owns reusable cross-capability workflows.

--- a/apps/site/src/content/docs/browser-support.mdx
+++ b/apps/site/src/content/docs/browser-support.mdx
@@ -1,9 +1,9 @@
 ---
 title: Browser support
-description: Where each web-ai-sdk package runs today, including Chrome and Edge specifics.
+description: Current Chrome and Edge support for each package.
 ---
 
-Browser support changes independently for every capability. The matrix below uses current public Chrome and Edge documentation rather than inferring behavior from a shared browser engine. The final column describes SDK behavior when the corresponding native global is missing; it is not a claim that another browser vendor has implemented or rejected the API.
+Support differs by capability and browser. This page reports only behavior documented by Chrome and Edge. The fallback column describes SDK behavior when the native API is missing.
 
 | Package | Chrome | Edge | When the native API is missing |
 | --- | --- | --- | --- |
@@ -16,20 +16,23 @@ Browser support changes independently for every capability. The matrix below use
 | `@web-ai-sdk/proofreader` | [Developer trial · local flag](https://developer.chrome.com/docs/ai/proofreader-api) | [142+ · Canary/Dev · flag](https://learn.microsoft.com/en-us/microsoft-edge/web-platform/proofreader-api) | feature-detected fallback |
 | `@web-ai-sdk/webmcp` | [OT from 149 · local flag](https://developer.chrome.com/docs/ai/webmcp) | [OT in 150](https://learn.microsoft.com/en-us/microsoft-edge/web-platform/release-notes/150) | feature-detected fallback |
 
-**Stable** means the vendor documents the API as enabled by default. **Canary/Dev** is an Edge developer preview that requires the documented flag. **Developer trial** is Chrome's current status-table label; it does not mean a public origin-trial token is currently active. **OT** means the vendor lists a public origin trial.
+- **Stable:** the vendor enables the API by default.
+- **Canary/Dev:** an Edge preview that requires a flag.
+- **Developer trial:** Chrome's current status label. It is not an active public origin trial.
+- **OT:** a public origin trial listed by the vendor.
 
-The wrappers do not detect browser brands or versions. They test for the native API and its reported availability. Vanilla execution throws a typed package-specific unavailability error where appropriate; React hooks surface `status: "unavailable"`.
+The wrappers do not detect browser brands or versions. They check the native API and its reported availability. React hooks return `status: "unavailable"`. Vanilla functions can throw a typed unavailability error.
 
 ## Chrome specifics
 
-Chrome's [current Built-in AI status table](https://developer.chrome.com/docs/ai/built-in-apis) lists Translator, Language Detector, and Summarizer as stable from Chrome 138, Prompt as stable from Chrome 148, and Writer, Rewriter, and Proofreader as **Developer trial**.
+Chrome's [status table](https://developer.chrome.com/docs/ai/built-in-apis) lists Translator, Language Detector, and Summarizer as stable from Chrome 138. Prompt is stable from Chrome 148. Writer, Rewriter, and Proofreader are in **Developer trial**.
 
 The public origin-trial milestone windows documented on the capability pages are historical:
 
 - Writer and Rewriter shared an origin trial from Chrome 137 through 148.
 - Proofreader had an origin trial from Chrome 141 through 145.
 
-Those ended windows should not be confused with the current Developer trial label or local flag access. For current localhost testing, the vendor pages document:
+These origin trials have ended. The current Developer trial label and localhost flags are separate forms of access.
 
 | Surface | Current Chrome localhost setup |
 | --- | --- |
@@ -37,11 +40,15 @@ Those ended windows should not be confused with the current Developer trial labe
 | Proofreader | Enable `#proofreader-api`. |
 | WebMCP | Enable `#enable-webmcp-testing`; production testing uses the origin trial from Chrome 149. |
 
-The [Prompt hardware requirements](https://developer.chrome.com/docs/ai/prompt-api) distinguish task-specific APIs from foundation-model APIs. Chrome documents Translator and Language Detector for desktop. Prompt, Summarizer, Writer, Rewriter, and Proofreader require a supported desktop or Chromebook Plus platform, sufficient storage, and either the documented GPU or CPU resources. Consult the capability page rather than assuming that any Chromium-based browser has the same support.
+Chrome documents Translator and Language Detector for desktop. The foundation-model APIs have additional platform, storage, GPU, and CPU requirements. See the [Prompt hardware requirements](https://developer.chrome.com/docs/ai/prompt-api).
+
+Do not infer support from the Chromium engine. Check the capability page for each browser.
 
 ## Edge specifics
 
-Microsoft documents Summarizer as enabled by default from Edge 138, Writer and Rewriter as Canary/Dev previews from 138.0.3309.2, Prompt as a Canary/Dev preview from 138.0.3309.2, and Proofreader as a Canary/Dev preview from 142. Translator and Language Detector shipped as Edge 148 web-platform features. Edge 150 also lists public origin trials for Prompt and WebMCP.
+Microsoft enables Summarizer by default from Edge 138. Prompt, Writer, and Rewriter are Canary/Dev previews from 138.0.3309.2. Proofreader is a preview from Edge 142.
+
+Translator and Language Detector shipped in Edge 148. Edge 150 lists origin trials for Prompt and WebMCP.
 
 ### Models and hardware are capability-specific
 
@@ -53,7 +60,7 @@ Microsoft documents Summarizer as enabled by default from Edge 138, Writer and R
 | Translator | Task-specific translation models | No Phi/Aion performance-class rule is documented on the Translator page |
 | Language Detector | Task-specific language-detection model | No Phi/Aion performance-class rule is documented on the Language Detector page |
 
-The Aion path is not generalized to Proofreader, Translator, or Language Detector because their public pages do not document it.
+Microsoft does not document the Aion path for Proofreader, Translator, or Language Detector.
 
 Current Edge preview flag labels are:
 
@@ -63,6 +70,14 @@ Current Edge preview flag labels are:
 - "Proofreader API for Phi mini"
 - "Enable prerelease on-device language model" for the optional Aion override documented for Prompt and Writing Assistance
 
-Summarizer is enabled by default. Translator and Language Detector do not require these generative-model flags.
+Summarizer is enabled by default. Translator and Language Detector do not use these generative-model flags.
 
-References: Microsoft Learn [Prompt](https://learn.microsoft.com/en-us/microsoft-edge/web-platform/prompt-api), [Writing Assistance](https://learn.microsoft.com/en-us/microsoft-edge/web-platform/writing-assistance-apis), [Proofreader](https://learn.microsoft.com/en-us/microsoft-edge/web-platform/proofreader-api), [Translator](https://learn.microsoft.com/en-us/microsoft-edge/web-platform/translator-api), [Language Detector](https://learn.microsoft.com/en-us/microsoft-edge/web-platform/languagedetector-api), [Edge 148 release notes](https://learn.microsoft.com/en-us/microsoft-edge/web-platform/release-notes/148), and [Edge 150 release notes](https://learn.microsoft.com/en-us/microsoft-edge/web-platform/release-notes/150).
+Microsoft sources:
+
+- [Prompt](https://learn.microsoft.com/en-us/microsoft-edge/web-platform/prompt-api)
+- [Writing Assistance](https://learn.microsoft.com/en-us/microsoft-edge/web-platform/writing-assistance-apis)
+- [Proofreader](https://learn.microsoft.com/en-us/microsoft-edge/web-platform/proofreader-api)
+- [Translator](https://learn.microsoft.com/en-us/microsoft-edge/web-platform/translator-api)
+- [Language Detector](https://learn.microsoft.com/en-us/microsoft-edge/web-platform/languagedetector-api)
+- [Edge 148 release notes](https://learn.microsoft.com/en-us/microsoft-edge/web-platform/release-notes/148)
+- [Edge 150 release notes](https://learn.microsoft.com/en-us/microsoft-edge/web-platform/release-notes/150)

--- a/apps/site/src/content/docs/browser-support.mdx
+++ b/apps/site/src/content/docs/browser-support.mdx
@@ -3,45 +3,66 @@ title: Browser support
 description: Where each web-ai-sdk package runs today, including Chrome and Edge specifics.
 ---
 
-Web AI support lands engine by engine, and it is desktop-only for now: mobile browsers, including Chrome and Edge on iOS and Android, don't expose these APIs yet. Where it isn't there yet, every package is a feature-detected no-op so your code doesn't crash; render whatever fallback UI you want.
+Browser support changes independently for every capability. The matrix below uses current public Chrome and Edge documentation rather than inferring behavior from a shared browser engine. The final column describes SDK behavior when the corresponding native global is missing; it is not a claim that another browser vendor has implemented or rejected the API.
 
-| Package | Chrome | Edge | Safari | Firefox |
-| --- | --- | --- | --- | --- |
-| `@web-ai-sdk/prompt` | 148+ · stable | 138+ · Canary/Dev · flag | no-op fallback | no-op fallback |
-| `@web-ai-sdk/summarizer` | 138+ · stable | 138+ · stable | no-op fallback | no-op fallback |
-| `@web-ai-sdk/translator` | 138+ · stable | 148+ · stable | no-op fallback | no-op fallback |
-| `@web-ai-sdk/detector` | 138+ · stable | 148+ · stable | no-op fallback | no-op fallback |
-| `@web-ai-sdk/writer` | 137+ · OT · flag | 138+ · Canary/Dev · flag | no-op fallback | no-op fallback |
-| `@web-ai-sdk/rewriter` | 137+ · OT · flag | 138+ · Canary/Dev · flag | no-op fallback | no-op fallback |
-| `@web-ai-sdk/proofreader` | 141+ · OT · flag | 142+ · Canary/Dev · flag | no-op fallback | no-op fallback |
-| `@web-ai-sdk/webmcp` | 146+ · flag · OT 149+ | 147+ · flag | no-op fallback | no-op fallback |
+| Package | Chrome | Edge | When the native API is missing |
+| --- | --- | --- | --- |
+| `@web-ai-sdk/prompt` | [148+ · stable](https://developer.chrome.com/docs/ai/prompt-api) | [138+ · Canary/Dev · flag](https://learn.microsoft.com/en-us/microsoft-edge/web-platform/prompt-api); [OT in 150](https://learn.microsoft.com/en-us/microsoft-edge/web-platform/release-notes/150) | feature-detected fallback |
+| `@web-ai-sdk/summarizer` | [138+ · stable](https://developer.chrome.com/docs/ai/built-in-apis) | [138+ · stable](https://learn.microsoft.com/en-us/microsoft-edge/web-platform/writing-assistance-apis) | feature-detected fallback |
+| `@web-ai-sdk/translator` | [138+ · stable](https://developer.chrome.com/docs/ai/built-in-apis) | [148+ · stable](https://learn.microsoft.com/en-us/microsoft-edge/web-platform/release-notes/148) | feature-detected fallback |
+| `@web-ai-sdk/detector` | [138+ · stable](https://developer.chrome.com/docs/ai/built-in-apis) | [148+ · stable](https://learn.microsoft.com/en-us/microsoft-edge/web-platform/release-notes/148) | feature-detected fallback |
+| `@web-ai-sdk/writer` | [Developer trial · local flag](https://developer.chrome.com/docs/ai/writer-api) | [138+ · Canary/Dev · flag](https://learn.microsoft.com/en-us/microsoft-edge/web-platform/writing-assistance-apis) | feature-detected fallback |
+| `@web-ai-sdk/rewriter` | [Developer trial · local flag](https://developer.chrome.com/docs/ai/rewriter-api) | [138+ · Canary/Dev · flag](https://learn.microsoft.com/en-us/microsoft-edge/web-platform/writing-assistance-apis) | feature-detected fallback |
+| `@web-ai-sdk/proofreader` | [Developer trial · local flag](https://developer.chrome.com/docs/ai/proofreader-api) | [142+ · Canary/Dev · flag](https://learn.microsoft.com/en-us/microsoft-edge/web-platform/proofreader-api) | feature-detected fallback |
+| `@web-ai-sdk/webmcp` | [OT from 149 · local flag](https://developer.chrome.com/docs/ai/webmcp) | [OT in 150](https://learn.microsoft.com/en-us/microsoft-edge/web-platform/release-notes/150) | feature-detected fallback |
 
-Versions reflect when the underlying platform API became available. Wrapper exports stay stable across all browsers. **stable** = on by default, no flag; **Canary/Dev** = preview channel that still needs the matching `edge://flags` toggle enabled; **flag** = ships in the normal channel but stays behind a `chrome://flags` / `edge://flags` toggle; **OT** = origin trial. Per-API sources are linked under [Edge specifics](#edge-specifics) and in References below.
+**Stable** means the vendor documents the API as enabled by default. **Canary/Dev** is an Edge developer preview that requires the documented flag. **Developer trial** is Chrome's current status-table label; it does not mean a public origin-trial token is currently active. **OT** means the vendor lists a public origin trial.
 
-The Writing Assistance APIs (Writer, Rewriter) and the Proofreader API are still experimental: developer/origin trials in Chrome and developer previews in Edge Canary/Dev. Like the other Gemini Nano / Phi-4-mini APIs, they are **desktop-only** (no Android, iOS, or non-Chromebook-Plus ChromeOS) and are **not available in Web Workers** — top-level windows and same-origin iframes only (cross-origin iframes require a Permissions-Policy `allow` delegation).
+The wrappers do not detect browser brands or versions. They test for the native API and its reported availability. Vanilla execution throws a typed package-specific unavailability error where appropriate; React hooks surface `status: "unavailable"`.
+
+## Chrome specifics
+
+Chrome's [current Built-in AI status table](https://developer.chrome.com/docs/ai/built-in-apis) lists Translator, Language Detector, and Summarizer as stable from Chrome 138, Prompt as stable from Chrome 148, and Writer, Rewriter, and Proofreader as **Developer trial**.
+
+The public origin-trial milestone windows documented on the capability pages are historical:
+
+- Writer and Rewriter shared an origin trial from Chrome 137 through 148.
+- Proofreader had an origin trial from Chrome 141 through 145.
+
+Those ended windows should not be confused with the current Developer trial label or local flag access. For current localhost testing, the vendor pages document:
+
+| Surface | Current Chrome localhost setup |
+| --- | --- |
+| Writer and Rewriter | Enable `#optimization-guide-on-device-model`, `#prompt-api-for-gemini-nano-multimodal-input`, and `#writer-api-for-gemini-nano`; Rewriter shares Writer's flag. |
+| Proofreader | Enable `#proofreader-api`. |
+| WebMCP | Enable `#enable-webmcp-testing`; production testing uses the origin trial from Chrome 149. |
+
+The [Prompt hardware requirements](https://developer.chrome.com/docs/ai/prompt-api) distinguish task-specific APIs from foundation-model APIs. Chrome documents Translator and Language Detector for desktop. Prompt, Summarizer, Writer, Rewriter, and Proofreader require a supported desktop or Chromebook Plus platform, sufficient storage, and either the documented GPU or CPU resources. Consult the capability page rather than assuming that any Chromium-based browser has the same support.
 
 ## Edge specifics
 
-Summarizer (enabled by default since Edge 138, per the [Edge Writing Assistance APIs docs](https://learn.microsoft.com/en-us/microsoft-edge/web-platform/writing-assistance-apis)), Translator (Edge 148+, per the [Edge Translator API docs](https://learn.microsoft.com/en-us/microsoft-edge/web-platform/translator-api)), and Language Detector (Edge 148+, per the [Edge Language Detector API docs](https://learn.microsoft.com/en-us/microsoft-edge/web-platform/languagedetector-api)) all ship in Edge stable with no flag. The Prompt API is still a developer preview in Edge Canary/Dev 138+, the Writer and Rewriter APIs in Edge Canary/Dev 138+, and the Proofreader API in Edge Canary/Dev 142+, each behind its own "… API for Phi mini" flag. WebMCP landed in Edge 147 behind a flag.
+Microsoft documents Summarizer as enabled by default from Edge 138, Writer and Rewriter as Canary/Dev previews from 138.0.3309.2, Prompt as a Canary/Dev preview from 138.0.3309.2, and Proofreader as a Canary/Dev preview from 142. Translator and Language Detector shipped as Edge 148 web-platform features. Edge 150 also lists public origin trials for Prompt and WebMCP.
 
-Prompt, Summarizer, Writer, Rewriter, and Proofreader all route through Phi-4-mini with a stricter safety pipeline than Chrome's Gemini Nano; Translator and Language Detector run dedicated on-device models.
+### Models and hardware are capability-specific
 
-- **macOS quirk:** on macOS, the on-device model frequently refuses output for Prompt and Summarizer — summarizer returns "low quality output blocked", prompt may emit C0 control-character placeholders. The library handles both (strips C0/C1, normalizes streaming shape, wraps refusals in typed errors), but the model itself is the bottleneck on that platform. Windows doesn't reproduce this.
-- Flags on `edge://flags/`: "Prompt API for Phi mini", "Writer API for Phi mini", "Rewriter API for Phi mini", "Proofreader API for Phi mini". Summarizer (Edge 138+), Translator (Edge 148+), and Language Detector (Edge 148+) ship on by default with no flag.
-- Hardware check: `edge://on-device-internals` must show a "High" device performance class.
+| Edge capability | Documented model path | Documented device-performance condition |
+| --- | --- | --- |
+| Prompt | Phi-4-mini by default; optional prerelease Aion-1.0-Instruct in Canary/Dev 150.0.4070+ when "Enable prerelease on-device language model" is enabled | High or greater for Phi; Medium/Low only through the prerelease Aion path |
+| Summarizer, Writer, Rewriter | Phi-4-mini by default; the [Writing Assistance docs](https://learn.microsoft.com/en-us/microsoft-edge/web-platform/writing-assistance-apis) now document the same optional prerelease Aion override in Canary/Dev 150.0.4070+ | High or greater for Phi; Medium/Low only through the documented prerelease Aion path |
+| Proofreader | Phi-4-mini | High or greater; Microsoft does not document an Aion override on the Proofreader page |
+| Translator | Task-specific translation models | No Phi/Aion performance-class rule is documented on the Translator page |
+| Language Detector | Task-specific language-detection model | No Phi/Aion performance-class rule is documented on the Language Detector page |
 
-WebMCP on Edge isn't yet covered by an official Microsoft developer-docs page; the version above reflects empirical Canary/Dev testing.
+The Aion path is not generalized to Proofreader, Translator, or Language Detector because their public pages do not document it.
 
-References: Microsoft Learn: [Prompt](https://learn.microsoft.com/en-us/microsoft-edge/web-platform/prompt-api) · [Writing Assistance](https://learn.microsoft.com/en-us/microsoft-edge/web-platform/writing-assistance-apis) · [Proofreader](https://learn.microsoft.com/en-us/microsoft-edge/web-platform/proofreader-api) · [Translator](https://learn.microsoft.com/en-us/microsoft-edge/web-platform/translator-api) · [Language Detector](https://learn.microsoft.com/en-us/microsoft-edge/web-platform/languagedetector-api).
+Current Edge preview flag labels are:
 
-## Enabling on Chrome
+- "Prompt API for on-device language model"
+- "Writer API for on-device language model"
+- "Rewriter API for on-device language model"
+- "Proofreader API for Phi mini"
+- "Enable prerelease on-device language model" for the optional Aion override documented for Prompt and Writing Assistance
 
-| Surface | Flag |
-| --- | --- |
-| WebMCP | `chrome://flags/#enable-webmcp-testing` (Chrome 146+); [origin trial](https://developer.chrome.com/docs/ai/webmcp) opens in Chrome 149 |
-| Prompt API | Stable in Chrome 148+ (no flag); Chrome 138–147 needs `chrome://flags/#prompt-api-for-gemini-nano` |
-| Summarizer, Translator, Detector | Stable in Chrome 138+ |
-| Writer & Rewriter | `chrome://flags/#writer-api-for-gemini-nano` (joint trial; Chrome 137–148). Rewriter has no separate flag — it shares the Writer toggle |
-| Proofreader | `chrome://flags/#proofreader-api-for-gemini-nano` (Chrome 141–145) |
+Summarizer is enabled by default. Translator and Language Detector do not require these generative-model flags.
 
-The Writing Assistance and Proofreader flags also require `chrome://flags/#optimization-guide-on-device-model` enabled. After enabling a flag, restart Chrome and wait for the on-device model to download (`chrome://on-device-internals`).
+References: Microsoft Learn [Prompt](https://learn.microsoft.com/en-us/microsoft-edge/web-platform/prompt-api), [Writing Assistance](https://learn.microsoft.com/en-us/microsoft-edge/web-platform/writing-assistance-apis), [Proofreader](https://learn.microsoft.com/en-us/microsoft-edge/web-platform/proofreader-api), [Translator](https://learn.microsoft.com/en-us/microsoft-edge/web-platform/translator-api), [Language Detector](https://learn.microsoft.com/en-us/microsoft-edge/web-platform/languagedetector-api), [Edge 148 release notes](https://learn.microsoft.com/en-us/microsoft-edge/web-platform/release-notes/148), and [Edge 150 release notes](https://learn.microsoft.com/en-us/microsoft-edge/web-platform/release-notes/150).

--- a/apps/site/src/content/docs/browser-support.mdx
+++ b/apps/site/src/content/docs/browser-support.mdx
@@ -3,9 +3,11 @@ title: Browser support
 description: Current Chrome and Edge support for each package.
 ---
 
+import BrowserTableHeading from "../../features/docs/components/BrowserTableHeading.astro";
+
 Support differs by capability and browser. This page reports only behavior documented by Chrome and Edge. The fallback column describes SDK behavior when the native API is missing.
 
-| Package | Chrome | Edge | When the native API is missing |
+| Package | <BrowserTableHeading browsers={["chrome"]} label="Chrome" /> | <BrowserTableHeading browsers={["edge"]} label="Edge" /> | <BrowserTableHeading browsers={["safari", "firefox"]} label="Fallback when the native API is missing" /> |
 | --- | --- | --- | --- |
 | `@web-ai-sdk/prompt` | [148+ · stable](https://developer.chrome.com/docs/ai/prompt-api) | [138+ · Canary/Dev · flag](https://learn.microsoft.com/en-us/microsoft-edge/web-platform/prompt-api); [OT in 150](https://learn.microsoft.com/en-us/microsoft-edge/web-platform/release-notes/150) | feature-detected fallback |
 | `@web-ai-sdk/summarizer` | [138+ · stable](https://developer.chrome.com/docs/ai/built-in-apis) | [138+ · stable](https://learn.microsoft.com/en-us/microsoft-edge/web-platform/writing-assistance-apis) | feature-detected fallback |

--- a/apps/site/src/content/docs/guides/detector.mdx
+++ b/apps/site/src/content/docs/guides/detector.mdx
@@ -1,9 +1,9 @@
 ---
 title: Language Detector API
-description: web-ai-sdk building block for the Web's Built-in LanguageDetector with confidence thresholds, bias hints, and session reuse.
+description: Detect text language with the built-in Language Detector API, confidence thresholds, bias hints, and session reuse.
 ---
 
-Building block for [the Web's Built-in Language Detector API](https://developer.chrome.com/docs/ai/language-detection). Detect the language of any text on-device, with confidence scores and a sorted list of alternates. Session reuse, opt-in result caching, AbortSignal-driven cleanup. See [useDetector](/docs/react/use-detector/) for React.
+This package wraps the built-in [Language Detector API](https://developer.chrome.com/docs/ai/language-detection). It returns confidence scores and sorted alternatives. It also adds session reuse, optional result caching, and abort cleanup. For React, see [useDetector](/docs/react/use-detector/).
 
 Before shipping, review the [Production checklist](/docs/production-checklist/) for intent-driven preparation, task-relevant input, progress, and cache freshness.
 

--- a/apps/site/src/content/docs/guides/detector.mdx
+++ b/apps/site/src/content/docs/guides/detector.mdx
@@ -5,6 +5,8 @@ description: web-ai-sdk building block for the Web's Built-in LanguageDetector w
 
 Building block for [the Web's Built-in Language Detector API](https://developer.chrome.com/docs/ai/language-detection). Detect the language of any text on-device, with confidence scores and a sorted list of alternates. Session reuse, opt-in result caching, AbortSignal-driven cleanup. See [useDetector](/docs/react/use-detector/) for React.
 
+Before shipping, review the [Production checklist](/docs/production-checklist/) for intent-driven preparation, task-relevant input, progress, and cache freshness.
+
 ## Usage
 
 ```ts
@@ -85,7 +87,7 @@ detect({
 });
 ```
 
-The hint is also forwarded to `availability()` so engines that warn on shape mismatch (Edge) stay quiet.
+The hint is also forwarded to `availability()` so the capability check and creation request use the same shape.
 
 ## Composing with the other packages
 

--- a/apps/site/src/content/docs/guides/prompt.mdx
+++ b/apps/site/src/content/docs/guides/prompt.mdx
@@ -3,9 +3,11 @@ title: Prompt API
 description: web-ai-sdk Prompt API. One-shot ask() and per-conversation createSession() on the Web's Built-in LanguageModel. System message, sampling controls, streaming, session reuse, pluggable result caching.
 ---
 
-Building block for the Web's Built-in [Prompt API](https://developer.chrome.com/docs/extensions/ai/prompt-api) (`LanguageModel`). One-shot `ask()` for embeds and widgets, plus a `createSession()` primitive for chat-shaped apps that need independent per-conversation sessions, streaming with deltas, and a multi-turn history.
+Building block for the Web's Built-in [Prompt API](https://developer.chrome.com/docs/ai/prompt-api) (`LanguageModel`). One-shot `ask()` for embeds and widgets, plus a `createSession()` primitive for chat-shaped apps that need independent per-conversation sessions, streaming with deltas, and a multi-turn history.
 
 The package's [README](https://github.com/obetomuniz/web-ai-sdk/tree/main/packages/prompt#readme) covers install and the API table. This page is the conceptual overview of the core (vanilla) surface. The React adapter lives at `@web-ai-sdk/prompt/react`; see [usePrompt](/docs/react/use-prompt/) and [useSession](/docs/react/use-session/).
+
+Before shipping, review the [Production checklist](/docs/production-checklist/) for intent-driven preparation, session isolation, input selection, safe rendering, progress, reversible edits, and cache freshness.
 
 ## One-shot: `ask()`
 
@@ -120,11 +122,11 @@ The wrapper is intentionally thin. It handles cross-browser smoothing every cons
 
 Calling `createSession()` starts `LanguageModel.create()` immediately. The first `send`, `sendStreaming`, or `clone` only awaits that already-started creation, so creating a base as soon as the user's intent is clear is a valid prewarming primitive. Finalize the initial instructions at that point; the native session is already being created when the synchronous wrapper returns.
 
-**Concurrency note.** Each session is an independent `LanguageModel` instance, but the underlying on-device model is single-instance. Chrome 148 / Edge 138 currently schedule `sendStreaming` calls across sessions FIFO: overlapping sends do not interleave token-by-token — the second send waits for the first to drain. This is a constraint of the runtime, not of the API; code written against `createSession()` becomes faster automatically if a future release exposes parallel inference.
+**Concurrency note.** Each session has independent history, system prompts, sampling, and lifecycle. Scheduling across different native sessions is browser-defined, so do not depend on token-level interleaving or a particular parallelism policy.
 
 ## Session resilience: base + per-task `clone()`
 
-For agents and multi-task flows there's a lose-lose with naive session handling: reuse one long-lived session and history accumulates (later runs start echoing earlier ones, and you eventually hit `QuotaExceededError`); recreate a session per task and you pay the cold start and can trip Chrome's single-instance degradation. Chrome's [session management guidance](https://developer.chrome.com/docs/ai/session-management) recommends a third way: keep one warm **base** session (system prompt only) and `clone()` it per task. The clone inherits the system prompt and history without re-parsing instructions or paying another `create()`, then gets its own independent history and lifecycle.
+For agents and multi-task flows, reusing one long-lived session lets unrelated history accumulate, while recreating a session per task repeats creation and instruction processing. Chrome's [session-management guidance](https://developer.chrome.com/docs/ai/session-management) recommends keeping one warm **base** session (system prompt only) and calling `clone()` per task. The clone inherits the system prompt without unrelated task history, then gets its own independent history and lifecycle.
 
 ```ts
 // As soon as the workflow is chosen, begin native creation with final instructions.
@@ -236,7 +238,7 @@ Chrome's `LanguageModel` exposes `LanguageModel.create({...})` to spin up a sess
 - **Feature detection.** `isAvailable()` / `checkAvailability()` return `false` / `null` on browsers without the API. The vanilla `ask()` throws `PromptUnavailableError`; the React hook surfaces `status: "unavailable"`.
 - **Warm base reuse for `ask()`** (ergonomic default, scoped to `ask`). A bounded LRU caches base `LanguageModel.create()` calls by stringified create options. Each prompt still runs on an isolated clone, or on a fresh one-shot instance when `clone()` is unavailable. `createSession()` never touches this cache.
 - **Optional result cache for `ask()` (off by default).** Every call hits the model unless you opt in. Pass `cache: "session"` for `sessionStorage`, `cache: "local"` for `localStorage`, or any `{ get, set }`-shaped object to memoize responses by `(input, systemPrompt, samplingMode / temperature / topK)`.
-- **Delta-vs-cumulative chunk detection.** Chrome ships delta chunks; some Edge backends ship cumulative. The wrapper normalizes per-chunk so `onUpdate` (cumulative) and `sendStreaming()` (deltas) work the same across browsers.
+- **Delta-vs-cumulative chunk detection.** Browser implementations may expose delta or cumulative chunks. The wrapper normalizes per chunk so `onUpdate` (cumulative) and `sendStreaming()` (deltas) have stable SDK semantics.
 
 The two cache-shaped items above are *ergonomic defaults scoped to `ask()`*, not opinions about how to use a language model. Multi-package compositions (agent loops, conversation history, tool dispatch) are not part of this package; see [Architecture](/docs/architecture/) for the split.
 
@@ -287,7 +289,7 @@ const result = await ask({
 const parsed = JSON.parse(result.output ?? "{}");
 ```
 
-The wrapper passes `responseConstraint` straight through to `session.prompt()` / `session.promptStreaming()`. Support depends on your Chrome version.
+The wrapper passes `responseConstraint` straight through to `session.prompt()` / `session.promptStreaming()`. Support depends on the browser implementation.
 
 By default the schema is inlined into the prompt context, which costs tokens. Pass `omitResponseConstraintInput: true` (on `ask()` or `SessionSendOptions`) to drop it; the constraint still shapes the output, but you should then include format guidance in the prompt text itself. The flag is only forwarded when `responseConstraint` is also set — the native API throws a `TypeError` otherwise, so the wrapper ignores it on its own.
 
@@ -317,11 +319,11 @@ const tools: LanguageModelTool[] = [
 const session = createSession({ systemPrompt, tools });
 ```
 
-This is **pass-through only** — the SDK forwards `tools` and never calls `execute` itself. Whether the model actually invokes a tool depends on the browser. Native execution is **not** wired on current stable Chrome: the option is accepted but is a silent no-op, and the model may surface its tool call as plain text (a `tool_code` block) that your own code must parse. The passthrough starts working automatically on browsers that ship native execution; until then, `responseConstraint` remains the robust default.
+This is **pass-through only** — the SDK forwards `tools` and never calls `execute` itself. Native tool execution depends on the browser implementation, so treat it as experimental and provide a fallback.
 
 The heuristic `tool_code` parser and the tool-execution loop are deliberately left to the consumer layer — parsing is model-dependent (it drifts on names and formats for less-trained tools), so it doesn't belong in a lifecycle wrapper. To declare the native tool modalities, pass `{ type: "tool-response" }` / `{ type: "tool-call" }` through the advanced `expectedInputs` / `expectedOutputs` fields.
 
-`tools` works on `ask()` too (`ask({ input, tools })`). One caveat: `ask()` may keep warm base sessions through an LRU keyed by `JSON.stringify(createOptions)`, and `JSON.stringify` drops functions — so a tool's `execute` doesn't contribute to the key, only its `name` / `description` / `inputSchema` do. Each `ask()` prompt still runs on a clone or fresh one-shot instance. That's harmless today (the SDK never runs `execute`), but it matters once native execution lands — so prefer `createSession()` for tool-bearing sessions. It bypasses the cache entirely and matches the base-session + per-run-`clone()` pattern.
+`tools` works on `ask()` too (`ask({ input, tools })`). One caveat: `ask()` may keep warm base sessions through an LRU keyed by `JSON.stringify(createOptions)`, and `JSON.stringify` drops functions — so a tool's `execute` doesn't contribute to the key, only its `name` / `description` / `inputSchema` do. Each `ask()` prompt still runs on a clone or fresh one-shot instance. Prefer `createSession()` for tool-bearing sessions: it bypasses the cache and matches the base-session + per-run-`clone()` pattern.
 
 ## Aborting
 
@@ -359,7 +361,7 @@ try {
   const result = await ask({ input: "hi" });
 } catch (err) {
   if (err instanceof PromptUnavailableError) {
-    // No Chrome flag, no model, or download blocked; fall back.
+    // Native API unavailable or model preparation blocked; fall back.
     return;
   }
   throw err;

--- a/apps/site/src/content/docs/guides/prompt.mdx
+++ b/apps/site/src/content/docs/guides/prompt.mdx
@@ -1,11 +1,11 @@
 ---
 title: Prompt API
-description: web-ai-sdk Prompt API. One-shot ask() and per-conversation createSession() on the Web's Built-in LanguageModel. System message, sampling controls, streaming, session reuse, pluggable result caching.
+description: Use ask() for one-shot prompts or createSession() for multi-turn conversations with the built-in LanguageModel API.
 ---
 
-Building block for the Web's Built-in [Prompt API](https://developer.chrome.com/docs/ai/prompt-api) (`LanguageModel`). One-shot `ask()` for embeds and widgets, plus a `createSession()` primitive for chat-shaped apps that need independent per-conversation sessions, streaming with deltas, and a multi-turn history.
+This package wraps the built-in [Prompt API](https://developer.chrome.com/docs/ai/prompt-api) (`LanguageModel`). Use `ask()` for one-shot prompts. Use `createSession()` for multi-turn conversations.
 
-The package's [README](https://github.com/obetomuniz/web-ai-sdk/tree/main/packages/prompt#readme) covers install and the API table. This page is the conceptual overview of the core (vanilla) surface. The React adapter lives at `@web-ai-sdk/prompt/react`; see [usePrompt](/docs/react/use-prompt/) and [useSession](/docs/react/use-session/).
+The package [README](https://github.com/obetomuniz/web-ai-sdk/tree/main/packages/prompt#readme) covers installation and the API reference. This page explains the vanilla API. For React, see [usePrompt](/docs/react/use-prompt/) and [useSession](/docs/react/use-session/).
 
 Before shipping, review the [Production checklist](/docs/production-checklist/) for intent-driven preparation, session isolation, input selection, safe rendering, progress, reversible edits, and cache freshness.
 
@@ -27,15 +27,15 @@ const result = await ask({
 console.log(result.output, result.cached);
 ```
 
-Pass `onUpdate` to render partial text as it streams. `result.output` is the final control-character-cleaned text; `result.cached` tells you whether the response came back without invoking the model.
+Pass `onUpdate` to render partial text. `result.output` contains the final cleaned text. `result.cached` reports whether the result came from cache.
 
 `onUpdate` receives the **cumulative** buffer, not deltas. For delta-shaped streaming use `createSession().sendStreaming()`.
 
 ### Treat model output as untrusted
 
-The Prompt wrapper removes selected non-printing control characters from model responses. This is control-character cleanup, **not** HTML or Markdown sanitization. Treat every final response and streaming update as untrusted.
+The wrapper removes selected non-printing control characters. It does not sanitize HTML or Markdown. Treat all model output as untrusted.
 
-React interpolation and DOM `textContent`, as shown above, are appropriate for plain text. If you convert model Markdown or HTML into rendered HTML, keep raw HTML disabled and sanitize the complete accumulated buffer before DOM insertion. Do not sanitize and concatenate individual deltas: a malicious construct can be split across stream updates.
+Use React interpolation or DOM `textContent` for plain text. If you render HTML, disable raw HTML and sanitize the complete buffer before insertion. Do not sanitize deltas separately; unsafe input can span updates.
 
 ## Options
 
@@ -94,7 +94,7 @@ interface AskResult {
 
 ## Chat: `createSession()`
 
-`ask()` is isolated per call: it may keep a warm base `LanguageModel` for same-shape calls, but each prompt runs on a fresh clone when the browser supports `clone()`, or on a fresh one-shot instance otherwise. That's a good fit for embeds and ask-and-display flows. `createSession()` gives every conversation its own underlying instance for multi-turn chat:
+`ask()` isolates each call. It can reuse a base model, but each prompt runs on a clone or fresh instance. Use `createSession()` when a conversation needs multi-turn history:
 
 ```ts
 import { createSession } from "@web-ai-sdk/prompt";
@@ -116,17 +116,23 @@ const text = await session.send("And what about the Prompt API?");
 session.destroy();
 ```
 
-The wrapper is intentionally thin. It handles cross-browser smoothing every consumer would otherwise reimplement (delta-vs-cumulative chunk detection, control-character cleanup, abort wiring, typed unavailability) and forwards everything else to the native instance. It does **not** track conversation history or queue concurrent sends; those are your data model and UI concerns. It does surface `clone()`, since forking a warm base session is the spec's recommended way to start a fresh task (see [Session resilience](#session-resilience-base--per-task-clone) below).
+The wrapper normalizes stream chunks, removes selected control characters, handles aborts, and reports typed unavailability. It forwards other behavior to the native instance.
 
-`createSession()` never touches the `ask()` session cache. Two sessions with identical options get two independent instances with isolated history, system prompt, sampling, and lifecycle — `abort()` / `destroy()` on one session never touch another. Concurrent `send` / `sendStreaming` calls on the **same** session are NOT queued — the underlying `LanguageModel` is sequential per instance and will reject the overlapping call with `InvalidStateError`. Either `await` the previous send or call `session.abort()` before issuing a new turn.
+It does not store UI history or queue sends. Your application owns both. Use `clone()` to start an isolated task from a prepared base session.
 
-Calling `createSession()` starts `LanguageModel.create()` immediately. The first `send`, `sendStreaming`, or `clone` only awaits that already-started creation, so creating a base as soon as the user's intent is clear is a valid prewarming primitive. Finalize the initial instructions at that point; the native session is already being created when the synchronous wrapper returns.
+`createSession()` does not use the `ask()` session cache. Each call creates an independent instance with its own history and lifecycle.
+
+Calls on the same session are not queued. Overlapping calls fail with `InvalidStateError`. Await the current send or call `session.abort()` first.
+
+`createSession()` starts native creation immediately. Create the base when the workflow is known and the initial instructions are final. The first send or clone waits for creation.
 
 **Concurrency note.** Each session has independent history, system prompts, sampling, and lifecycle. Scheduling across different native sessions is browser-defined, so do not depend on token-level interleaving or a particular parallelism policy.
 
 ## Session resilience: base + per-task `clone()`
 
-For agents and multi-task flows, reusing one long-lived session lets unrelated history accumulate, while recreating a session per task repeats creation and instruction processing. Chrome's [session-management guidance](https://developer.chrome.com/docs/ai/session-management) recommends keeping one warm **base** session (system prompt only) and calling `clone()` per task. The clone inherits the system prompt without unrelated task history, then gets its own independent history and lifecycle.
+Do not reuse one session across unrelated tasks. Its history will continue to grow. Creating a new session for every task repeats setup work.
+
+Chrome's [session-management guidance](https://developer.chrome.com/docs/ai/session-management) recommends one prepared base session with only the system prompt. Clone it for each task. Each clone has independent history and lifecycle.
 
 ```ts
 // As soon as the workflow is chosen, begin native creation with final instructions.
@@ -194,18 +200,20 @@ const json = await session.send([
 
 They compose: prefill the opening brace, set `responseConstraint` for the full shape.
 
-**Spec rule:** `prefix: true` is only valid on the **trailing** `assistant` message. Anywhere else (a non-final message, a non-assistant role) the browser throws a `"SyntaxError"` `DOMException`. The SDK does **not** catch this, so it propagates to your `send` / `sendStreaming` caller.
+**Spec rule:** `prefix: true` is valid only on the final `assistant` message. Other uses cause a `"SyntaxError"` `DOMException`. The SDK passes this error to the caller.
 
 > **Note on `content`:** `LanguageModelMessage.content` is currently `string` only. Multimodal `ContentPart[]` content (images, audio) is tracked as a future enhancement; no timeline is promised.
 
 ## Context-window introspection
 
-`Session` surfaces the live token budget the native instance reports, so consumers can size work to the real context window instead of hardcoding a char cap (the exact bypass — reaching past the SDK to `globalThis.LanguageModel` — that this avoids):
+`Session` exposes the token budget reported by the native instance. Use it to size input for the current context window:
 
 - `session.contextWindow` — max input tokens for the session (the context window).
 - `session.contextUsage` — input tokens used so far. On a fresh base-clone this reflects the inherited history (≈ the system prompt), the right baseline to budget a turn against.
 
-These mirror the Prompt API's [`contextWindow` / `contextUsage`](https://developer.chrome.com/docs/ai/prompt-api#session_management) (the renamed successors of `inputQuota` / `inputUsage`); the wrapper reads the new names and falls back to the deprecated ones on older Chrome builds. Calling `createSession()` starts native creation eagerly, but the wrapper returns synchronously, so both getters remain `undefined` while that promise is in flight. The first `send` awaits the already-started creation; alternatively, read the getters on a session from `clone()`, whose native instance is live the moment `clone()` resolves. React's `useSession` similarly stays `"loading"` until creation resolves.
+These values mirror the Prompt API's [`contextWindow` and `contextUsage`](https://developer.chrome.com/docs/ai/prompt-api#session_management). The wrapper also reads the deprecated names for older Chrome builds.
+
+Both getters are `undefined` until native creation finishes. A resolved clone is ready immediately. React's `useSession` stays `"loading"` until creation finishes.
 
 ```ts
 const base = createSession({ systemPrompt }); // native creation starts here
@@ -319,11 +327,13 @@ const tools: LanguageModelTool[] = [
 const session = createSession({ systemPrompt, tools });
 ```
 
-This is **pass-through only** — the SDK forwards `tools` and never calls `execute` itself. Native tool execution depends on the browser implementation, so treat it as experimental and provide a fallback.
+The SDK only forwards `tools`; it does not call `execute`. Native execution depends on the browser. Treat it as experimental and provide a fallback.
 
-The heuristic `tool_code` parser and the tool-execution loop are deliberately left to the consumer layer — parsing is model-dependent (it drifts on names and formats for less-trained tools), so it doesn't belong in a lifecycle wrapper. To declare the native tool modalities, pass `{ type: "tool-response" }` / `{ type: "tool-call" }` through the advanced `expectedInputs` / `expectedOutputs` fields.
+Your application must parse model-emitted tool calls and run any manual execution loop. To declare native tool modalities, use `expectedInputs` and `expectedOutputs`.
 
-`tools` works on `ask()` too (`ask({ input, tools })`). One caveat: `ask()` may keep warm base sessions through an LRU keyed by `JSON.stringify(createOptions)`, and `JSON.stringify` drops functions — so a tool's `execute` doesn't contribute to the key, only its `name` / `description` / `inputSchema` do. Each `ask()` prompt still runs on a clone or fresh one-shot instance. Prefer `createSession()` for tool-bearing sessions: it bypasses the cache and matches the base-session + per-run-`clone()` pattern.
+`tools` also works with `ask({ input, tools })`. Its base-session cache key excludes functions, so `execute` does not affect that key.
+
+Each `ask()` still uses a clone or fresh instance. Prefer `createSession()` for tool-based sessions because it bypasses this cache.
 
 ## Aborting
 

--- a/apps/site/src/content/docs/guides/proofreader.mdx
+++ b/apps/site/src/content/docs/guides/proofreader.mdx
@@ -5,6 +5,8 @@ description: web-ai-sdk building block for the Web's Built-in Proofreader API. C
 
 Building block for the Web's Built-in [Proofreader API](https://developer.chrome.com/docs/ai/proofreader-api). Corrects grammar, spelling, and punctuation, returning the fully corrected text plus per-issue corrections with offsets into the original input. Session reuse and pluggable result caching included. The React adapter lives at `@web-ai-sdk/proofreader/react`; see [useProofreader](/docs/react/use-proofreader/).
 
+Before shipping, review the [Production checklist](/docs/production-checklist/) for preserving originals, Accept/Reject/Undo flows, safe rendering, and cache freshness.
+
 ## Usage
 
 ```ts
@@ -56,8 +58,8 @@ interface ProofreadCorrection {
   startIndex: number;   // inclusive offset into the original input
   endIndex: number;     // exclusive offset into the original input
   correction: string;   // suggested replacement
-  type?: string;        // not emitted by Chrome's current build
-  explanation?: string; // not emitted by Chrome's current build
+  type?: string;        // optional platform metadata
+  explanation?: string; // optional platform metadata
 }
 
 interface ProofreadOutput {

--- a/apps/site/src/content/docs/guides/proofreader.mdx
+++ b/apps/site/src/content/docs/guides/proofreader.mdx
@@ -1,9 +1,9 @@
 ---
 title: Proofreader API
-description: web-ai-sdk building block for the Web's Built-in Proofreader API. Corrects grammar, spelling, and punctuation and returns per-issue corrections.
+description: Correct grammar, spelling, and punctuation with the built-in Proofreader API and inspect each correction.
 ---
 
-Building block for the Web's Built-in [Proofreader API](https://developer.chrome.com/docs/ai/proofreader-api). Corrects grammar, spelling, and punctuation, returning the fully corrected text plus per-issue corrections with offsets into the original input. Session reuse and pluggable result caching included. The React adapter lives at `@web-ai-sdk/proofreader/react`; see [useProofreader](/docs/react/use-proofreader/).
+This package wraps the built-in [Proofreader API](https://developer.chrome.com/docs/ai/proofreader-api). It returns corrected text and individual corrections with source offsets. It also adds session reuse and optional result caching. For React, see [useProofreader](/docs/react/use-proofreader/).
 
 Before shipping, review the [Production checklist](/docs/production-checklist/) for preserving originals, Accept/Reject/Undo flows, safe rendering, and cache freshness.
 

--- a/apps/site/src/content/docs/guides/rewriter.mdx
+++ b/apps/site/src/content/docs/guides/rewriter.mdx
@@ -5,6 +5,8 @@ description: web-ai-sdk building block for the Web's Built-in Rewriter API with 
 
 Building block for the Web's Built-in [Rewriter API](https://developer.chrome.com/docs/ai/rewriter-api). Revises and restructures existing text with tone / length adjustments, session reuse, streaming, and pluggable result caching. The React adapter lives at `@web-ai-sdk/rewriter/react`; see [useRewriter](/docs/react/use-rewriter/).
 
+Before shipping, review the [Production checklist](/docs/production-checklist/) for safe rendering, progress, Accept/Reject/Undo flows, and cache freshness.
+
 ## Usage
 
 ```ts

--- a/apps/site/src/content/docs/guides/rewriter.mdx
+++ b/apps/site/src/content/docs/guides/rewriter.mdx
@@ -1,9 +1,9 @@
 ---
 title: Rewriter API
-description: web-ai-sdk building block for the Web's Built-in Rewriter API with session reuse, streaming, and opt-in result caching.
+description: Revise text with the built-in Rewriter API, streaming, session reuse, and optional result caching.
 ---
 
-Building block for the Web's Built-in [Rewriter API](https://developer.chrome.com/docs/ai/rewriter-api). Revises and restructures existing text with tone / length adjustments, session reuse, streaming, and pluggable result caching. The React adapter lives at `@web-ai-sdk/rewriter/react`; see [useRewriter](/docs/react/use-rewriter/).
+This package wraps the built-in [Rewriter API](https://developer.chrome.com/docs/ai/rewriter-api). It adds session reuse, streaming, and optional result caching. For React, see [useRewriter](/docs/react/use-rewriter/).
 
 Before shipping, review the [Production checklist](/docs/production-checklist/) for safe rendering, progress, Accept/Reject/Undo flows, and cache freshness.
 

--- a/apps/site/src/content/docs/guides/summarizer.mdx
+++ b/apps/site/src/content/docs/guides/summarizer.mdx
@@ -1,9 +1,9 @@
 ---
 title: Summarizer API
-description: web-ai-sdk building block for the Web's Built-in Summarizer with session reuse, opt-in result caching, and streaming.
+description: Summarize text with the built-in Summarizer API, streaming, session reuse, and optional result caching.
 ---
 
-Building block for the Web's Built-in [Summarizer API](https://developer.chrome.com/docs/ai/summarizer-api). String-mode summarization with session reuse, sentence-aware output cleaning, streaming, and pluggable result caching. The React adapter lives at `@web-ai-sdk/summarizer/react`; see [useSummarizer](/docs/react/use-summarizer/).
+This package wraps the built-in [Summarizer API](https://developer.chrome.com/docs/ai/summarizer-api). It adds session reuse, streaming, output cleanup, and optional result caching. For React, see [useSummarizer](/docs/react/use-summarizer/).
 
 Before shipping, review the [Production checklist](/docs/production-checklist/) for task-relevant text extraction, safe rendering, progress, user control, and cache freshness.
 

--- a/apps/site/src/content/docs/guides/summarizer.mdx
+++ b/apps/site/src/content/docs/guides/summarizer.mdx
@@ -5,6 +5,8 @@ description: web-ai-sdk building block for the Web's Built-in Summarizer with se
 
 Building block for the Web's Built-in [Summarizer API](https://developer.chrome.com/docs/ai/summarizer-api). String-mode summarization with session reuse, sentence-aware output cleaning, streaming, and pluggable result caching. The React adapter lives at `@web-ai-sdk/summarizer/react`; see [useSummarizer](/docs/react/use-summarizer/).
 
+Before shipping, review the [Production checklist](/docs/production-checklist/) for task-relevant text extraction, safe rendering, progress, user control, and cache freshness.
+
 ## Usage
 
 ```ts
@@ -55,7 +57,7 @@ interface SummarizeOptions {
 | `format` | `"plain-text" \| "markdown"` | Output format. Defaults to `"plain-text"`. |
 | `preference` | `"auto" \| "speed" \| "capability"` | Performance preference hint. Defaults to `"auto"`. See [Performance preference](#performance-preference). |
 | `sharedContext` | `string` | Native `sharedContext` string (a hint about who/what the summary is for). |
-| `monitor` | `(m) => void` | Observe the first-call model download (~1.7 GB on a fresh profile). |
+| `monitor` | `(m) => void` | Observe first-call model download progress. |
 | `cache` | `"session" \| "local" \| { get, set }` | Opt-in result cache. |
 | `cacheKey` | `string` | Override the default cache key (defaults to `JSON.stringify([pathname, trimmed input, normalizedLanguage, languageHints, type, length, format, preference, sharedContext])`; `normalizedLanguage` is `language`'s lowercase primary subtag (e.g. `pt-BR` → `pt`), and `languageHints` is a boolean for whether that language is in `supportedLanguages`). |
 | `onUpdate` | `(text: string) => void` | Streaming update callback. Receives the cumulative buffer, not deltas. |
@@ -150,7 +152,7 @@ The wrapper strips wrapping quotes / whitespace and collapses internal whitespac
 
 ## Language support beyond en/es/ja
 
-The Web's Built-in Summarizer (Chrome 138+, Edge 138+) only accepts `expectedInputLanguages` / `outputLanguage` for `["en", "es", "ja"]`. Pass any other language as `language: "pt"` and the library omits those hints. The model still runs, but you steer it via `sharedContext` instead:
+By default, the wrapper emits `expectedInputLanguages` / `outputLanguage` hints only for `["en", "es", "ja"]`. Pass another language as `language: "pt"` and the library omits those hints; steer the output via `sharedContext` instead:
 
 ```ts
 summarize({
@@ -160,7 +162,7 @@ summarize({
 });
 ```
 
-When Chrome adds more accepted languages, pass them explicitly via `supportedLanguages: ["en", "es", "ja", "pt"]` and the hints fire through.
+When your target browser documents more accepted languages, pass them explicitly via `supportedLanguages: ["en", "es", "ja", "pt"]` and the hints fire through.
 
 ## Errors and unavailability
 

--- a/apps/site/src/content/docs/guides/translator.mdx
+++ b/apps/site/src/content/docs/guides/translator.mdx
@@ -5,6 +5,8 @@ description: web-ai-sdk building block for the Web's Built-in Translator. String
 
 Building block for the Web's Built-in [Translator API](https://developer.chrome.com/docs/ai/translator-api) (on-demand language packs). String-mode translation with pair-cached sessions, opt-in result caching, AbortSignal-driven cleanup. See [useTranslator](/docs/react/use-translator/) for React.
 
+Before shipping, review the [Production checklist](/docs/production-checklist/) for task-relevant input, safe rendering, progress, reversible changes, and cache freshness.
+
 ## Usage
 
 ```ts
@@ -129,4 +131,3 @@ try {
   throw err;
 }
 ```
-

--- a/apps/site/src/content/docs/guides/translator.mdx
+++ b/apps/site/src/content/docs/guides/translator.mdx
@@ -1,9 +1,9 @@
 ---
 title: Translator API
-description: web-ai-sdk building block for the Web's Built-in Translator. String-mode translation with pair-cached sessions and opt-in result caching.
+description: Translate text with the built-in Translator API, pair-based session reuse, and optional result caching.
 ---
 
-Building block for the Web's Built-in [Translator API](https://developer.chrome.com/docs/ai/translator-api) (on-demand language packs). String-mode translation with pair-cached sessions, opt-in result caching, AbortSignal-driven cleanup. See [useTranslator](/docs/react/use-translator/) for React.
+This package wraps the built-in [Translator API](https://developer.chrome.com/docs/ai/translator-api). It adds pair-based session reuse, optional result caching, and abort cleanup. For React, see [useTranslator](/docs/react/use-translator/).
 
 Before shipping, review the [Production checklist](/docs/production-checklist/) for task-relevant input, safe rendering, progress, reversible changes, and cache freshness.
 

--- a/apps/site/src/content/docs/guides/webmcp.mdx
+++ b/apps/site/src/content/docs/guides/webmcp.mdx
@@ -8,7 +8,7 @@ Building block for the W3C [WebMCP](https://webmachinelearning.github.io/webmcp/
 Where the Built-in AI APIs make the browser an AI runtime, WebMCP makes your page an agent surface: instead of a visiting agent guessing what your interface elements do, the page declares structured tools the agent can discover and call.
 
 :::caution[Experimental]
-WebMCP is a proposed standard in early preview: behind flags and an origin trial in Chromium browsers, absent everywhere else. Treat it as progressive enhancement — keep the human UI path, and let the wrapper no-op where the API is missing. Current versions and flag names live in [Browser support](/docs/browser-support/).
+WebMCP is a proposed standard in early preview. Chrome documents an origin trial from Chrome 149 plus a local-development flag, and Microsoft lists an Edge 150 origin trial. Treat it as progressive enhancement: keep the human UI path, and let the wrapper no-op where the API is missing. Current sources and setup live in [Browser support](/docs/browser-support/).
 :::
 
 ## Usage
@@ -70,7 +70,7 @@ const unsubscribe = subscribeToToolChanges(() => {
 
 `getTools({ fromOrigins })` can additionally request tools from descendant documents at listed secure origins. Cross-origin tools are returned only when the registering document also exposed them to the caller's origin. The browser returns each `inputSchema` as a serialized JSON string and includes the registering `window` and `origin`.
 
-`executeTool()` returns the native serialized string unchanged; `null` means the tool triggered navigation. It is implemented and publicly documented by Chromium but is not yet in the published WebMCP community-draft IDL, so the SDK marks it experimental.
+`executeTool()` returns the native serialized string unchanged; `null` means the tool triggered navigation. Chrome [publicly documents it](https://developer.chrome.com/docs/ai/webmcp), but it is not yet in the published WebMCP community-draft IDL, so the SDK marks it experimental.
 
 ## Tool
 
@@ -149,7 +149,7 @@ maintaining a second handwritten definition.
 `document.modelContext.registerTool({...}, { signal, exposedTo })` is the spec entry point. (For backward compatibility with the previous shape of the API, this package also reads from `navigator.modelContext`.) The wrapper sits on top with these quality-of-life additions:
 
 - **Feature detection.** On browsers without `document.modelContext` (or the legacy `navigator.modelContext`), registration and subscriptions are no-ops, discovery resolves to `[]`, and `isAvailable()` returns `false`. Execution rejects with `WebMCPUnavailableError` so missing support is distinct from a `null` navigation result.
-- **Last-writer-wins on duplicate names.** React effect cleanup is asynchronous; a fast re-render can attempt to register `"foo"` before Chrome processed the prior `abort()`. The wrapper detects the resulting duplicate-name error, queues a microtask retry, and tracks ownership so a stale registration can't squat the name.
+- **Last-writer-wins on duplicate names.** React effect cleanup is asynchronous; a fast re-render can attempt to register `"foo"` before the browser processes the prior `abort()`. The wrapper detects the resulting duplicate-name error, queues a microtask retry, and tracks ownership so a stale registration can't squat the name.
 - **One AbortController per call.** `registerTool` returns a cleanup function that aborts the underlying controller and unregisters the tool.
 - **Library-neutral validation.** Direct definitions may carry Standard Schema input and output validators. The SDK validates and transforms around `execute`, then strips those SDK-only fields before native registration.
 
@@ -234,7 +234,7 @@ definitions directly to `registerTool()` or `useWebMCP()`.
 
 ## Origin trial
 
-Chrome opened a public [origin trial](https://developer.chrome.com/blog/ai-webmcp-origin-trial) for WebMCP (Chrome 149), so you can test agent-callable tools with real traffic before the API stabilizes. Sign up on the [Chrome origin trials](https://developer.chrome.com/origintrials) page; for local development a flag works without a token — see [Browser support](/docs/browser-support/) for the current flag names.
+Chrome opened a public [origin trial](https://developer.chrome.com/blog/ai-webmcp-origin-trial) for WebMCP from Chrome 149, and Microsoft lists WebMCP among the [Edge 150 origin trials](https://learn.microsoft.com/en-us/microsoft-edge/web-platform/release-notes/150). For local Chrome development, the vendor documents a flag that works without a token. See [Browser support](/docs/browser-support/) for the current setup and source links.
 
 Keep WebMCP optional either way. The wrapper already no-ops when the API is missing, so the same registration code ships to every browser — with or without the trial:
 
@@ -257,9 +257,9 @@ registerTool({
 
 ## Debugging in DevTools
 
-Chromium DevTools includes experimental WebMCP debugging in the **Application** panel (introduced in Chrome's [DevTools 149](https://developer.chrome.com/blog/new-in-devtools-149); Edge ships it too): inspect registered tools and their schemas, run a tool manually with custom parameters, track active and pending invocations, and inspect execution status and return payloads. Tools registered through `registerTool` show up there like any other `document.modelContext` registration.
+Chrome DevTools includes experimental WebMCP debugging in the **Application** panel, introduced in [DevTools 149](https://developer.chrome.com/blog/new-in-devtools-149): inspect registered tools and their schemas, run a tool manually with custom parameters, track active and pending invocations, and inspect execution status and return payloads. Tools registered through `registerTool` show up there like any other `document.modelContext` registration.
 
-The panel is off by default; enable both flags (under `chrome://flags` / `edge://flags`) and restart the browser:
+The panel is off by default; enable both Chrome flags and restart the browser:
 
 - `#devtools-webmcp-support`
 - `#enable-webmcp-testing`

--- a/apps/site/src/content/docs/guides/webmcp.mdx
+++ b/apps/site/src/content/docs/guides/webmcp.mdx
@@ -3,12 +3,12 @@ title: WebMCP
 description: Register, discover, and execute agent-callable tools on the W3C WebMCP surface through typed vanilla and React SDK APIs.
 ---
 
-Building block for the W3C [WebMCP](https://webmachinelearning.github.io/webmcp/) API exposed at `document.modelContext`. (For backward compatibility with the previous shape of the API, this package also reads from `navigator.modelContext`.) Register, discover, and execute agent-callable tools from any framework; the package is vanilla TypeScript / DOM with an optional React adapter shipped as a subpath export. See [useWebMCP](/docs/react/use-web-mcp/) for React.
+This package wraps the W3C [WebMCP](https://webmachinelearning.github.io/webmcp/) API at `document.modelContext`. It can register, discover, and execute tools. It also reads the earlier `navigator.modelContext` API for compatibility. For React, see [useWebMCP](/docs/react/use-web-mcp/).
 
-Where the Built-in AI APIs make the browser an AI runtime, WebMCP makes your page an agent surface: instead of a visiting agent guessing what your interface elements do, the page declares structured tools the agent can discover and call.
+WebMCP lets a page declare structured tools that agents can discover and call.
 
 :::caution[Experimental]
-WebMCP is a proposed standard in early preview. Chrome documents an origin trial from Chrome 149 plus a local-development flag, and Microsoft lists an Edge 150 origin trial. Treat it as progressive enhancement: keep the human UI path, and let the wrapper no-op where the API is missing. Current sources and setup live in [Browser support](/docs/browser-support/).
+WebMCP is an early proposal. Chrome documents an origin trial from version 149 and a local flag. Microsoft lists an Edge 150 origin trial. Keep the human UI path. See [Browser support](/docs/browser-support/) for setup.
 :::
 
 ## Usage
@@ -46,7 +46,7 @@ const cleanup = () => cleanups.forEach((c) => c());
 
 ## Discover and execute tools
 
-Use SDK primitives rather than reaching through `document.modelContext` directly. `getTools()` returns the browser-facing metadata for tools exposed to the current document; `executeTool()` accepts one of those returned objects and serializes the JavaScript input value for the native call.
+`getTools()` returns metadata for tools exposed to the current document. `executeTool()` accepts one returned tool and serializes its input for the native call.
 
 ```ts
 import {
@@ -68,7 +68,9 @@ const unsubscribe = subscribeToToolChanges(() => {
 });
 ```
 
-`getTools({ fromOrigins })` can additionally request tools from descendant documents at listed secure origins. Cross-origin tools are returned only when the registering document also exposed them to the caller's origin. The browser returns each `inputSchema` as a serialized JSON string and includes the registering `window` and `origin`.
+`getTools({ fromOrigins })` also requests tools from descendant documents at listed secure origins. The registering document must expose each tool to the caller's origin.
+
+The browser returns `inputSchema` as serialized JSON. It also includes the registering `window` and `origin`.
 
 `executeTool()` returns the native serialized string unchanged; `null` means the tool triggered navigation. Chrome [publicly documents it](https://developer.chrome.com/docs/ai/webmcp), but it is not yet in the published WebMCP community-draft IDL, so the SDK marks it experimental.
 
@@ -142,11 +144,11 @@ maintaining a second handwritten definition.
 
 ## Registration cleanup
 
-`registerTool(tool, options?)` returns a cleanup function: `() => void`. Calling it unregisters the tool. Calling it twice is a no-op. On browsers without `document.modelContext` (or the legacy `navigator.modelContext`), the cleanup is itself a no-op.
+`registerTool(tool, options?)` returns a cleanup function. It unregisters the tool and is safe to call more than once. Unsupported browsers return a no-op cleanup.
 
 ## How it works
 
-`document.modelContext.registerTool({...}, { signal, exposedTo })` is the spec entry point. (For backward compatibility with the previous shape of the API, this package also reads from `navigator.modelContext`.) The wrapper sits on top with these quality-of-life additions:
+`document.modelContext.registerTool({...}, { signal, exposedTo })` is the standard entry point. The wrapper adds this lifecycle behavior:
 
 - **Feature detection.** On browsers without `document.modelContext` (or the legacy `navigator.modelContext`), registration and subscriptions are no-ops, discovery resolves to `[]`, and `isAvailable()` returns `false`. Execution rejects with `WebMCPUnavailableError` so missing support is distinct from a `null` navigation result.
 - **Last-writer-wins on duplicate names.** React effect cleanup is asynchronous; a fast re-render can attempt to register `"foo"` before the browser processes the prior `abort()`. The wrapper detects the resulting duplicate-name error, queues a microtask retry, and tracks ownership so a stale registration can't squat the name.
@@ -163,7 +165,9 @@ const cleanup = registerTool(tool, {
 });
 ```
 
-The SDK forwards the array unchanged alongside its internally owned `AbortSignal`. The browser validates each origin and rejects invalid or untrustworthy values. Those asynchronous failures follow the package's existing non-throwing registration posture: they are logged without creating an unhandled rejection. Grant access only to origins that genuinely need it; `exposedTo` is exposure configuration, not an authorization layer.
+The SDK forwards the array with its own `AbortSignal`. The browser validates each origin. The wrapper logs validation failures without creating an unhandled rejection.
+
+List only origins that need access. `exposedTo` controls exposure; it does not grant authorization.
 
 An in-page agent or inspector requests those cross-origin tools with the complementary discovery option:
 
@@ -196,7 +200,7 @@ For source compatibility, the SDK retains `destructiveHint`, `idempotentHint`, `
 
 ## Tool design
 
-A tool is a semantic interface, not just a function: the agent selects tools by reading names, descriptions, schemas, and annotations. A few rules of thumb:
+Agents select tools by reading their names, descriptions, schemas, and annotations. Follow these rules:
 
 - **Action-oriented names.** `add_to_cart`, `select_shipping_address`, `run_diagnostics` — not `doAction`, `submit`, or `handleClick`.
 - **Descriptions that say when to use the tool**, not just what it does. Besides the schema, the description is the agent's only routing signal.
@@ -207,7 +211,9 @@ A tool is a semantic interface, not just a function: the agent selects tools by 
 
 ## Errors and unavailability
 
-Registration and event subscription never throw for a missing API; they return no-op cleanups. Discovery returns an empty list. Tool execution is different because `null` already means that execution triggered a navigation, so missing support rejects with the typed `WebMCPUnavailableError`:
+Registration and event subscription return no-op cleanups when the API is missing. Discovery returns an empty list.
+
+Execution uses `null` for navigation. It therefore reports missing support with `WebMCPUnavailableError`:
 
 ```ts
 import { registerTool, isAvailable } from "@web-ai-sdk/webmcp";
@@ -236,7 +242,7 @@ definitions directly to `registerTool()` or `useWebMCP()`.
 
 Chrome opened a public [origin trial](https://developer.chrome.com/blog/ai-webmcp-origin-trial) for WebMCP from Chrome 149, and Microsoft lists WebMCP among the [Edge 150 origin trials](https://learn.microsoft.com/en-us/microsoft-edge/web-platform/release-notes/150). For local Chrome development, the vendor documents a flag that works without a token. See [Browser support](/docs/browser-support/) for the current setup and source links.
 
-Keep WebMCP optional either way. The wrapper already no-ops when the API is missing, so the same registration code ships to every browser — with or without the trial:
+Keep WebMCP optional. Registration becomes a no-op when the API is missing, so the same code can run in other browsers:
 
 ```ts
 import { registerTool } from "@web-ai-sdk/webmcp";
@@ -257,7 +263,7 @@ registerTool({
 
 ## Debugging in DevTools
 
-Chrome DevTools includes experimental WebMCP debugging in the **Application** panel, introduced in [DevTools 149](https://developer.chrome.com/blog/new-in-devtools-149): inspect registered tools and their schemas, run a tool manually with custom parameters, track active and pending invocations, and inspect execution status and return payloads. Tools registered through `registerTool` show up there like any other `document.modelContext` registration.
+Chrome DevTools 149 added experimental WebMCP debugging to the **Application** panel. You can inspect tools, run them with custom input, and inspect results. Tools registered through this SDK appear with other `document.modelContext` tools.
 
 The panel is off by default; enable both Chrome flags and restart the browser:
 

--- a/apps/site/src/content/docs/guides/writer.mdx
+++ b/apps/site/src/content/docs/guides/writer.mdx
@@ -1,9 +1,9 @@
 ---
 title: Writer API
-description: web-ai-sdk building block for the Web's Built-in Writer API with session reuse, streaming, and opt-in result caching.
+description: Generate text with the built-in Writer API, streaming, session reuse, and optional result caching.
 ---
 
-Building block for the Web's Built-in [Writer API](https://developer.chrome.com/docs/ai/writer-api). Generates new content from a writing task with tone / format / length options, session reuse, streaming, and pluggable result caching. The React adapter lives at `@web-ai-sdk/writer/react`; see [useWriter](/docs/react/use-writer/).
+This package wraps the built-in [Writer API](https://developer.chrome.com/docs/ai/writer-api). It adds session reuse, streaming, and optional result caching. For React, see [useWriter](/docs/react/use-writer/).
 
 Before shipping, review the [Production checklist](/docs/production-checklist/) for safe rendering, progress, reversible suggestions, user control, and cache freshness.
 

--- a/apps/site/src/content/docs/guides/writer.mdx
+++ b/apps/site/src/content/docs/guides/writer.mdx
@@ -5,6 +5,8 @@ description: web-ai-sdk building block for the Web's Built-in Writer API with se
 
 Building block for the Web's Built-in [Writer API](https://developer.chrome.com/docs/ai/writer-api). Generates new content from a writing task with tone / format / length options, session reuse, streaming, and pluggable result caching. The React adapter lives at `@web-ai-sdk/writer/react`; see [useWriter](/docs/react/use-writer/).
 
+Before shipping, review the [Production checklist](/docs/production-checklist/) for safe rendering, progress, reversible suggestions, user control, and cache freshness.
+
 ## Usage
 
 ```ts

--- a/apps/site/src/content/docs/index.mdx
+++ b/apps/site/src/content/docs/index.mdx
@@ -25,6 +25,8 @@ import { Card, CardGrid } from "@astrojs/starlight/components";
 
 You can always use the raw browser APIs directly; the SDK doesn't replace or hide them. It just owns the lifecycle layer around them (session reuse, streaming, AbortSignals, feature-detected fallbacks) and is built to get thinner as the platform matures.
 
+Before shipping a feature, use the [Production checklist](/docs/production-checklist/) to cover user intent, input selection, safe rendering, progress, reversible edits, and cache freshness.
+
 Compositions that bond multiple primitives (block-level DOM translation,
 article-aware summarization, detect-then-summarize chains) are
 deliberately out of scope — the SDK wraps one capability per package;

--- a/apps/site/src/content/docs/index.mdx
+++ b/apps/site/src/content/docs/index.mdx
@@ -17,7 +17,7 @@ hero:
       variant: minimal
 ---
 
-import { Card, CardGrid } from "@astrojs/starlight/components";
+import PackageIndex from "../../features/docs/components/PackageIndex.astro";
 
 ## What it is
 
@@ -48,45 +48,7 @@ You can use the browser APIs directly. The SDK handles lifecycle code that appli
 
 ## Packages
 
-<CardGrid>
-  <Card title="@web-ai-sdk/all" icon="open-book">
-    Meta-package: install once, get all eight wrappers under a single
-    dependency. [Read the guide →](/docs/guides/meta-package/)
-  </Card>
-  <Card title="@web-ai-sdk/prompt" icon="comment">
-    Send prompts and manage independent sessions, streams, and abort signals.
-    [Read the guide →](/docs/guides/prompt/)
-  </Card>
-  <Card title="@web-ai-sdk/webmcp" icon="puzzle">
-    Register tools for the browser's model context. The package manages
-    registration cleanup. [Read the guide →](/docs/guides/webmcp/)
-  </Card>
-  <Card title="@web-ai-sdk/summarizer" icon="list-format">
-    Create key points, summaries, teasers, or headlines. Configure length and
-    stream the result.
-    [Read the guide →](/docs/guides/summarizer/)
-  </Card>
-  <Card title="@web-ai-sdk/translator" icon="translate">
-    Translate text between a source and target language. Sessions are cached by
-    language pair. [Read the guide →](/docs/guides/translator/)
-  </Card>
-  <Card title="@web-ai-sdk/detector" icon="magnifier">
-    Detect a text's language. Receive confidence scores and sorted alternatives.
-    [Read the guide →](/docs/guides/detector/)
-  </Card>
-  <Card title="@web-ai-sdk/writer" icon="pen">
-    Draft new content from a task description. Tone, format, length, streaming.
-    [Read the guide →](/docs/guides/writer/)
-  </Card>
-  <Card title="@web-ai-sdk/rewriter" icon="random">
-    Change the tone or length of existing text.
-    [Read the guide →](/docs/guides/rewriter/)
-  </Card>
-  <Card title="@web-ai-sdk/proofreader" icon="approve-check-circle">
-    Correct grammar, spelling, and punctuation. Receive an offset for each issue.
-    [Read the guide →](/docs/guides/proofreader/)
-  </Card>
-</CardGrid>
+<PackageIndex />
 
 ## Install
 

--- a/apps/site/src/content/docs/index.mdx
+++ b/apps/site/src/content/docs/index.mdx
@@ -1,9 +1,9 @@
 ---
 title: web-ai-sdk
-description: Building blocks in TypeScript for the Web AI surface. Composable, no runtime deps, just lifecycle, streaming, and AbortSignals.
+description: TypeScript lifecycle wrappers for browser AI APIs.
 template: splash
 hero:
-  tagline: Building blocks in TypeScript for the Web AI surface. Composable, no runtime deps, just lifecycle, streaming, and AbortSignals.
+  tagline: TypeScript lifecycle wrappers for browser AI APIs. No runtime dependencies.
   actions:
     - text: Browser support
       link: /docs/browser-support/
@@ -21,32 +21,32 @@ import { Card, CardGrid } from "@astrojs/starlight/components";
 
 ## What it is
 
-**`web-ai-sdk`** ships building blocks for the Web AI surface. One package per browser capability (Prompt, WebMCP, Summarizer, Translator, Detector, Writer, Rewriter, Proofreader). Zero runtime dependencies. Written in TypeScript. See [Architecture](/docs/architecture/) for the model.
+`web-ai-sdk` provides one TypeScript package for each supported browser capability. The packages have no runtime dependencies. See [Architecture](/docs/architecture/) for the package boundaries.
 
-You can always use the raw browser APIs directly; the SDK doesn't replace or hide them. It just owns the lifecycle layer around them (session reuse, streaming, AbortSignals, feature-detected fallbacks) and is built to get thinner as the platform matures.
+The SDK does not replace the browser APIs. It manages session reuse, streaming, abort signals, cleanup, and unavailable states.
 
 Before shipping a feature, use the [Production checklist](/docs/production-checklist/) to cover user intent, input selection, safe rendering, progress, reversible edits, and cache freshness.
 
-Compositions that bond multiple primitives (block-level DOM translation,
-article-aware summarization, detect-then-summarize chains) are
-deliberately out of scope — the SDK wraps one capability per package;
-composition is your code.
+The SDK does not compose capabilities or walk the DOM. Application code owns tasks such as article extraction and detect-then-summarize flows.
 
-## One capability per package, on purpose
+## One capability per package
 
-A single text-generation model abstraction reaches exactly one of these built-ins, `LanguageModel` (Prompt). The other seven carry options it cannot express (target language, tone, length, confidence thresholds, per-issue offsets), and one of them, WebMCP, is an *agent* surface rather than a model. That breadth is why the SDK is per-capability rather than one provider adapter. The model abstraction is one surface among eight, not the whole product. See [Why web-ai-sdk](/docs/why-web-ai-sdk/) for the full argument.
+Only Prompt uses the general `LanguageModel` API. The other capabilities have different inputs and results. WebMCP exposes page tools instead of generating text.
 
-## Why not just use the APIs directly?
+See [Why web-ai-sdk](/docs/why-web-ai-sdk/) for a detailed comparison.
 
-You can, and nothing here stops you. The Web AI surface is the foundation; web-ai-sdk owns the thin, repetitive lifecycle layer you'd otherwise rewrite in every component, and nothing more.
+## Why use a wrapper?
 
-- **It's the same APIs.** Drop down to `LanguageModel`, `Summarizer`, `Writer`, and friends whenever you want. No lock-in, no wrapper objects you can't escape.
-- **What you'd otherwise rebuild.** Feature detection, session reuse, delta-vs-cumulative stream smoothing, AbortSignal cleanup, and feature-detected no-op fallbacks when the API is missing.
-- **It's built to shrink.** As the platform absorbs more, this layer gets thinner, not fatter. The goal is to do less over time, not more.
+You can use the browser APIs directly. The SDK handles lifecycle code that applications often repeat:
 
-[Why this layer is designed to get thinner over time →](/docs/architecture/#lineage-thin-shims-over-platform-primitives)
+- feature detection and unavailable states;
+- session reuse and cleanup;
+- delta and cumulative stream normalization;
+- `AbortSignal` wiring.
 
-## Composable wrappers. One philosophy.
+[Read the architecture guide →](/docs/architecture/)
+
+## Packages
 
 <CardGrid>
   <Card title="@web-ai-sdk/all" icon="open-book">
@@ -54,57 +54,56 @@ You can, and nothing here stops you. The Web AI surface is the foundation; web-a
     dependency. [Read the guide →](/docs/guides/meta-package/)
   </Card>
   <Card title="@web-ai-sdk/prompt" icon="comment">
-    Talk to the on-device language model. Sessions, streaming, AbortSignals.
+    Send prompts and manage independent sessions, streams, and abort signals.
     [Read the guide →](/docs/guides/prompt/)
   </Card>
   <Card title="@web-ai-sdk/webmcp" icon="puzzle">
-    Register tools the browser's model context can call. Real agents, real
-    cleanup, no boilerplate. [Read the guide →](/docs/guides/webmcp/)
+    Register tools for the browser's model context. The package manages
+    registration cleanup. [Read the guide →](/docs/guides/webmcp/)
   </Card>
   <Card title="@web-ai-sdk/summarizer" icon="list-format">
-    Key-points, TL;DR, headlines. Configurable type and length, streaming.
+    Create key points, summaries, teasers, or headlines. Configure length and
+    stream the result.
     [Read the guide →](/docs/guides/summarizer/)
   </Card>
   <Card title="@web-ai-sdk/translator" icon="translate">
-    String-mode translation with pair-cached sessions. Source → target in one
-    call. [Read the guide →](/docs/guides/translator/)
+    Translate text between a source and target language. Sessions are cached by
+    language pair. [Read the guide →](/docs/guides/translator/)
   </Card>
   <Card title="@web-ai-sdk/detector" icon="magnifier">
-    Detect the language of any text on-device. Confidence scores plus a sorted
-    list of alternates. [Read the guide →](/docs/guides/detector/)
+    Detect a text's language. Receive confidence scores and sorted alternatives.
+    [Read the guide →](/docs/guides/detector/)
   </Card>
   <Card title="@web-ai-sdk/writer" icon="pen">
     Draft new content from a task description. Tone, format, length, streaming.
     [Read the guide →](/docs/guides/writer/)
   </Card>
   <Card title="@web-ai-sdk/rewriter" icon="random">
-    Tone-shift and reshape text you already have. Shorter, longer, more formal.
+    Change the tone or length of existing text.
     [Read the guide →](/docs/guides/rewriter/)
   </Card>
   <Card title="@web-ai-sdk/proofreader" icon="approve-check-circle">
-    Grammar, spelling, and punctuation fixes with per-issue offsets you can
-    highlight in place. [Read the guide →](/docs/guides/proofreader/)
+    Correct grammar, spelling, and punctuation. Receive an offset for each issue.
+    [Read the guide →](/docs/guides/proofreader/)
   </Card>
 </CardGrid>
 
 ## Install
 
-Pick a building block, or grab the whole suite under a single install:
+Install one package or the full set:
 
 ```sh
 pnpm add @web-ai-sdk/prompt        # one block
 pnpm add @web-ai-sdk/all           # all eight blocks
 ```
 
-See the [meta-package guide](/docs/guides/meta-package/) for the two import shapes (`@web-ai-sdk/all/prompt` subpath vs `{ prompt } from "@web-ai-sdk/all"` namespaced root).
+The [meta-package guide](/docs/guides/meta-package/) documents subpath and namespaced imports.
 
 Each package ships:
 
-- **Vanilla** (`@web-ai-sdk/<pkg>`); TypeScript / DOM only, zero framework deps.
-- **React** (`@web-ai-sdk/<pkg>/react`); small hook adapter that wraps the vanilla core. `react` is an optional peer dependency.
+- **Vanilla** (`@web-ai-sdk/<pkg>`): TypeScript and DOM APIs with no framework dependency.
+- **React** (`@web-ai-sdk/<pkg>/react`): hooks over the vanilla API. `react` is an optional peer dependency.
 
-## Why composable
+## Package scope
 
-Browsers are shipping Web AI APIs behind flags. The shape changes; the lifecycle is similar across them: feature-detect, lazily create a session, stream chunks, cache results, clean up. Those concerns are framework-agnostic and worth sharing.
-
-We ship that lifecycle layer. Framework adapters, polyfills, UI primitives stay optional subpaths so they don't constrain your design system, framework, or styling stack. Pick the layers you need; skip the rest.
+Each package owns one browser capability. UI, polyfills, DOM traversal, and cross-capability workflows remain outside the core wrappers.

--- a/apps/site/src/content/docs/packages/all.md
+++ b/apps/site/src/content/docs/packages/all.md
@@ -13,7 +13,7 @@ One-install meta-package for web-ai-sdk, the TypeScript SDK for the Web AI surfa
 
 ## Status
 
-Each underlying scoped package is independently supported in Chrome / Edge with the corresponding Web AI flag enabled. See the per-package READMEs for browser support details:
+Each underlying package tracks its browser capability independently: some APIs are stable, while others require a developer preview, developer trial, or origin trial. See the sourced [browser-support matrix](https://web-ai-sdk.dev/docs/browser-support/) and per-package READMEs for current details:
 
 - [`@web-ai-sdk/prompt`](https://github.com/obetomuniz/web-ai-sdk/tree/main/packages/prompt)
 - [`@web-ai-sdk/summarizer`](https://github.com/obetomuniz/web-ai-sdk/tree/main/packages/summarizer)

--- a/apps/site/src/content/docs/packages/all.md
+++ b/apps/site/src/content/docs/packages/all.md
@@ -1,6 +1,6 @@
 ---
 title: "@web-ai-sdk/all"
-description: "One-install meta-package for web-ai-sdk, the TypeScript SDK for the Web AI surface. Pulls in every @web-ai-sdk/* building block: prompt, summarizer, translator, detector, writer, rewriter, proofreader, and webmcp, each as a regular dependency so consumers don't have to track them individually."
+description: "Install all eight wrappers through one package: prompt, summarizer, translator, detector, writer, rewriter, proofreader, and webmcp."
 editUrl: https://github.com/obetomuniz/web-ai-sdk/edit/main/packages/sdk/README.md
 ---
 
@@ -8,12 +8,12 @@ editUrl: https://github.com/obetomuniz/web-ai-sdk/edit/main/packages/sdk/README.
 This page is synced from [`packages/sdk/README.md`](https://github.com/obetomuniz/web-ai-sdk/blob/main/packages/sdk/README.md) by `pnpm --filter @web-ai-sdk-apps/site docs:sync`. Edits should go to the README.
 :::
 
-One-install meta-package for web-ai-sdk, the TypeScript SDK for the Web AI surface. Pulls in every `@web-ai-sdk/*` building block: `prompt`, `summarizer`, `translator`, `detector`, `writer`, `rewriter`, `proofreader`, and `webmcp`, each as a regular dependency so consumers don't have to track them individually.
+Install all eight wrappers through one package: `prompt`, `summarizer`, `translator`, `detector`, `writer`, `rewriter`, `proofreader`, and `webmcp`.
 
 
 ## Status
 
-Each underlying package tracks its browser capability independently: some APIs are stable, while others require a developer preview, developer trial, or origin trial. See the sourced [browser-support matrix](https://web-ai-sdk.dev/docs/browser-support/) and per-package READMEs for current details:
+Browser support differs by capability. See the [browser-support matrix](https://web-ai-sdk.dev/docs/browser-support/) and package READMEs for current status:
 
 - [`@web-ai-sdk/prompt`](https://github.com/obetomuniz/web-ai-sdk/tree/main/packages/prompt)
 - [`@web-ai-sdk/summarizer`](https://github.com/obetomuniz/web-ai-sdk/tree/main/packages/summarizer)

--- a/apps/site/src/content/docs/packages/detector.md
+++ b/apps/site/src/content/docs/packages/detector.md
@@ -1,6 +1,6 @@
 ---
 title: "@web-ai-sdk/detector"
-description: "web-ai-sdk building block for the Web's Built-in Language Detector API. Detect the language of any text on-device, with confidence scores and a sorted list of alternates. Session reuse, pluggable result caching, AbortSignal-driven cleanup."
+description: "This package wraps the Web's Built-in Language Detector API. It returns confidence scores and sorted alternatives. It also supports session reuse, optional result caching, and abort signals."
 editUrl: https://github.com/obetomuniz/web-ai-sdk/edit/main/packages/detector/README.md
 ---
 
@@ -8,12 +8,14 @@ editUrl: https://github.com/obetomuniz/web-ai-sdk/edit/main/packages/detector/RE
 This page is synced from [`packages/detector/README.md`](https://github.com/obetomuniz/web-ai-sdk/blob/main/packages/detector/README.md) by `pnpm --filter @web-ai-sdk-apps/site docs:sync`. Edits should go to the README.
 :::
 
-web-ai-sdk building block for [the Web's Built-in Language Detector API](https://developer.chrome.com/docs/ai/language-detection). Detect the language of any text on-device, with confidence scores and a sorted list of alternates. Session reuse, pluggable result caching, AbortSignal-driven cleanup.
+This package wraps the Web's Built-in [Language Detector API](https://developer.chrome.com/docs/ai/language-detection). It returns confidence scores and sorted alternatives. It also supports session reuse, optional result caching, and abort signals.
 
 
 ## Status
 
-Language Detector ships stable in Chrome 138+ and shipped in Edge 148, with no flag required, per the [Chrome status table](https://developer.chrome.com/docs/ai/built-in-apis) and [Edge 148 release notes](https://learn.microsoft.com/en-us/microsoft-edge/web-platform/release-notes/148). On browsers without `LanguageDetector`, the React hook stays `"unavailable"`; vanilla `detect()` throws `DetectorUnavailableError` so callers can branch explicitly.
+Language Detector is stable in Chrome 138+ and shipped in Edge 148. It does not require a flag. See the [Chrome status table](https://developer.chrome.com/docs/ai/built-in-apis) and [Edge 148 release notes](https://learn.microsoft.com/en-us/microsoft-edge/web-platform/release-notes/148).
+
+Without `LanguageDetector`, React reports `"unavailable"` and `detect()` throws `DetectorUnavailableError`.
 
 ## Install
 
@@ -22,7 +24,7 @@ pnpm add @web-ai-sdk/detector
 # or: npm i @web-ai-sdk/detector / bun add @web-ai-sdk/detector
 ```
 
-The React adapter ships as a subpath export, with no extra install. `react` is a peer dependency only when you import the `/react` entry.
+The React adapter uses the `/react` subpath. `react` is an optional peer dependency.
 
 ## Vanilla TypeScript / DOM
 

--- a/apps/site/src/content/docs/packages/detector.md
+++ b/apps/site/src/content/docs/packages/detector.md
@@ -13,7 +13,7 @@ web-ai-sdk building block for [the Web's Built-in Language Detector API](https:/
 
 ## Status
 
-Language Detector ships stable in Chrome 138+ and Edge 148+ on desktop, with no flag required (per the [Edge Language Detector API docs](https://learn.microsoft.com/en-us/microsoft-edge/web-platform/languagedetector-api)). On any other browser this library is a no-op for the React hook (it stays in `"unavailable"`). The vanilla `detect()` throws `DetectorUnavailableError` so callers can branch explicitly.
+Language Detector ships stable in Chrome 138+ and shipped in Edge 148, with no flag required, per the [Chrome status table](https://developer.chrome.com/docs/ai/built-in-apis) and [Edge 148 release notes](https://learn.microsoft.com/en-us/microsoft-edge/web-platform/release-notes/148). On browsers without `LanguageDetector`, the React hook stays `"unavailable"`; vanilla `detect()` throws `DetectorUnavailableError` so callers can branch explicitly.
 
 ## Install
 

--- a/apps/site/src/content/docs/packages/prompt.md
+++ b/apps/site/src/content/docs/packages/prompt.md
@@ -8,12 +8,12 @@ editUrl: https://github.com/obetomuniz/web-ai-sdk/edit/main/packages/prompt/READ
 This page is synced from [`packages/prompt/README.md`](https://github.com/obetomuniz/web-ai-sdk/blob/main/packages/prompt/README.md) by `pnpm --filter @web-ai-sdk-apps/site docs:sync`. Edits should go to the README.
 :::
 
-web-ai-sdk building block for the Web's Built-in [Prompt API](https://developer.chrome.com/docs/extensions/ai/prompt-api) (`LanguageModel`). One-shot `ask()` for embeds and widgets, plus a thin `createSession()` primitive (and React `useSession`) for chat-shaped apps that need independent per-conversation sessions and delta-shaped streaming. The wrapper smooths cross-browser quirks (delta-vs-cumulative chunks, control-character cleanup, abort wiring); UI state and conversation history are the consumer's concern.
+web-ai-sdk building block for the Web's Built-in [Prompt API](https://developer.chrome.com/docs/ai/prompt-api) (`LanguageModel`). One-shot `ask()` for embeds and widgets, plus a thin `createSession()` primitive (and React `useSession`) for chat-shaped apps that need independent per-conversation sessions and delta-shaped streaming. The wrapper smooths cross-browser quirks (delta-vs-cumulative chunks, control-character cleanup, abort wiring); UI state and conversation history are the consumer's concern.
 
 
 ## Status
 
-Prompt API ships stable in Chrome 148+ — no flag required. Chrome 138–147 still works with `chrome://flags/#prompt-api-for-gemini-nano` enabled. On Edge it remains a developer preview in Canary/Dev 138+ behind `edge://flags/#prompt-api-for-phi-mini`, with Phi-4-mini's stricter safety pipeline often refusing output (see [Browser support](https://web-ai-sdk.dev/browser-support)). On any other browser this library is a no-op for the React hook (it stays in `"unavailable"`). The vanilla `ask()` throws `PromptUnavailableError` so callers can branch explicitly.
+Prompt API [ships stable in Chrome 148+](https://developer.chrome.com/docs/ai/prompt-api) with no flag required. On Edge it is a [developer preview](https://learn.microsoft.com/en-us/microsoft-edge/web-platform/prompt-api) in Canary/Dev 138.0.3309.2+ behind "Prompt API for on-device language model." Phi-4-mini is the documented default and requires a High-or-greater device performance class; Canary/Dev 150.0.4070+ can optionally use the prerelease Aion-1.0-Instruct model on Medium/Low devices behind the additional "Enable prerelease on-device language model" flag. See [Browser support](https://web-ai-sdk.dev/docs/browser-support/) for the sourced matrix. On browsers without `LanguageModel`, the React hook stays `"unavailable"`; vanilla `ask()` throws `PromptUnavailableError` so callers can branch explicitly.
 
 ## Install
 
@@ -69,7 +69,7 @@ Every `createSession()` call returns an independent `LanguageModelInstance` with
 
 Calling `createSession()` starts `LanguageModel.create()` immediately. The first `send`, `sendStreaming`, or `clone` only awaits that already-started creation, so creating a base session as soon as the user's intent is clear is a valid prewarming primitive. The synchronous `Session` wrapper is returned before native creation necessarily resolves; see [Context-window introspection](#context-window-introspection) for the resulting getter-readiness distinction.
 
-**Concurrency note.** Each session is an independent `LanguageModel` instance: independent history, system prompt, sampling, and lifecycle. The underlying on-device model is single-instance, so the browser currently schedules `sendStreaming` calls across sessions FIFO. Overlapping sends do not interleave token-by-token in Chrome 148 / Edge 138 — the second send waits for the first to drain. This is a constraint of the runtime, not of the API; code written against `createSession()` becomes faster automatically if a future release exposes parallel inference.
+**Concurrency note.** Each session has independent history, system prompts, sampling, and lifecycle. Scheduling across different native sessions is browser-defined, so do not depend on token-level interleaving or a particular parallelism policy.
 
 ## React
 
@@ -138,7 +138,7 @@ export function Chat({ persona }: { persona: string }) {
 }
 ```
 
-`useSession` is lifecycle-only: it starts in `"loading"` while the native `LanguageModel.create()` call is in flight, moves to `"ready"` when `session` is usable, destroys the session on unmount, and recreates it when any primitive option changes. It deliberately does **not** track `response` / `history` / streaming status — that's your UI state, you own it. Each `useSession()` call owns its own underlying `LanguageModelInstance`, so component state and `abort()` / `destroy()` stay scoped to the owning component. Token-level interleaving across sessions is browser-defined (see the Concurrency note above) — Chrome 148 / Edge 138 currently drain through one underlying model FIFO.
+`useSession` is lifecycle-only: it starts in `"loading"` while the native `LanguageModel.create()` call is in flight, moves to `"ready"` when `session` is usable, destroys the session on unmount, and recreates it when any primitive option changes. It deliberately does **not** track `response` / `history` / streaming status — that's your UI state, you own it. Each `useSession()` call owns its own underlying `LanguageModelInstance`, so component state and `abort()` / `destroy()` stay scoped to the owning component. Scheduling across sessions remains browser-defined (see the Concurrency note above).
 
 ## API
 
@@ -255,15 +255,15 @@ const tools: LanguageModelTool[] = [
 const session = createSession({ systemPrompt, tools });
 ```
 
-This is **pass-through only**: the SDK forwards `tools` and never calls `execute` itself. Whether the model actually invokes a tool depends on the browser. Native execution is **not** wired on current stable Chrome — the option is accepted but is a silent no-op, and the model may surface its tool call as plain text (a `tool_code` block) that your code must parse. The passthrough begins working automatically on browsers that ship native execution; until then, `responseConstraint` remains the robust default. The heuristic `tool_code` parser and the tool-execution loop are deliberately left in the consumer layer.
+This is **pass-through only**: the SDK forwards `tools` and never calls `execute` itself. Native tool execution depends on the browser implementation, so treat it as experimental and provide a fallback. Parsing model-emitted tool-like text and running a manual execution loop are deliberately left in the consumer layer.
 
-`tools` works on `ask()` too (`ask({ input, tools })`), with one caveat: `ask()` may keep warm base sessions through an LRU keyed by `JSON.stringify(createOptions)`, and `JSON.stringify` drops functions — so a tool's `execute` doesn't contribute to the key, only its `name` / `description` / `inputSchema` do. Each `ask()` prompt still runs on a clone or fresh one-shot instance. It's harmless today (the SDK never runs `execute`), but it matters once native execution lands, so prefer `createSession()` for tool-bearing sessions — it bypasses the cache and matches the base-session + per-run-`clone()` pattern.
+`tools` works on `ask()` too (`ask({ input, tools })`), with one caveat: `ask()` may keep warm base sessions through an LRU keyed by `JSON.stringify(createOptions)`, and `JSON.stringify` drops functions — so a tool's `execute` doesn't contribute to the key, only its `name` / `description` / `inputSchema` do. Each `ask()` prompt still runs on a clone or fresh one-shot instance. Prefer `createSession()` for tool-bearing sessions: it bypasses the cache and matches the base-session + per-run-`clone()` pattern.
 
 To declare the native tool modalities, pass them through the advanced `expectedInputs` / `expectedOutputs` fields (`{ type: "tool-response" }` / `{ type: "tool-call" }`).
 
 ### Session resilience: base + per-task `clone()`
 
-For agents and multi-task flows, reusing one long-lived session lets history accumulate (later runs "echo" earlier ones, and you eventually hit `QuotaExceededError`), while recreating a session per task pays the cold start and can hit Chrome's single-instance degradation. The spec's [recommended pattern](https://developer.chrome.com/docs/ai/session-management) is to keep one warm **base** session (system prompt only) and `clone()` it per task: the clone inherits the system prompt and history without re-parsing or another `create()`, then gets independent history and lifecycle.
+For agents and multi-task flows, reusing one long-lived session lets unrelated history accumulate, while recreating a session per task repeats creation and instruction processing. Chrome's [session-management guidance](https://developer.chrome.com/docs/ai/session-management) recommends keeping one warm **base** session (system prompt only) and calling `clone()` per task: the clone inherits the system prompt without unrelated task history, then gets independent history and lifecycle.
 
 ```ts
 // As soon as the workflow is chosen, begin native creation with final instructions.
@@ -342,7 +342,7 @@ They compose: prefill the opening brace, set `responseConstraint` for the full s
 - `session.contextWindow` — max input tokens for the session (the context window).
 - `session.contextUsage` — input tokens used so far. On a fresh base-clone this reflects the inherited history (≈ the system prompt), the right baseline to budget a turn against.
 
-These mirror the Prompt API's `contextWindow` / `contextUsage` (the renamed successors of `inputQuota` / `inputUsage`); the wrapper reads the new names and falls back to the deprecated ones on older Chrome builds.
+These mirror the Prompt API's `contextWindow` / `contextUsage`; the wrapper also reads the deprecated `inputQuota` / `inputUsage` names for compatibility.
 
 ```ts
 const base = createSession({ systemPrompt }); // native creation starts here

--- a/apps/site/src/content/docs/packages/prompt.md
+++ b/apps/site/src/content/docs/packages/prompt.md
@@ -1,6 +1,6 @@
 ---
 title: "@web-ai-sdk/prompt"
-description: "web-ai-sdk building block for the Web's Built-in Prompt API (LanguageModel). One-shot ask() for embeds and widgets, plus a thin createSession() primitive (and React useSession) for chat-shaped apps that need independent per-conversation sessions and delta-shaped streaming. The wrapper smooths cross-browser quirks (delta-vs-cumulative chunks, control-character cleanup, abort wiring); UI state and conversation history are the consumer's concern."
+description: "This package wraps the Web's Built-in Prompt API (LanguageModel). Use ask() for one-shot prompts. Use createSession() or React useSession() for conversations and delta streams."
 editUrl: https://github.com/obetomuniz/web-ai-sdk/edit/main/packages/prompt/README.md
 ---
 
@@ -8,12 +8,20 @@ editUrl: https://github.com/obetomuniz/web-ai-sdk/edit/main/packages/prompt/READ
 This page is synced from [`packages/prompt/README.md`](https://github.com/obetomuniz/web-ai-sdk/blob/main/packages/prompt/README.md) by `pnpm --filter @web-ai-sdk-apps/site docs:sync`. Edits should go to the README.
 :::
 
-web-ai-sdk building block for the Web's Built-in [Prompt API](https://developer.chrome.com/docs/ai/prompt-api) (`LanguageModel`). One-shot `ask()` for embeds and widgets, plus a thin `createSession()` primitive (and React `useSession`) for chat-shaped apps that need independent per-conversation sessions and delta-shaped streaming. The wrapper smooths cross-browser quirks (delta-vs-cumulative chunks, control-character cleanup, abort wiring); UI state and conversation history are the consumer's concern.
+This package wraps the Web's Built-in [Prompt API](https://developer.chrome.com/docs/ai/prompt-api) (`LanguageModel`). Use `ask()` for one-shot prompts. Use `createSession()` or React `useSession()` for conversations and delta streams.
+
+The package normalizes stream chunks, removes selected control characters, and wires abort signals. Application code owns UI state and message history.
 
 
 ## Status
 
-Prompt API [ships stable in Chrome 148+](https://developer.chrome.com/docs/ai/prompt-api) with no flag required. On Edge it is a [developer preview](https://learn.microsoft.com/en-us/microsoft-edge/web-platform/prompt-api) in Canary/Dev 138.0.3309.2+ behind "Prompt API for on-device language model." Phi-4-mini is the documented default and requires a High-or-greater device performance class; Canary/Dev 150.0.4070+ can optionally use the prerelease Aion-1.0-Instruct model on Medium/Low devices behind the additional "Enable prerelease on-device language model" flag. See [Browser support](https://web-ai-sdk.dev/docs/browser-support/) for the sourced matrix. On browsers without `LanguageModel`, the React hook stays `"unavailable"`; vanilla `ask()` throws `PromptUnavailableError` so callers can branch explicitly.
+Prompt API is [stable in Chrome 148+](https://developer.chrome.com/docs/ai/prompt-api). It does not require a flag.
+
+Edge provides a [Canary/Dev preview](https://learn.microsoft.com/en-us/microsoft-edge/web-platform/prompt-api) from 138.0.3309.2. Enable "Prompt API for on-device language model." Edge uses Phi-4-mini by default on High-class devices.
+
+Canary/Dev 150.0.4070+ can use prerelease Aion-1.0-Instruct on Medium/Low devices. This path requires the "Enable prerelease on-device language model" flag.
+
+See [Browser support](https://web-ai-sdk.dev/docs/browser-support/) for the full matrix. Without `LanguageModel`, React reports `"unavailable"` and `ask()` throws `PromptUnavailableError`.
 
 ## Install
 
@@ -22,7 +30,7 @@ pnpm add @web-ai-sdk/prompt
 # or: npm i @web-ai-sdk/prompt / bun add @web-ai-sdk/prompt
 ```
 
-The React adapter ships as a subpath export, with no extra install. `react` is a peer dependency only when you import the `/react` entry.
+The React adapter uses the `/react` subpath. `react` is an optional peer dependency.
 
 ## Vanilla TypeScript / DOM
 
@@ -65,9 +73,15 @@ const text = await session.send("And what about the Prompt API?");
 session.destroy();
 ```
 
-Every `createSession()` call returns an independent `LanguageModelInstance` with its own history, system prompt, sampling, and lifecycle — `abort()` / `destroy()` on one session never touch another. Concurrent `send` / `sendStreaming` calls on the **same** session are NOT queued — the underlying `LanguageModel` is sequential per instance and will reject the overlapping call with `InvalidStateError`. Either `await` the previous send or call `session.abort()` before issuing a new turn. Multi-turn conversation context is tracked by the native instance itself; UI message lists are your data model.
+Each `createSession()` call returns an independent `LanguageModelInstance`. It has its own history, system prompt, sampling, and lifecycle.
 
-Calling `createSession()` starts `LanguageModel.create()` immediately. The first `send`, `sendStreaming`, or `clone` only awaits that already-started creation, so creating a base session as soon as the user's intent is clear is a valid prewarming primitive. The synchronous `Session` wrapper is returned before native creation necessarily resolves; see [Context-window introspection](#context-window-introspection) for the resulting getter-readiness distinction.
+Calls on the same session are not queued. An overlapping `send()` or `sendStreaming()` call fails with `InvalidStateError`. Await the current call or call `session.abort()` first.
+
+The native instance tracks conversation context. Your application owns the UI message list.
+
+`createSession()` starts `LanguageModel.create()` immediately. Create a base session when the workflow becomes known to start preparation early.
+
+The synchronous `Session` wrapper can return before native creation finishes. The first `send()`, `sendStreaming()`, or `clone()` waits for it. See [Context-window introspection](#context-window-introspection) for getter readiness.
 
 **Concurrency note.** Each session has independent history, system prompts, sampling, and lifecycle. Scheduling across different native sessions is browser-defined, so do not depend on token-level interleaving or a particular parallelism policy.
 
@@ -138,7 +152,9 @@ export function Chat({ persona }: { persona: string }) {
 }
 ```
 
-`useSession` is lifecycle-only: it starts in `"loading"` while the native `LanguageModel.create()` call is in flight, moves to `"ready"` when `session` is usable, destroys the session on unmount, and recreates it when any primitive option changes. It deliberately does **not** track `response` / `history` / streaming status — that's your UI state, you own it. Each `useSession()` call owns its own underlying `LanguageModelInstance`, so component state and `abort()` / `destroy()` stay scoped to the owning component. Scheduling across sessions remains browser-defined (see the Concurrency note above).
+`useSession` manages lifecycle only. It reports `"loading"` during native creation and `"ready"` when the session is usable. It destroys the session on unmount and recreates it when a primitive option changes.
+
+The hook does not track responses, history, or streaming status. Keep that state in your component. Each hook call owns one native instance. Scheduling across instances is browser-defined.
 
 ## API
 
@@ -255,15 +271,21 @@ const tools: LanguageModelTool[] = [
 const session = createSession({ systemPrompt, tools });
 ```
 
-This is **pass-through only**: the SDK forwards `tools` and never calls `execute` itself. Native tool execution depends on the browser implementation, so treat it as experimental and provide a fallback. Parsing model-emitted tool-like text and running a manual execution loop are deliberately left in the consumer layer.
+The SDK only forwards `tools`; it does not call `execute`. Native tool execution depends on the browser. Treat it as experimental and provide a fallback.
 
-`tools` works on `ask()` too (`ask({ input, tools })`), with one caveat: `ask()` may keep warm base sessions through an LRU keyed by `JSON.stringify(createOptions)`, and `JSON.stringify` drops functions — so a tool's `execute` doesn't contribute to the key, only its `name` / `description` / `inputSchema` do. Each `ask()` prompt still runs on a clone or fresh one-shot instance. Prefer `createSession()` for tool-bearing sessions: it bypasses the cache and matches the base-session + per-run-`clone()` pattern.
+Your application must parse tool-like model output and run any manual execution loop.
+
+`tools` also works with `ask({ input, tools })`. Its base-session cache key uses `JSON.stringify(createOptions)`, which excludes functions. A tool's `execute` function does not affect the key; its metadata does.
+
+Each `ask()` call still uses a clone or fresh instance. Prefer `createSession()` for tool-based sessions because it bypasses this cache.
 
 To declare the native tool modalities, pass them through the advanced `expectedInputs` / `expectedOutputs` fields (`{ type: "tool-response" }` / `{ type: "tool-call" }`).
 
 ### Session resilience: base + per-task `clone()`
 
-For agents and multi-task flows, reusing one long-lived session lets unrelated history accumulate, while recreating a session per task repeats creation and instruction processing. Chrome's [session-management guidance](https://developer.chrome.com/docs/ai/session-management) recommends keeping one warm **base** session (system prompt only) and calling `clone()` per task: the clone inherits the system prompt without unrelated task history, then gets independent history and lifecycle.
+Do not reuse one session across unrelated tasks. Its history will continue to grow. Creating a new session for every task repeats setup work.
+
+Chrome's [session-management guidance](https://developer.chrome.com/docs/ai/session-management) recommends a warm base session with only the system prompt. Call `clone()` for each task. Each clone inherits the prompt but has independent history and lifecycle.
 
 ```ts
 // As soon as the workflow is chosen, begin native creation with final instructions.
@@ -331,13 +353,15 @@ const json = await session.send([
 
 They compose: prefill the opening brace, set `responseConstraint` for the full shape.
 
-**Spec rule:** `prefix: true` is only valid on the **trailing** `assistant` message. Anywhere else (a non-final message, a non-assistant role) the browser throws a `"SyntaxError"` `DOMException`. The SDK does **not** catch this, so it propagates to your `send` / `sendStreaming` caller.
+**Spec rule:** `prefix: true` is valid only on the final `assistant` message. Other uses cause a `"SyntaxError"` `DOMException`. The SDK passes this error to the caller.
 
 > **Note on `content`:** `LanguageModelMessage.content` is currently `string` only. Multimodal `ContentPart[]` content (images, audio) is tracked as a future enhancement; no timeline is promised.
 
 ### Context-window introspection
 
-`Session` surfaces the live token budget the native instance reports, so consumers can size work to the actual context window instead of hardcoding a char cap. Calling `createSession()` starts native creation eagerly, but the wrapper returns synchronously: both getters remain `undefined` while that creation promise is in flight. The first `send` awaits the already-started creation; alternatively, read the getters on a session from `clone()`, whose instance is live the moment `clone()` resolves. In React, `useSession` does not report `"ready"` until the same native creation has resolved.
+`Session` exposes the token budget reported by the native instance. Use it to size input for the current context window.
+
+Both getters are `undefined` until native creation finishes. The first `send()` waits for creation. A resolved `clone()` is ready immediately. In React, `useSession` reports `"ready"` after creation finishes.
 
 - `session.contextWindow` — max input tokens for the session (the context window).
 - `session.contextUsage` — input tokens used so far. On a fresh base-clone this reflects the inherited history (≈ the system prompt), the right baseline to budget a turn against.
@@ -358,7 +382,9 @@ if (quota) {
 // (older browsers / pre-creation).
 ```
 
-`session.onContextOverflow(listener)` subscribes to the native `contextoverflow` event, which fires when a turn pushes usage past the window and the oldest history is dropped. Use it to compact or fork a fresh `clone()` before hitting `QuotaExceededError`. It returns an idempotent cleanup function, and is a no-op (returns a no-op cleanup) when the instance doesn't expose the event.
+`session.onContextOverflow(listener)` subscribes to the native `contextoverflow` event. The event fires when a turn exceeds the window and drops the oldest history.
+
+Use it to compact history or create a fresh clone before `QuotaExceededError`. It returns an idempotent cleanup function. Unsupported instances return a no-op cleanup.
 
 ```ts
 const stop = session.onContextOverflow(() => {
@@ -378,7 +404,9 @@ interface UseSessionReturn {
 }
 ```
 
-Lifecycle-only: feature detection + create + destroy on unmount + recreate when any primitive option (`systemPrompt`, `samplingMode`, `temperature`, `topK`, `language`) changes. Object options (`expectedInputs`, `createOptions`) participate by reference; memoize them or accept the recreate cost. UI state is your concern — iterate `session.sendStreaming()` and accumulate text into your own component state.
+The hook detects support, creates a session, and destroys it on unmount. It recreates the session when a primitive option changes.
+
+Object options participate by reference. Memoize them to avoid recreation. Store streamed output and other UI state in your component.
 
 ### `isAvailable(): boolean`
 
@@ -392,7 +420,7 @@ Forwards to `LanguageModel.availability()`. Returns `null` if the global is miss
 
 Two layers, same as `@web-ai-sdk/summarizer`:
 
-- **Session cache** (internal, in-memory, on by default for `ask()` only): a bounded LRU of warm base `LanguageModel` instances keyed by stringified create-options. Cold-start ≈ 1-3s; when `clone()` is supported, warm calls can skip re-parsing the same base instructions while still prompting on an isolated clone. `createSession()` bypasses this cache entirely.
+- **Session cache** (internal, in-memory, on for `ask()`): a bounded LRU of base instances keyed by serialized creation options. When supported, each call uses an isolated clone. `createSession()` bypasses this cache.
 - **Result cache** (opt-in): pass a `cache` (anything matching `{ get, set }`) to memoize final responses by `(input, systemPrompt, samplingMode / temperature / topK)`. Omit it for a fresh model call every time.
 
 ```ts
@@ -413,9 +441,11 @@ ask({ input: "hi", cache: myMap, cacheKey: "greeting" });
 
 The vanilla `ask()` throws `PromptUnavailableError` when the API is missing or reports `availability: "unavailable"`. The React hook absorbs this and returns `status: "unavailable"` instead.
 
-`createSession()` starts native creation immediately and returns a `Session` wrapper synchronously. If the underlying `create()` rejects, the error surfaces when the first `send`, `sendStreaming`, or `clone` awaits that already-started work. In React, `useSession()` waits for native creation before reporting `"ready"` and reports `"unavailable"` with `error` if creation fails.
+`createSession()` starts native creation and returns a `Session` wrapper immediately. If creation fails, the first `send()`, `sendStreaming()`, or `clone()` reports the error.
 
-`AbortSignal` is supported on every surface. Aborting mid-stream resolves cleanly; the result cache is not written for aborted runs. Aborts reject with `PromptAbortError` (exported; `instanceof PromptAbortError` works, and its `name` is `"AbortError"`), thrown by both `ask()` and sessions.
+In React, `useSession()` waits for creation before reporting `"ready"`. It reports `"unavailable"` and stores the error when creation fails.
+
+Every API accepts `AbortSignal`. An aborted run does not write to the result cache. Both `ask()` and sessions reject with the exported `PromptAbortError`. Its `name` is `"AbortError"`.
 
 ## License
 

--- a/apps/site/src/content/docs/packages/proofreader.md
+++ b/apps/site/src/content/docs/packages/proofreader.md
@@ -13,9 +13,7 @@ web-ai-sdk building block for the Web's Built-in [Proofreader API](https://devel
 
 ## Status
 
-The Proofreader API is in an origin trial in Chrome 141 to 145, behind `chrome://flags/#proofreader-api-for-gemini-nano` on localhost (`chrome://flags/#optimization-guide-on-device-model` must also be enabled). In Edge it's a developer preview in Canary/Dev 142+ behind "Proofreader API for Phi mini". On any other browser this library is a no-op for the React hook (it stays in `"unavailable"`). The vanilla `proofread()` throws `ProofreaderUnavailableError` so callers can branch explicitly.
-
-The API is **English-only** today. `expectedInputLanguages` accepts an array, but a request for an unsupported language causes the underlying `create()` to reject (surfaced here as `ProofreaderUnavailableError`); pass `["en"]` or omit it.
+Chrome's current [Built-in AI status table](https://developer.chrome.com/docs/ai/built-in-apis) labels Proofreader a **Developer trial**. Its public origin-trial window ran from Chrome 141 through 145 and has ended; the [Proofreader docs](https://developer.chrome.com/docs/ai/proofreader-api) list `chrome://flags/#proofreader-api` for localhost testing. In Edge it is a [developer preview](https://learn.microsoft.com/en-us/microsoft-edge/web-platform/proofreader-api) in Canary/Dev 142+ behind "Proofreader API for Phi mini," with a documented High-or-greater device performance class requirement. On browsers without `Proofreader`, the React hook stays `"unavailable"`; vanilla `proofread()` throws `ProofreaderUnavailableError` so callers can branch explicitly.
 
 ## Install
 
@@ -78,8 +76,8 @@ interface ProofreadCorrection {
   startIndex: number;     // inclusive offset into the original input
   endIndex: number;       // exclusive offset into the original input
   correction: string;     // suggested replacement
-  type?: string;          // not emitted by Chrome's current build
-  explanation?: string;   // not emitted by Chrome's current build
+  type?: string;          // optional platform metadata
+  explanation?: string;   // optional platform metadata
 }
 
 interface ProofreadOutput {

--- a/apps/site/src/content/docs/packages/proofreader.md
+++ b/apps/site/src/content/docs/packages/proofreader.md
@@ -1,6 +1,6 @@
 ---
 title: "@web-ai-sdk/proofreader"
-description: "web-ai-sdk building block for the Web's Built-in Proofreader API. Corrects grammar, spelling, and punctuation and returns per-issue corrections with offsets, plus session reuse and opt-in result caching."
+description: "This package wraps the Web's Built-in Proofreader API. It returns corrected text and an offset for each issue. It also provides session reuse and optional result caching."
 editUrl: https://github.com/obetomuniz/web-ai-sdk/edit/main/packages/proofreader/README.md
 ---
 
@@ -8,12 +8,16 @@ editUrl: https://github.com/obetomuniz/web-ai-sdk/edit/main/packages/proofreader
 This page is synced from [`packages/proofreader/README.md`](https://github.com/obetomuniz/web-ai-sdk/blob/main/packages/proofreader/README.md) by `pnpm --filter @web-ai-sdk-apps/site docs:sync`. Edits should go to the README.
 :::
 
-web-ai-sdk building block for the Web's Built-in [Proofreader API](https://developer.chrome.com/docs/ai/proofreader-api). Corrects grammar, spelling, and punctuation and returns per-issue corrections with offsets, plus session reuse and opt-in result caching.
+This package wraps the Web's Built-in [Proofreader API](https://developer.chrome.com/docs/ai/proofreader-api). It returns corrected text and an offset for each issue. It also provides session reuse and optional result caching.
 
 
 ## Status
 
-Chrome's current [Built-in AI status table](https://developer.chrome.com/docs/ai/built-in-apis) labels Proofreader a **Developer trial**. Its public origin-trial window ran from Chrome 141 through 145 and has ended; the [Proofreader docs](https://developer.chrome.com/docs/ai/proofreader-api) list `chrome://flags/#proofreader-api` for localhost testing. In Edge it is a [developer preview](https://learn.microsoft.com/en-us/microsoft-edge/web-platform/proofreader-api) in Canary/Dev 142+ behind "Proofreader API for Phi mini," with a documented High-or-greater device performance class requirement. On browsers without `Proofreader`, the React hook stays `"unavailable"`; vanilla `proofread()` throws `ProofreaderUnavailableError` so callers can branch explicitly.
+Chrome labels Proofreader a **Developer trial** in its [status table](https://developer.chrome.com/docs/ai/built-in-apis). The public origin trial for Chrome 141–145 has ended. For localhost, enable `chrome://flags/#proofreader-api`.
+
+Edge provides a [Canary/Dev preview](https://learn.microsoft.com/en-us/microsoft-edge/web-platform/proofreader-api) from 142. Enable "Proofreader API for Phi mini." Edge requires a High device-performance class or greater.
+
+Without `Proofreader`, React reports `"unavailable"` and `proofread()` throws `ProofreaderUnavailableError`.
 
 ## Install
 
@@ -22,7 +26,7 @@ pnpm add @web-ai-sdk/proofreader
 # or: npm i @web-ai-sdk/proofreader / bun add @web-ai-sdk/proofreader
 ```
 
-The React adapter ships as a subpath export, with no extra install. `react` is a peer dependency only when you import the `/react` entry.
+The React adapter uses the `/react` subpath. `react` is an optional peer dependency.
 
 ## Vanilla TypeScript / DOM
 

--- a/apps/site/src/content/docs/packages/rewriter.md
+++ b/apps/site/src/content/docs/packages/rewriter.md
@@ -13,7 +13,7 @@ web-ai-sdk building block for the Web's Built-in [Rewriter API](https://develope
 
 ## Status
 
-The Rewriter API is in a developer trial (origin trial) in Chrome 137 to 148. It shares the Writer's joint trial, so it's enabled via the same `chrome://flags/#writer-api-for-gemini-nano` flag on localhost (there is no separate Rewriter flag; `chrome://flags/#optimization-guide-on-device-model` must also be enabled). In Edge it's a developer preview in Canary/Dev 138+ behind "Rewriter API for Phi mini". On any other browser this library is a no-op for the React hook (it stays in `"unavailable"`). The vanilla `rewrite()` throws `RewriterUnavailableError` so callers can branch explicitly.
+Chrome's current [Built-in AI status table](https://developer.chrome.com/docs/ai/built-in-apis) labels Rewriter a **Developer trial**. Its public joint origin-trial window with Writer ran from Chrome 137 through 148 and has ended; the [Rewriter docs](https://developer.chrome.com/docs/ai/rewriter-api) list the current localhost flags. In Edge it is a [developer preview](https://learn.microsoft.com/en-us/microsoft-edge/web-platform/writing-assistance-apis) in Canary/Dev 138.0.3309.2+ behind "Rewriter API for on-device language model." On browsers without `Rewriter`, the React hook stays `"unavailable"`; vanilla `rewrite()` throws `RewriterUnavailableError` so callers can branch explicitly.
 
 ## Install
 

--- a/apps/site/src/content/docs/packages/rewriter.md
+++ b/apps/site/src/content/docs/packages/rewriter.md
@@ -1,6 +1,6 @@
 ---
 title: "@web-ai-sdk/rewriter"
-description: "web-ai-sdk building block for the Web's Built-in Rewriter API. Revises and restructures existing text with tone / length adjustments, session reuse, streaming, and opt-in result caching."
+description: "This package wraps the Web's Built-in Rewriter API. It changes the tone or length of text. It also provides session reuse, streaming, and optional result caching."
 editUrl: https://github.com/obetomuniz/web-ai-sdk/edit/main/packages/rewriter/README.md
 ---
 
@@ -8,12 +8,16 @@ editUrl: https://github.com/obetomuniz/web-ai-sdk/edit/main/packages/rewriter/RE
 This page is synced from [`packages/rewriter/README.md`](https://github.com/obetomuniz/web-ai-sdk/blob/main/packages/rewriter/README.md) by `pnpm --filter @web-ai-sdk-apps/site docs:sync`. Edits should go to the README.
 :::
 
-web-ai-sdk building block for the Web's Built-in [Rewriter API](https://developer.chrome.com/docs/ai/rewriter-api). Revises and restructures existing text with tone / length adjustments, session reuse, streaming, and opt-in result caching.
+This package wraps the Web's Built-in [Rewriter API](https://developer.chrome.com/docs/ai/rewriter-api). It changes the tone or length of text. It also provides session reuse, streaming, and optional result caching.
 
 
 ## Status
 
-Chrome's current [Built-in AI status table](https://developer.chrome.com/docs/ai/built-in-apis) labels Rewriter a **Developer trial**. Its public joint origin-trial window with Writer ran from Chrome 137 through 148 and has ended; the [Rewriter docs](https://developer.chrome.com/docs/ai/rewriter-api) list the current localhost flags. In Edge it is a [developer preview](https://learn.microsoft.com/en-us/microsoft-edge/web-platform/writing-assistance-apis) in Canary/Dev 138.0.3309.2+ behind "Rewriter API for on-device language model." On browsers without `Rewriter`, the React hook stays `"unavailable"`; vanilla `rewrite()` throws `RewriterUnavailableError` so callers can branch explicitly.
+Chrome labels Rewriter a **Developer trial** in its [status table](https://developer.chrome.com/docs/ai/built-in-apis). The public origin trial for Chrome 137–148 has ended. See the [Rewriter guide](https://developer.chrome.com/docs/ai/rewriter-api) for current localhost flags.
+
+Edge provides a [Canary/Dev preview](https://learn.microsoft.com/en-us/microsoft-edge/web-platform/writing-assistance-apis) from 138.0.3309.2. Enable "Rewriter API for on-device language model."
+
+Without `Rewriter`, React reports `"unavailable"` and `rewrite()` throws `RewriterUnavailableError`.
 
 ## Install
 
@@ -22,7 +26,7 @@ pnpm add @web-ai-sdk/rewriter
 # or: npm i @web-ai-sdk/rewriter / bun add @web-ai-sdk/rewriter
 ```
 
-The React adapter ships as a subpath export, with no extra install. `react` is a peer dependency only when you import the `/react` entry.
+The React adapter uses the `/react` subpath. `react` is an optional peer dependency.
 
 ## Vanilla TypeScript / DOM
 

--- a/apps/site/src/content/docs/packages/summarizer.md
+++ b/apps/site/src/content/docs/packages/summarizer.md
@@ -1,6 +1,6 @@
 ---
 title: "@web-ai-sdk/summarizer"
-description: "web-ai-sdk building block for the Web's Built-in Summarizer API. String-mode summarization with session reuse, output cleaning, streaming, and opt-in result caching."
+description: "This package wraps the Web's Built-in Summarizer API. It provides session reuse, output cleanup, streaming, and optional result caching."
 editUrl: https://github.com/obetomuniz/web-ai-sdk/edit/main/packages/summarizer/README.md
 ---
 
@@ -8,12 +8,14 @@ editUrl: https://github.com/obetomuniz/web-ai-sdk/edit/main/packages/summarizer/
 This page is synced from [`packages/summarizer/README.md`](https://github.com/obetomuniz/web-ai-sdk/blob/main/packages/summarizer/README.md) by `pnpm --filter @web-ai-sdk-apps/site docs:sync`. Edits should go to the README.
 :::
 
-web-ai-sdk building block for the Web's Built-in [Summarizer API](https://developer.chrome.com/docs/ai/summarizer-api). String-mode summarization with session reuse, output cleaning, streaming, and opt-in result caching.
+This package wraps the Web's Built-in [Summarizer API](https://developer.chrome.com/docs/ai/summarizer-api). It provides session reuse, output cleanup, streaming, and optional result caching.
 
 
 ## Status
 
-Summarizer API is stable in Chrome 138+ and enabled by default in Edge 138+, per the [Chrome status table](https://developer.chrome.com/docs/ai/built-in-apis) and [Edge Writing Assistance API docs](https://learn.microsoft.com/en-us/microsoft-edge/web-platform/writing-assistance-apis). On browsers without `Summarizer`, the React hook stays `"unavailable"`; vanilla `summarize()` throws `SummarizerUnavailableError` so callers can branch explicitly.
+Summarizer is stable in Chrome 138+ and enabled by default in Edge 138+. See the [Chrome status table](https://developer.chrome.com/docs/ai/built-in-apis) and [Edge guide](https://learn.microsoft.com/en-us/microsoft-edge/web-platform/writing-assistance-apis).
+
+Without `Summarizer`, React reports `"unavailable"` and `summarize()` throws `SummarizerUnavailableError`.
 
 ## Install
 
@@ -22,7 +24,7 @@ pnpm add @web-ai-sdk/summarizer
 # or: npm i @web-ai-sdk/summarizer / bun add @web-ai-sdk/summarizer
 ```
 
-The React adapter ships as a subpath export, with no extra install. `react` is a peer dependency only when you import the `/react` entry.
+The React adapter uses the `/react` subpath. `react` is an optional peer dependency.
 
 ## Vanilla TypeScript / DOM
 

--- a/apps/site/src/content/docs/packages/summarizer.md
+++ b/apps/site/src/content/docs/packages/summarizer.md
@@ -13,7 +13,7 @@ web-ai-sdk building block for the Web's Built-in [Summarizer API](https://develo
 
 ## Status
 
-Summarizer API is stable in Chrome 138+ and Edge 138+ on desktop (enabled by default since Edge 138, per the [Edge Writing Assistance APIs docs](https://learn.microsoft.com/en-us/microsoft-edge/web-platform/writing-assistance-apis)). On Edge the Phi-4-mini safety pipeline frequently returns "low quality output blocked"; the library wraps that as a typed error. On any other browser this library is a no-op for the React hook (it stays in `"unavailable"`). The vanilla `summarize()` throws `SummarizerUnavailableError` so callers can branch explicitly.
+Summarizer API is stable in Chrome 138+ and enabled by default in Edge 138+, per the [Chrome status table](https://developer.chrome.com/docs/ai/built-in-apis) and [Edge Writing Assistance API docs](https://learn.microsoft.com/en-us/microsoft-edge/web-platform/writing-assistance-apis). On browsers without `Summarizer`, the React hook stays `"unavailable"`; vanilla `summarize()` throws `SummarizerUnavailableError` so callers can branch explicitly.
 
 ## Install
 
@@ -137,7 +137,7 @@ The wrapper strips wrapping quotes / whitespace and collapses internal whitespac
 
 ## Language support
 
-The Web's Built-in Summarizer (Chrome 138+ and Edge 138+) accepts `expectedInputLanguages` / `outputLanguage` only for `["en", "es", "ja"]`. For other languages this library omits those hints and you steer output via `sharedContext` instead. Pass your own `supportedLanguages` if Chrome adds more.
+By default, the wrapper emits `expectedInputLanguages` / `outputLanguage` hints only for `["en", "es", "ja"]`. For other languages it omits those hints and you can steer output via `sharedContext` instead. Pass `supportedLanguages` explicitly when your target browser documents a broader set.
 
 ## License
 

--- a/apps/site/src/content/docs/packages/translator.md
+++ b/apps/site/src/content/docs/packages/translator.md
@@ -1,6 +1,6 @@
 ---
 title: "@web-ai-sdk/translator"
-description: "web-ai-sdk building block for the Web's Built-in Translator API. String-mode translation with pair-cached sessions, opt-in result caching, and AbortSignal-driven cleanup."
+description: "This package wraps the Web's Built-in Translator API. It caches sessions by language pair and supports optional result caching and abort signals."
 editUrl: https://github.com/obetomuniz/web-ai-sdk/edit/main/packages/translator/README.md
 ---
 
@@ -8,12 +8,14 @@ editUrl: https://github.com/obetomuniz/web-ai-sdk/edit/main/packages/translator/
 This page is synced from [`packages/translator/README.md`](https://github.com/obetomuniz/web-ai-sdk/blob/main/packages/translator/README.md) by `pnpm --filter @web-ai-sdk-apps/site docs:sync`. Edits should go to the README.
 :::
 
-web-ai-sdk building block for the Web's Built-in [Translator API](https://developer.chrome.com/docs/ai/translator-api). String-mode translation with pair-cached sessions, opt-in result caching, and AbortSignal-driven cleanup.
+This package wraps the Web's Built-in [Translator API](https://developer.chrome.com/docs/ai/translator-api). It caches sessions by language pair and supports optional result caching and abort signals.
 
 
 ## Status
 
-Translator API is stable in Chrome 138+ and shipped in Edge 148, with no flag required, per the [Chrome status table](https://developer.chrome.com/docs/ai/built-in-apis) and [Edge 148 release notes](https://learn.microsoft.com/en-us/microsoft-edge/web-platform/release-notes/148). On browsers without `Translator`, the React hook stays `"unavailable"`; vanilla `translate()` throws `TranslatorUnavailableError` so callers can branch explicitly.
+Translator is stable in Chrome 138+ and shipped in Edge 148. It does not require a flag. See the [Chrome status table](https://developer.chrome.com/docs/ai/built-in-apis) and [Edge 148 release notes](https://learn.microsoft.com/en-us/microsoft-edge/web-platform/release-notes/148).
+
+Without `Translator`, React reports `"unavailable"` and `translate()` throws `TranslatorUnavailableError`.
 
 ## Install
 
@@ -22,7 +24,7 @@ pnpm add @web-ai-sdk/translator
 # or: npm i @web-ai-sdk/translator / bun add @web-ai-sdk/translator
 ```
 
-The React adapter ships as a subpath export, with no extra install. `react` is a peer dependency only when you import the `/react` entry.
+The React adapter uses the `/react` subpath. `react` is an optional peer dependency.
 
 ## Vanilla TypeScript / DOM
 

--- a/apps/site/src/content/docs/packages/translator.md
+++ b/apps/site/src/content/docs/packages/translator.md
@@ -13,7 +13,7 @@ web-ai-sdk building block for the Web's Built-in [Translator API](https://develo
 
 ## Status
 
-Translator API is stable in Chrome 138+ and Edge 148+ on desktop, with no flag required (per the [Edge Translator API docs](https://learn.microsoft.com/en-us/microsoft-edge/web-platform/translator-api)). On any other browser this library is a no-op for the React hook (it stays in `"unavailable"`). The vanilla `translate()` throws `TranslatorUnavailableError` so callers can branch explicitly.
+Translator API is stable in Chrome 138+ and shipped in Edge 148, with no flag required, per the [Chrome status table](https://developer.chrome.com/docs/ai/built-in-apis) and [Edge 148 release notes](https://learn.microsoft.com/en-us/microsoft-edge/web-platform/release-notes/148). On browsers without `Translator`, the React hook stays `"unavailable"`; vanilla `translate()` throws `TranslatorUnavailableError` so callers can branch explicitly.
 
 ## Install
 

--- a/apps/site/src/content/docs/packages/webmcp.md
+++ b/apps/site/src/content/docs/packages/webmcp.md
@@ -1,6 +1,6 @@
 ---
 title: "@web-ai-sdk/webmcp"
-description: "web-ai-sdk building block for the W3C WebMCP API exposed at document.modelContext. (For backward compatibility with the previous shape of the API, this package also reads from navigator.modelContext.)"
+description: "This package wraps the W3C WebMCP API at document.modelContext. It also reads the previous navigator.modelContext shape for compatibility."
 editUrl: https://github.com/obetomuniz/web-ai-sdk/edit/main/packages/webmcp/README.md
 ---
 
@@ -8,14 +8,18 @@ editUrl: https://github.com/obetomuniz/web-ai-sdk/edit/main/packages/webmcp/READ
 This page is synced from [`packages/webmcp/README.md`](https://github.com/obetomuniz/web-ai-sdk/blob/main/packages/webmcp/README.md) by `pnpm --filter @web-ai-sdk-apps/site docs:sync`. Edits should go to the README.
 :::
 
-web-ai-sdk building block for the W3C [WebMCP](https://webmachinelearning.github.io/webmcp/) API exposed at `document.modelContext`. (For backward compatibility with the previous shape of the API, this package also reads from `navigator.modelContext`.)
+This package wraps the W3C [WebMCP](https://webmachinelearning.github.io/webmcp/) API at `document.modelContext`. It also reads the previous `navigator.modelContext` shape for compatibility.
 
-An ergonomic, framework-agnostic adapter over the native browser API, with safe register/unregister cleanup, typed tool discovery and execution, and progressive fallback behavior for non-supporting browsers.
+The package provides typed registration, cleanup, discovery, and execution. It has no framework dependency.
 
 
 ## Status
 
-WebMCP is available through a public [Chrome origin trial from Chrome 149](https://developer.chrome.com/docs/ai/webmcp), with `chrome://flags/#enable-webmcp-testing` documented for local development. Microsoft lists WebMCP in the [Edge 150 origin trials](https://learn.microsoft.com/en-us/microsoft-edge/web-platform/release-notes/150). On browsers without WebMCP, registration is a no-op and discovery returns an empty list; execution rejects with `WebMCPUnavailableError` so a missing capability cannot be confused with a navigation result. A WebMCP spec update changed `registerTool` to return a Promise (cross-origin iframe tool sharing made registration asynchronous); this adapter normalizes both the legacy synchronous shape and the async shape, so consumer code is unchanged.
+Chrome provides a public [origin trial from Chrome 149](https://developer.chrome.com/docs/ai/webmcp). For local development, enable `chrome://flags/#enable-webmcp-testing`. Microsoft lists WebMCP in the [Edge 150 origin trials](https://learn.microsoft.com/en-us/microsoft-edge/web-platform/release-notes/150).
+
+Without WebMCP, registration is a no-op and discovery returns an empty list. Execution throws `WebMCPUnavailableError`.
+
+Current `registerTool` implementations can be synchronous or asynchronous. The package supports both forms.
 
 ## Install
 
@@ -110,9 +114,13 @@ export function WebMCP({ isSignedIn }: { isSignedIn: boolean }) {
 }
 ```
 
-`useWebMCP` accepts one tool or a readonly array. It registers on mount, unregisters on unmount, and cleans up immediately when `enabled` changes to `false`. Registration follows discoverable metadata and `exposedTo` values rather than object identity, while `execute` always uses the latest committed callback. Inline tool objects, arrays, and options are safe: changing React state alone does not rebuild the registration, but changing a tool's name, title, description, schema, annotations, or exposure does. Memoize tool arrays and large schemas when practical to avoid rebuilding and comparing their metadata on every render; correctness does not depend on memoization.
+`useWebMCP` accepts one tool or a readonly array. It registers on mount and unregisters on unmount. Setting `enabled` to `false` also removes the registration.
 
-The same hook retrieves every tool exposed to the current document and refreshes the returned list after native `toolchange` events. Its `refresh()` method performs an explicit fresh read. Call `useWebMCP({ fromOrigins })` without definitions for retrieval-only use. Inline `fromOrigins` arrays are safe; discovery restarts only when their values change.
+Registration follows tool metadata and `exposedTo` values, not object identity. `execute` always uses the latest callback. Inline objects and arrays are safe. Metadata changes rebuild the registration. Memoize large schemas and tool arrays to reduce comparison work.
+
+The hook also retrieves tools exposed to the current document. It refreshes after native `toolchange` events. Call `refresh()` for an explicit read.
+
+For retrieval only, call `useWebMCP({ fromOrigins })` without tool definitions. Inline `fromOrigins` arrays are safe; discovery restarts only when their values change.
 
 ## API
 
@@ -120,7 +128,7 @@ The same hook retrieves every tool exposed to the current document and refreshes
 
 Register a single tool. Returns a cleanup function. No-op on unsupported browsers.
 
-Registration is asynchronous under the hood (per the current spec); the returned cleanup is synchronous and safe to call before registration settles — it aborts the in-flight registration cleanly.
+Native registration is asynchronous. The returned cleanup is synchronous and can abort registration before it finishes.
 
 To register many at once, map and combine:
 
@@ -137,7 +145,9 @@ const cleanup = registerTool(tool, {
 });
 ```
 
-The SDK forwards the array unchanged alongside its internally owned `AbortSignal`. The browser validates each origin and rejects invalid or untrustworthy values; the wrapper preserves its non-throwing registration posture and logs that failure. Exposure is unnecessary for the owning document and should be limited to origins that genuinely need access.
+The SDK forwards the array with its own `AbortSignal`. The browser validates each origin. The wrapper logs validation failures without throwing.
+
+The owning document does not need exposure. List only origins that need access.
 
 ### `getTools(options?): Promise<RegisteredTool[]>`
 
@@ -152,7 +162,9 @@ const toolsAcrossFrames = await getTools({
 });
 ```
 
-The browser always includes eligible same-origin tools. `fromOrigins` additionally requests tools from listed secure origins; those tools must also have exposed themselves to the caller's origin. Unsupported browsers resolve to `[]`. Native permission, origin-validation, and document-state errors remain observable as rejected promises.
+The browser includes eligible same-origin tools. `fromOrigins` also requests tools from listed secure origins. Those tools must expose themselves to the caller's origin.
+
+Unsupported browsers return `[]`. Native permission, origin, and document-state errors reject the promise.
 
 ### `executeTool(tool, input?, options?): Promise<string | null>`
 

--- a/apps/site/src/content/docs/packages/webmcp.md
+++ b/apps/site/src/content/docs/packages/webmcp.md
@@ -15,7 +15,7 @@ An ergonomic, framework-agnostic adapter over the native browser API, with safe 
 
 ## Status
 
-WebMCP shipped as an early preview in Chrome 146+ behind `chrome://flags/#enable-webmcp-testing`; a public [origin trial](https://developer.chrome.com/docs/ai/webmcp) opens in Chrome 149. Edge added support in 147+ behind the matching `edge://flags/` toggle. On browsers without WebMCP, registration is a no-op and discovery returns an empty list; execution rejects with `WebMCPUnavailableError` so a missing capability cannot be confused with a navigation result. A WebMCP spec update changed `registerTool` to return a Promise (cross-origin iframe tool sharing made registration asynchronous); this adapter normalizes both the legacy synchronous shape and the async shape, so consumer code is unchanged.
+WebMCP is available through a public [Chrome origin trial from Chrome 149](https://developer.chrome.com/docs/ai/webmcp), with `chrome://flags/#enable-webmcp-testing` documented for local development. Microsoft lists WebMCP in the [Edge 150 origin trials](https://learn.microsoft.com/en-us/microsoft-edge/web-platform/release-notes/150). On browsers without WebMCP, registration is a no-op and discovery returns an empty list; execution rejects with `WebMCPUnavailableError` so a missing capability cannot be confused with a navigation result. A WebMCP spec update changed `registerTool` to return a Promise (cross-origin iframe tool sharing made registration asynchronous); this adapter normalizes both the legacy synchronous shape and the async shape, so consumer code is unchanged.
 
 ## Install
 
@@ -171,7 +171,7 @@ if (echo) {
 
 The native serialized string is returned unchanged. `null` means tool execution triggered a navigation. Pass `{ signal }` to cancel an in-flight call. Unsupported browsers reject with `WebMCPUnavailableError`.
 
-`executeTool()` is experimental: Chromium implements and publicly documents it, but it is not yet present in the published WebMCP community-draft IDL.
+`executeTool()` is experimental: Chrome [publicly documents it](https://developer.chrome.com/docs/ai/webmcp), but it is not yet present in the published WebMCP community-draft IDL.
 
 ### `subscribeToToolChanges(listener): () => void`
 
@@ -252,7 +252,7 @@ interface ToolDefinition<
 }
 ```
 
-`title` is for human-facing host UI. `description` is consumed by the agent host (Cursor / Claude / Chrome agent / etc.); write it as an instruction to an LLM about when to call the tool.
+`title` is for human-facing host UI. `description` is consumed by the agent host; write it as an instruction to an LLM about when to call the tool.
 
 The current WebMCP draft defines `readOnlyHint` and `untrustedContentHint`. The SDK also retains `destructiveHint`, `idempotentHint`, `openWorldHint`, and the `destructive` shorthand as source-compatible passthroughs for MCP-shaped and earlier WebMCP hosts; current-draft browsers may ignore those compatibility fields.
 

--- a/apps/site/src/content/docs/packages/writer.md
+++ b/apps/site/src/content/docs/packages/writer.md
@@ -13,7 +13,7 @@ web-ai-sdk building block for the Web's Built-in [Writer API](https://developer.
 
 ## Status
 
-The Writer API is in a developer trial (origin trial) in Chrome 137 to 148, behind `chrome://flags/#writer-api-for-gemini-nano` on localhost (`chrome://flags/#optimization-guide-on-device-model` must also be enabled). In Edge it's a developer preview in Canary/Dev 138+ behind "Writer API for Phi mini". On any other browser this library is a no-op for the React hook (it stays in `"unavailable"`). The vanilla `write()` throws `WriterUnavailableError` so callers can branch explicitly.
+Chrome's current [Built-in AI status table](https://developer.chrome.com/docs/ai/built-in-apis) labels Writer a **Developer trial**. Its public joint origin-trial window with Rewriter ran from Chrome 137 through 148 and has ended; the [Writer docs](https://developer.chrome.com/docs/ai/writer-api) list the current localhost flags. In Edge it is a [developer preview](https://learn.microsoft.com/en-us/microsoft-edge/web-platform/writing-assistance-apis) in Canary/Dev 138.0.3309.2+ behind "Writer API for on-device language model." On browsers without `Writer`, the React hook stays `"unavailable"`; vanilla `write()` throws `WriterUnavailableError` so callers can branch explicitly.
 
 ## Install
 

--- a/apps/site/src/content/docs/packages/writer.md
+++ b/apps/site/src/content/docs/packages/writer.md
@@ -1,6 +1,6 @@
 ---
 title: "@web-ai-sdk/writer"
-description: "web-ai-sdk building block for the Web's Built-in Writer API. Generates new content from a writing task with session reuse, streaming, and opt-in result caching."
+description: "This package wraps the Web's Built-in Writer API. It provides session reuse, streaming, and optional result caching."
 editUrl: https://github.com/obetomuniz/web-ai-sdk/edit/main/packages/writer/README.md
 ---
 
@@ -8,12 +8,16 @@ editUrl: https://github.com/obetomuniz/web-ai-sdk/edit/main/packages/writer/READ
 This page is synced from [`packages/writer/README.md`](https://github.com/obetomuniz/web-ai-sdk/blob/main/packages/writer/README.md) by `pnpm --filter @web-ai-sdk-apps/site docs:sync`. Edits should go to the README.
 :::
 
-web-ai-sdk building block for the Web's Built-in [Writer API](https://developer.chrome.com/docs/ai/writer-api). Generates new content from a writing task with session reuse, streaming, and opt-in result caching.
+This package wraps the Web's Built-in [Writer API](https://developer.chrome.com/docs/ai/writer-api). It provides session reuse, streaming, and optional result caching.
 
 
 ## Status
 
-Chrome's current [Built-in AI status table](https://developer.chrome.com/docs/ai/built-in-apis) labels Writer a **Developer trial**. Its public joint origin-trial window with Rewriter ran from Chrome 137 through 148 and has ended; the [Writer docs](https://developer.chrome.com/docs/ai/writer-api) list the current localhost flags. In Edge it is a [developer preview](https://learn.microsoft.com/en-us/microsoft-edge/web-platform/writing-assistance-apis) in Canary/Dev 138.0.3309.2+ behind "Writer API for on-device language model." On browsers without `Writer`, the React hook stays `"unavailable"`; vanilla `write()` throws `WriterUnavailableError` so callers can branch explicitly.
+Chrome labels Writer a **Developer trial** in its [status table](https://developer.chrome.com/docs/ai/built-in-apis). The public origin trial for Chrome 137–148 has ended. See the [Writer guide](https://developer.chrome.com/docs/ai/writer-api) for current localhost flags.
+
+Edge provides a [Canary/Dev preview](https://learn.microsoft.com/en-us/microsoft-edge/web-platform/writing-assistance-apis) from 138.0.3309.2. Enable "Writer API for on-device language model."
+
+Without `Writer`, React reports `"unavailable"` and `write()` throws `WriterUnavailableError`.
 
 ## Install
 
@@ -22,7 +26,7 @@ pnpm add @web-ai-sdk/writer
 # or: npm i @web-ai-sdk/writer / bun add @web-ai-sdk/writer
 ```
 
-The React adapter ships as a subpath export, with no extra install. `react` is a peer dependency only when you import the `/react` entry.
+The React adapter uses the `/react` subpath. `react` is an optional peer dependency.
 
 ## Vanilla TypeScript / DOM
 

--- a/apps/site/src/content/docs/production-checklist.mdx
+++ b/apps/site/src/content/docs/production-checklist.mdx
@@ -1,22 +1,22 @@
 ---
 title: Production checklist
-description: Production guidance for input selection, session lifetime, safe rendering, user control, progress, and caching around the Web AI lifecycle wrappers.
+description: A checklist for input, sessions, safe output, user control, progress, and caches.
 ---
 
-The SDK owns the repetitive lifecycle around each browser capability. Your application still owns the product decisions around that lifecycle. This checklist adapts Chrome's public [Built-in AI APIs: Do and don't](https://developer.chrome.com/docs/ai/built-in-ai-dos-donts) guidance to the `@web-ai-sdk/*` packages.
+The SDK manages browser API lifecycles. Your application manages product behavior. This checklist adapts Chrome's [Built-in AI guidance](https://developer.chrome.com/docs/ai/built-in-ai-dos-donts) to the SDK packages.
 
 | The wrapper owns | Your application owns |
 | --- | --- |
-| Feature detection and typed unavailability | Establishing clear user intent before preparing a model |
-| Session creation, reuse, stream normalization, and cleanup hooks | Selecting task-relevant input and excluding unrelated page content |
+| Feature detection and typed unavailability | Confirming user intent before preparing a model |
+| Session reuse, stream normalization, and cleanup hooks | Selecting relevant input and excluding unrelated page content |
 | AbortSignal wiring and React effect cleanup | Rendering, sanitization, progress, and fallback UI |
 | Optional result-cache adapters and complete default cache keys | Expiration, refresh, persistence policy, and user-visible history |
 
-The wrapper never walks your page, chooses what a user meant, sanitizes formatted output, persists edits, or renders UI. Those responsibilities depend on your product and intentionally stay in consumer code.
+The SDK does not select page content, interpret user intent, sanitize formatted output, persist edits, or render UI.
 
 ## Prepare after clear user intent
 
-Prepare a session when the user enters or points at a relevant AI surface, not on every page load and not only after the final **Generate** click. For Prompt, provide system instructions at creation time so they become native `initialPrompts`:
+Prepare a session after the user enters an AI feature. Do not prepare every model on page load. For Prompt, pass system instructions when you create the session.
 
 ```ts
 import { createSession } from "@web-ai-sdk/prompt";
@@ -30,13 +30,13 @@ reviewWorkspace.addEventListener("pointerenter", () => {
 });
 ```
 
-Do not prewarm speculative features the user has shown no intent to use. The first preparation can download a model, consume memory, and take time.
+Preparation can download a model and use memory. Do not prepare features that the user has not opened.
 
 ## Reuse the right kind of session
 
-Writer, Rewriter, and Summarizer sessions are stateless between tasks. Their high-level SDK functions reuse compatible native sessions automatically. Prompt sessions retain conversation history, so unrelated tasks should not share one conversation.
+Writer, Rewriter, and Summarizer do not keep task history. Their high-level functions reuse compatible native sessions. Prompt sessions keep history.
 
-For repeated independent Prompt tasks, keep a base containing only the system instructions, clone it per task, and destroy each clone when it finishes:
+For independent Prompt tasks, create one base session. Clone it for each task. Destroy each clone after use.
 
 ```ts
 import { createSession } from "@web-ai-sdk/prompt";
@@ -58,11 +58,11 @@ async function review(code: string, signal: AbortSignal) {
 base.destroy();
 ```
 
-For one-shot Prompt work, `ask()` already uses a warm base plus a fresh clone when the browser supports cloning. For a real conversation, use one `createSession()` per conversation and keep its history deliberately.
+`ask()` already uses this pattern when the browser supports cloning. For chat, create one session per conversation.
 
 ## Abort work that is no longer relevant
 
-Connect cancellation to navigation, changed input, and an explicit Stop action. Destroy long-lived sessions when their feature unmounts or closes.
+Abort work after navigation, changed input, or a Stop action. Destroy long-lived sessions when their feature closes.
 
 ```ts
 import { rewrite } from "@web-ai-sdk/rewriter";
@@ -77,11 +77,11 @@ await rewrite({
 });
 ```
 
-React hooks clean up the native session when their effect is replaced or unmounted. Per-operation cancellation and an explicit Stop control are still consumer decisions.
+React hooks destroy sessions during effect cleanup. Your UI must still provide per-operation cancellation and a Stop control.
 
 ## Send only task-relevant text
 
-Extract the smallest readable text that answers the task. Exclude navigation, cookie banners, hidden controls, metadata, and unrelated comments. Prefer `innerText` or explicit text extraction; never send raw `innerHTML`.
+Send only text needed for the task. Exclude navigation, banners, hidden controls, metadata, and unrelated comments. Use `innerText` or explicit fields. Never send raw `innerHTML`.
 
 ```ts
 import { summarize } from "@web-ai-sdk/summarizer";
@@ -92,11 +92,11 @@ const input = article?.innerText.trim() ?? "";
 const result = await summarize({ input, type: "key-points" });
 ```
 
-If a task needs headings or selected fields, extract those values explicitly. DOM traversal and article-shape decisions stay outside the SDK because every application has a different document model.
+Extract headings or fields explicitly when the task needs them. The SDK does not define your document structure.
 
 ## Treat every output as untrusted
 
-Model output can be incorrect, hostile, or malformed. The SDK removes selected non-printing control characters; it does not make HTML or Markdown safe.
+Model output can be wrong, hostile, or malformed. The SDK removes selected control characters. It does not make HTML or Markdown safe.
 
 For plain text, use React interpolation or `textContent`:
 
@@ -104,11 +104,13 @@ For plain text, use React interpolation or `textContent`:
 outputElement.textContent = result.output ?? "";
 ```
 
-If you render formatted output, accumulate the full stream, parse it with raw HTML disabled, sanitize the complete result, and only then update the live DOM. Do not set `innerHTML` from model output, and do not sanitize chunks independently: unsafe syntax can span chunk boundaries.
+For formatted output, first collect the complete stream. Disable raw HTML and sanitize the complete result before rendering. Never pass model output directly to `innerHTML`.
+
+Do not sanitize individual stream chunks. Unsafe syntax can span multiple chunks.
 
 ## Use schemas for data, layout for visual length
 
-Use Prompt structured output when application logic needs a predictable shape:
+Use Prompt structured output when code needs a predictable data shape:
 
 ```ts
 import { ask } from "@web-ai-sdk/prompt";
@@ -131,11 +133,13 @@ const { output } = await ask({
 const card = output ? JSON.parse(output) : null;
 ```
 
-Do not add schema `maxLength` solely to fit a card, and do not prompt for an exact character count. A model can satisfy those constraints with compressed or degraded text. Let it generate naturally, then constrain the preview visually with overflow or line clamping and offer an expanded view.
+Do not use schema `maxLength` only to fit a card. Do not request an exact character count. These limits can reduce output quality.
+
+Use CSS overflow or line clamping for the preview. Provide a way to expand the text.
 
 ## Show preparation and generation progress
 
-Distinguish model preparation from inference. Surface download progress when available, show an active state for non-streaming tasks, and stream longer output when partial text is useful.
+Show model preparation and generation as separate states. Show download progress when available. Stream output only when partial text is useful.
 
 ```ts
 import { ask } from "@web-ai-sdk/prompt";
@@ -153,95 +157,51 @@ await ask({
 });
 ```
 
-Avoid replacing user-visible content without a transition or status cue. For short tasks, a spinner or pending label may be clearer than token-by-token output.
+Show a status before replacing visible content. For short tasks, use a spinner or pending label instead of streaming.
 
 ## Preserve originals and make edits reversible
 
-AI editing should produce a suggestion, not silently replace the source. Keep the original, let the user Accept or Reject, and retain enough version history to Undo.
+Treat AI edits as suggestions. Keep the original text until the user accepts the result.
 
-```ts
-const versions = [editor.value];
-let suggestion: string | null = null;
+- **Accept** applies the suggestion and stores the previous version.
+- **Reject** removes the suggestion without changing the source.
+- **Undo** restores the previous accepted version.
 
-function accept() {
-  if (!suggestion) return;
-  versions.push(suggestion);
-  editor.value = suggestion;
-  suggestion = null;
-}
-
-function reject() {
-  suggestion = null;
-  editor.value = versions.at(-1) ?? "";
-}
-
-function undo() {
-  if (versions.length > 1) versions.pop();
-  editor.value = versions.at(-1) ?? "";
-}
-```
-
-For multi-step workflows, add previous/next version navigation or a diff. The user remains the final editor.
+For multi-step edits, provide version navigation or a diff.
 
 ## Expire caches and offer refresh
 
-The built-in `"session"` and `"local"` cache shortcuts are intentionally small adapters; they do not impose a product-specific freshness policy. Use a custom cache when results need a time-to-live, and provide a visible way to force fresh inference.
+The `"session"` and `"local"` caches do not expire entries. Use a custom cache when results need a time-to-live (TTL). Add a visible Refresh action.
 
 ```ts
 import type { ResponseCache } from "@web-ai-sdk/prompt";
 import { ask } from "@web-ai-sdk/prompt";
 
-const TTL_MS = 60 * 60 * 1000;
-const prefix = "ai-summary:";
-
-const cache: ResponseCache & { delete(key: string): void } = {
-  get(key) {
-    const raw = localStorage.getItem(prefix + key);
-    if (!raw) return null;
-    try {
-      const item = JSON.parse(raw) as { value: unknown; expiresAt: unknown };
-      if (
-        typeof item.value === "string" &&
-        typeof item.expiresAt === "number" &&
-        Date.now() < item.expiresAt
-      ) {
-        return item.value;
-      }
-    } catch {
-      // Treat malformed storage as a cache miss.
+const entries = new Map<string, { value: string; expiresAt: number }>();
+const ttlCache = {
+  get(key: string) {
+    const entry = entries.get(key);
+    if (!entry || entry.expiresAt <= Date.now()) {
+      entries.delete(key);
+      return null;
     }
-    localStorage.removeItem(prefix + key);
-    return null;
+    return entry.value;
   },
-  set(key, value) {
-    localStorage.setItem(
-      prefix + key,
-      JSON.stringify({ value, expiresAt: Date.now() + TTL_MS }),
-    );
+  set(key: string, value: string) {
+    entries.set(key, { value, expiresAt: Date.now() + 60 * 60 * 1000 });
   },
-  delete(key) {
-    localStorage.removeItem(prefix + key);
+  delete(key: string) {
+    entries.delete(key);
   },
-};
+} satisfies ResponseCache & { delete(key: string): void };
 
 async function summarizeFresh(input: string, refresh = false) {
   const cacheKey = JSON.stringify(["article-summary-v1", input]);
-  if (refresh) cache.delete(cacheKey);
-  return ask({ input, cache, cacheKey });
+  if (refresh) ttlCache.delete(cacheKey);
+  return ask({ input, cache: ttlCache, cacheKey });
 }
 ```
 
-Custom keys must include every input and option that can change the output. Validate cached data before rendering, expire it conservatively, and never let a background refresh overwrite user edits.
+Include every output-changing input and option in the key. Do not let a background refresh overwrite user edits.
 
-## Before shipping
-
-- Prepare only after clear user intent, with Prompt instructions ready at creation.
-- Reuse stateless sessions; isolate unrelated Prompt histories with base-plus-clone.
-- Abort stale work and destroy sessions when the feature goes away.
-- Extract task-relevant text with `innerText` or explicit fields, never raw `innerHTML`.
-- Render plain text safely; sanitize complete formatted output.
-- Use schemas for data shape, not visual character limits.
-- Show preparation and inference progress.
-- Preserve originals with Accept, Reject, Undo, or version navigation.
-- Give persistent caches a TTL and a user-visible refresh path.
-- Keep unsupported-browser fallback UI useful; see [Browser support](/docs/browser-support/).
+Provide a useful fallback when an API is unavailable. See [Browser support](/docs/browser-support/).

--- a/apps/site/src/content/docs/production-checklist.mdx
+++ b/apps/site/src/content/docs/production-checklist.mdx
@@ -1,0 +1,247 @@
+---
+title: Production checklist
+description: Production guidance for input selection, session lifetime, safe rendering, user control, progress, and caching around the Web AI lifecycle wrappers.
+---
+
+The SDK owns the repetitive lifecycle around each browser capability. Your application still owns the product decisions around that lifecycle. This checklist adapts Chrome's public [Built-in AI APIs: Do and don't](https://developer.chrome.com/docs/ai/built-in-ai-dos-donts) guidance to the `@web-ai-sdk/*` packages.
+
+| The wrapper owns | Your application owns |
+| --- | --- |
+| Feature detection and typed unavailability | Establishing clear user intent before preparing a model |
+| Session creation, reuse, stream normalization, and cleanup hooks | Selecting task-relevant input and excluding unrelated page content |
+| AbortSignal wiring and React effect cleanup | Rendering, sanitization, progress, and fallback UI |
+| Optional result-cache adapters and complete default cache keys | Expiration, refresh, persistence policy, and user-visible history |
+
+The wrapper never walks your page, chooses what a user meant, sanitizes formatted output, persists edits, or renders UI. Those responsibilities depend on your product and intentionally stay in consumer code.
+
+## Prepare after clear user intent
+
+Prepare a session when the user enters or points at a relevant AI surface, not on every page load and not only after the final **Generate** click. For Prompt, provide system instructions at creation time so they become native `initialPrompts`:
+
+```ts
+import { createSession } from "@web-ai-sdk/prompt";
+
+let reviewBase: ReturnType<typeof createSession> | undefined;
+
+reviewWorkspace.addEventListener("pointerenter", () => {
+  reviewBase ??= createSession({
+    systemPrompt: "Review code for correctness. Be concise and cite lines.",
+  });
+});
+```
+
+Do not prewarm speculative features the user has shown no intent to use. The first preparation can download a model, consume memory, and take time.
+
+## Reuse the right kind of session
+
+Writer, Rewriter, and Summarizer sessions are stateless between tasks. Their high-level SDK functions reuse compatible native sessions automatically. Prompt sessions retain conversation history, so unrelated tasks should not share one conversation.
+
+For repeated independent Prompt tasks, keep a base containing only the system instructions, clone it per task, and destroy each clone when it finishes:
+
+```ts
+import { createSession } from "@web-ai-sdk/prompt";
+
+const base = createSession({
+  systemPrompt: "Review code for correctness. Return concise findings.",
+});
+
+async function review(code: string, signal: AbortSignal) {
+  const task = await base.clone({ signal });
+  try {
+    return await task.send(`Review this code:\n\n${code}`, { signal });
+  } finally {
+    task.destroy();
+  }
+}
+
+// When the feature itself is removed:
+base.destroy();
+```
+
+For one-shot Prompt work, `ask()` already uses a warm base plus a fresh clone when the browser supports cloning. For a real conversation, use one `createSession()` per conversation and keep its history deliberately.
+
+## Abort work that is no longer relevant
+
+Connect cancellation to navigation, changed input, and an explicit Stop action. Destroy long-lived sessions when their feature unmounts or closes.
+
+```ts
+import { rewrite } from "@web-ai-sdk/rewriter";
+
+const controller = new AbortController();
+stopButton.addEventListener("click", () => controller.abort());
+
+await rewrite({
+  input: editor.value,
+  tone: "more-formal",
+  signal: controller.signal,
+});
+```
+
+React hooks clean up the native session when their effect is replaced or unmounted. Per-operation cancellation and an explicit Stop control are still consumer decisions.
+
+## Send only task-relevant text
+
+Extract the smallest readable text that answers the task. Exclude navigation, cookie banners, hidden controls, metadata, and unrelated comments. Prefer `innerText` or explicit text extraction; never send raw `innerHTML`.
+
+```ts
+import { summarize } from "@web-ai-sdk/summarizer";
+
+const article = document.querySelector<HTMLElement>("[data-article-body]");
+const input = article?.innerText.trim() ?? "";
+
+const result = await summarize({ input, type: "key-points" });
+```
+
+If a task needs headings or selected fields, extract those values explicitly. DOM traversal and article-shape decisions stay outside the SDK because every application has a different document model.
+
+## Treat every output as untrusted
+
+Model output can be incorrect, hostile, or malformed. The SDK removes selected non-printing control characters; it does not make HTML or Markdown safe.
+
+For plain text, use React interpolation or `textContent`:
+
+```ts
+outputElement.textContent = result.output ?? "";
+```
+
+If you render formatted output, accumulate the full stream, parse it with raw HTML disabled, sanitize the complete result, and only then update the live DOM. Do not set `innerHTML` from model output, and do not sanitize chunks independently: unsafe syntax can span chunk boundaries.
+
+## Use schemas for data, layout for visual length
+
+Use Prompt structured output when application logic needs a predictable shape:
+
+```ts
+import { ask } from "@web-ai-sdk/prompt";
+
+const responseConstraint = {
+  type: "object",
+  properties: {
+    title: { type: "string" },
+    summary: { type: "string" },
+  },
+  required: ["title", "summary"],
+  additionalProperties: false,
+};
+
+const { output } = await ask({
+  input: `Summarize this article:\n\n${articleText}`,
+  responseConstraint,
+});
+
+const card = output ? JSON.parse(output) : null;
+```
+
+Do not add schema `maxLength` solely to fit a card, and do not prompt for an exact character count. A model can satisfy those constraints with compressed or degraded text. Let it generate naturally, then constrain the preview visually with overflow or line clamping and offer an expanded view.
+
+## Show preparation and generation progress
+
+Distinguish model preparation from inference. Surface download progress when available, show an active state for non-streaming tasks, and stream longer output when partial text is useful.
+
+```ts
+import { ask } from "@web-ai-sdk/prompt";
+
+await ask({
+  input,
+  monitor(monitor) {
+    monitor.addEventListener("downloadprogress", (event) => {
+      setDownloadProgress(event.loaded);
+    });
+  },
+  onUpdate(text) {
+    outputElement.textContent = text;
+  },
+});
+```
+
+Avoid replacing user-visible content without a transition or status cue. For short tasks, a spinner or pending label may be clearer than token-by-token output.
+
+## Preserve originals and make edits reversible
+
+AI editing should produce a suggestion, not silently replace the source. Keep the original, let the user Accept or Reject, and retain enough version history to Undo.
+
+```ts
+const versions = [editor.value];
+let suggestion: string | null = null;
+
+function accept() {
+  if (!suggestion) return;
+  versions.push(suggestion);
+  editor.value = suggestion;
+  suggestion = null;
+}
+
+function reject() {
+  suggestion = null;
+  editor.value = versions.at(-1) ?? "";
+}
+
+function undo() {
+  if (versions.length > 1) versions.pop();
+  editor.value = versions.at(-1) ?? "";
+}
+```
+
+For multi-step workflows, add previous/next version navigation or a diff. The user remains the final editor.
+
+## Expire caches and offer refresh
+
+The built-in `"session"` and `"local"` cache shortcuts are intentionally small adapters; they do not impose a product-specific freshness policy. Use a custom cache when results need a time-to-live, and provide a visible way to force fresh inference.
+
+```ts
+import type { ResponseCache } from "@web-ai-sdk/prompt";
+import { ask } from "@web-ai-sdk/prompt";
+
+const TTL_MS = 60 * 60 * 1000;
+const prefix = "ai-summary:";
+
+const cache: ResponseCache & { delete(key: string): void } = {
+  get(key) {
+    const raw = localStorage.getItem(prefix + key);
+    if (!raw) return null;
+    try {
+      const item = JSON.parse(raw) as { value: unknown; expiresAt: unknown };
+      if (
+        typeof item.value === "string" &&
+        typeof item.expiresAt === "number" &&
+        Date.now() < item.expiresAt
+      ) {
+        return item.value;
+      }
+    } catch {
+      // Treat malformed storage as a cache miss.
+    }
+    localStorage.removeItem(prefix + key);
+    return null;
+  },
+  set(key, value) {
+    localStorage.setItem(
+      prefix + key,
+      JSON.stringify({ value, expiresAt: Date.now() + TTL_MS }),
+    );
+  },
+  delete(key) {
+    localStorage.removeItem(prefix + key);
+  },
+};
+
+async function summarizeFresh(input: string, refresh = false) {
+  const cacheKey = JSON.stringify(["article-summary-v1", input]);
+  if (refresh) cache.delete(cacheKey);
+  return ask({ input, cache, cacheKey });
+}
+```
+
+Custom keys must include every input and option that can change the output. Validate cached data before rendering, expire it conservatively, and never let a background refresh overwrite user edits.
+
+## Before shipping
+
+- Prepare only after clear user intent, with Prompt instructions ready at creation.
+- Reuse stateless sessions; isolate unrelated Prompt histories with base-plus-clone.
+- Abort stale work and destroy sessions when the feature goes away.
+- Extract task-relevant text with `innerText` or explicit fields, never raw `innerHTML`.
+- Render plain text safely; sanitize complete formatted output.
+- Use schemas for data shape, not visual character limits.
+- Show preparation and inference progress.
+- Preserve originals with Accept, Reject, Undo, or version navigation.
+- Give persistent caches a TTL and a user-visible refresh path.
+- Keep unsupported-browser fallback UI useful; see [Browser support](/docs/browser-support/).

--- a/apps/site/src/content/docs/react/use-detector.mdx
+++ b/apps/site/src/content/docs/react/use-detector.mdx
@@ -7,6 +7,8 @@ import { DetectorDemo } from "../../../features/docs/components/DetectorDemo.tsx
 
 React adapter for `@web-ai-sdk/detector`. Auto-detects the language of `input` on mount and re-runs whenever it changes. For the conceptual overview see [Detector](/docs/guides/detector/).
 
+Before shipping, review the [Production checklist](/docs/production-checklist/) for task-relevant input, progress, and cache freshness.
+
 ## Live demo
 
 <DetectorDemo client:only="react" />

--- a/apps/site/src/content/docs/react/use-prompt.mdx
+++ b/apps/site/src/content/docs/react/use-prompt.mdx
@@ -7,6 +7,8 @@ import { PromptDemo } from "../../../features/docs/components/PromptDemo.tsx";
 
 React adapter for `@web-ai-sdk/prompt`. Runs single-shot prompts on demand via `ask(input)` and exposes status, streaming output text, and abort / reset controls. For the conceptual overview of the underlying API see [Prompt](/docs/guides/prompt/).
 
+Before shipping, review the [Production checklist](/docs/production-checklist/) for intent-driven preparation, safe streaming, progress, user control, and cache freshness.
+
 ## Live demo
 
 <PromptDemo client:only="react" />

--- a/apps/site/src/content/docs/react/use-proofreader.mdx
+++ b/apps/site/src/content/docs/react/use-proofreader.mdx
@@ -7,6 +7,8 @@ import { ProofreaderDemo } from "../../../features/docs/components/ProofreaderDe
 
 React adapter for `@web-ai-sdk/proofreader`. Auto-runs on mount and re-runs when `input` changes. For the conceptual overview see [Proofreader](/docs/guides/proofreader/).
 
+Before shipping, review the [Production checklist](/docs/production-checklist/) for preserving originals, Accept/Reject/Undo flows, safe rendering, and cache freshness.
+
 ## Live demo
 
 <ProofreaderDemo client:only="react" />

--- a/apps/site/src/content/docs/react/use-rewriter.mdx
+++ b/apps/site/src/content/docs/react/use-rewriter.mdx
@@ -7,6 +7,8 @@ import { RewriterDemo } from "../../../features/docs/components/RewriterDemo.tsx
 
 React adapter for `@web-ai-sdk/rewriter`. Auto-runs on mount, re-runs when `input` / config options change, and streams chunks through state updates. For the conceptual overview see [Rewriter](/docs/guides/rewriter/).
 
+Before shipping, review the [Production checklist](/docs/production-checklist/) for safe streaming, progress, Accept/Reject/Undo flows, and cache freshness.
+
 ## Live demo
 
 <RewriterDemo client:only="react" />

--- a/apps/site/src/content/docs/react/use-session.mdx
+++ b/apps/site/src/content/docs/react/use-session.mdx
@@ -9,6 +9,8 @@ For ask-and-display flows (embeds, widgets, single-question UIs) prefer [`usePro
 
 When enabled, mounting `useSession` starts `LanguageModel.create()` in the hook's lifecycle effect; it does not wait for a call to `send`. This makes mounting an intent-driven workflow a valid prewarm. The hook stays `"loading"` and keeps `session` null until that eagerly started native creation resolves.
 
+Before shipping, review the [Production checklist](/docs/production-checklist/) for initial instructions, base-plus-clone tasks, destruction, safe rendering, progress, and reversible UI.
+
 ## Usage
 
 ```tsx
@@ -56,7 +58,7 @@ export function Chat({ persona }: { persona: string }) {
 
 ## Independent chats
 
-Two `useSession` calls with identical options get two independent underlying instances. In a chat app with N agents in the same mode, each pane owns its own history, abort, and destroy lifecycle. Current Chrome / Edge builds may still serialize token generation FIFO across sessions because the underlying on-device model is single-instance.
+Two `useSession` calls with identical options get two independent underlying instances. In a chat app with N agents in the same mode, each pane owns its own history, abort, and destroy lifecycle. Scheduling across those native sessions is browser-defined, so do not depend on token-level interleaving or a particular parallelism policy.
 
 ```tsx
 function ChatList({ agents }: { agents: Agent[] }) {

--- a/apps/site/src/content/docs/react/use-session.mdx
+++ b/apps/site/src/content/docs/react/use-session.mdx
@@ -3,11 +3,13 @@ title: useSession
 description: Lifecycle-only React adapter for createSession. Each call owns one never-shared LanguageModel session; UI state is the consumer's concern.
 ---
 
-Lifecycle-only React adapter for the chat-shaped [`createSession()`](/docs/guides/prompt/#chat-createsession) primitive in `@web-ai-sdk/prompt`. Each `useSession` call owns one underlying `LanguageModelInstance`, with independent history, system prompt, sampling, and lifecycle. The hook handles feature detection, async create readiness, destroy-on-unmount, and recreate-on-options-change. It does **not** track `response`, `history`, or streaming status; iterate `session.sendStreaming()` yourself and keep UI state in your own component.
+`useSession` is the React adapter for [`createSession()`](/docs/guides/prompt/#chat-createsession). Each call owns one native instance. The hook detects support, waits for creation, destroys on unmount, and recreates after option changes.
 
-For ask-and-display flows (embeds, widgets, single-question UIs) prefer [`usePrompt`](/docs/react/use-prompt/); it uses isolated one-shot prompts and may keep a warm base session for same-shape calls.
+The hook does not track responses, history, or streaming status. Keep that state in your component.
 
-When enabled, mounting `useSession` starts `LanguageModel.create()` in the hook's lifecycle effect; it does not wait for a call to `send`. This makes mounting an intent-driven workflow a valid prewarm. The hook stays `"loading"` and keeps `session` null until that eagerly started native creation resolves.
+For one-shot interfaces, use [`usePrompt`](/docs/react/use-prompt/). It isolates each prompt and can reuse a prepared base session.
+
+When enabled, mounting the hook starts native creation. The hook stays `"loading"` and keeps `session` null until creation finishes.
 
 Before shipping, review the [Production checklist](/docs/production-checklist/) for initial instructions, base-plus-clone tasks, destruction, safe rendering, progress, and reversible UI.
 
@@ -54,11 +56,11 @@ export function Chat({ persona }: { persona: string }) {
 }
 ```
 
-`session.sendStreaming(text)` yields **deltas** (each chunk is the new text since the last yield). Accumulate into your own `response` state for a typewriter effect. The hook stays out of the streaming loop entirely.
+`session.sendStreaming(text)` yields deltas. Accumulate them in your response state. The hook does not manage the streaming loop.
 
 ## Independent chats
 
-Two `useSession` calls with identical options get two independent underlying instances. In a chat app with N agents in the same mode, each pane owns its own history, abort, and destroy lifecycle. Scheduling across those native sessions is browser-defined, so do not depend on token-level interleaving or a particular parallelism policy.
+Two hook calls with identical options get independent native instances. Each component owns its history, abort, and destroy lifecycle. Scheduling across instances is browser-defined.
 
 ```tsx
 function ChatList({ agents }: { agents: Agent[] }) {
@@ -78,7 +80,7 @@ function ChatPane({ agent }: { agent: Agent }) {
 
 ## Forking with `clone()` (agents / multi-task)
 
-`session` is the vanilla `Session`, so `session.clone()` is available in React too. For agents that run many tasks against one persona, keep the `useSession` base warm (system prompt only) and clone it per task so each run gets fresh history without re-parsing the system prompt. See [Session resilience](/docs/guides/prompt/#session-resilience-base--per-task-clone) for the full rationale.
+`session` is the vanilla `Session`, so it supports `clone()`. Keep one base with the system prompt and clone it for each independent task. See [Session resilience](/docs/guides/prompt/#session-resilience-base--per-task-clone).
 
 ```tsx
 const { session } = useSession({ systemPrompt });
@@ -102,7 +104,7 @@ const runTask = async (input: string) => {
 return <p>{response}</p>;
 ```
 
-Destroying a clone never affects the base session. The hook still owns the base session's lifecycle (destroyed on unmount / option change); clones you create are yours to destroy.
+Destroying a clone does not affect its base. The hook manages the base lifecycle. You must destroy clones that you create.
 
 ## Return shape
 
@@ -122,7 +124,7 @@ The hook waits for native creation before reporting `"ready"`. If `LanguageModel
 
 ## Recreating the session
 
-The hook recreates the underlying instance whenever a primitive option changes (`systemPrompt`, `samplingMode`, `temperature`, `topK`, `language`, `enabled`). Object options (`expectedInputs`, `expectedOutputs`, `createOptions`) participate in the dependency check by reference; memoize them or accept the recreate cost.
+The hook recreates the instance when a primitive option changes. It compares object options by reference; memoize them to avoid recreation.
 
 ```tsx
 const expected = useMemo<LanguageModelExpectedInput[]>(
@@ -134,7 +136,7 @@ const { session } = useSession({ systemPrompt, expectedInputs: expected });
 
 ## Disabled state
 
-Pass `enabled: false` to skip session creation entirely (status stays `"unavailable"`). Flipping it back to `true` creates the session on the next render. Useful when the session depends on user opt-in.
+Pass `enabled: false` to skip creation. The status stays `"unavailable"`. Setting it to `true` creates the session on the next render.
 
 ## Seeding multi-turn context
 
@@ -154,7 +156,9 @@ const { status, session } = useSession({
 if (status !== "ready" || !session) return null;
 ```
 
-The seeded turns become real context for the model. UI history lives in your own component state. Use either the `systemPrompt` shorthand or `createOptions.initialPrompts`, without duplicating the instruction. If both are supplied, `initialPrompts` is authoritative and the SDK warns once per loaded module instance that `systemPrompt` was ignored.
+Seeded turns become model context. Keep UI history in component state. Use either `systemPrompt` or `createOptions.initialPrompts`, not both.
+
+If you supply both, `initialPrompts` takes precedence. The SDK warns once that it ignored `systemPrompt`.
 
 ## Reference
 

--- a/apps/site/src/content/docs/react/use-summarizer.mdx
+++ b/apps/site/src/content/docs/react/use-summarizer.mdx
@@ -7,6 +7,8 @@ import { SummarizerDemo } from "../../../features/docs/components/SummarizerDemo
 
 React adapter for `@web-ai-sdk/summarizer`. Auto-runs on mount, re-runs when `input` / `language` / config options change, and streams chunks through state updates. For the conceptual overview see [Summarizer](/docs/guides/summarizer/).
 
+Before shipping, review the [Production checklist](/docs/production-checklist/) for task-relevant text extraction, safe streaming, progress, and cache freshness.
+
 ## Live demo
 
 <SummarizerDemo client:only="react" />

--- a/apps/site/src/content/docs/react/use-translator.mdx
+++ b/apps/site/src/content/docs/react/use-translator.mdx
@@ -7,6 +7,8 @@ import { TranslatorDemo } from "../../../features/docs/components/TranslatorDemo
 
 React adapter for `@web-ai-sdk/translator`. Auto-translates `input` from `sourceLanguage` to `targetLanguage` and re-runs whenever the inputs change. For the conceptual overview see [Translator](/docs/guides/translator/).
 
+Before shipping, review the [Production checklist](/docs/production-checklist/) for safe rendering, progress, reversible changes, and cache freshness.
+
 ## Live demo
 
 <TranslatorDemo client:only="react" />

--- a/apps/site/src/content/docs/react/use-writer.mdx
+++ b/apps/site/src/content/docs/react/use-writer.mdx
@@ -7,6 +7,8 @@ import { WriterDemo } from "../../../features/docs/components/WriterDemo.tsx";
 
 React adapter for `@web-ai-sdk/writer`. Auto-runs on mount, re-runs when `input` / config options change, and streams chunks through state updates. For the conceptual overview see [Writer](/docs/guides/writer/).
 
+Before shipping, review the [Production checklist](/docs/production-checklist/) for safe streaming, progress, reversible suggestions, and cache freshness.
+
 ## Live demo
 
 <WriterDemo client:only="react" />

--- a/apps/site/src/content/docs/why-web-ai-sdk.mdx
+++ b/apps/site/src/content/docs/why-web-ai-sdk.mdx
@@ -1,19 +1,19 @@
 ---
 title: Why web-ai-sdk
-description: How web-ai-sdk differs from provider SDKs like Vercel's AI SDK. web-ai-sdk is a typed layer for the Web AI surface, not a server-side model-provider SDK.
+description: How web-ai-sdk differs from server-side model-provider SDKs.
 ---
 
-`web-ai-sdk` is a TypeScript SDK for the Web AI surface: the browser-native `LanguageModel` (Prompt), `Writer`, `Rewriter`, `Proofreader`, `Translator`, `Summarizer`, `LanguageDetector`, and `document.modelContext` (WebMCP) surfaces.
+`web-ai-sdk` wraps browser-native AI APIs and WebMCP. It does not connect to hosted model providers.
 
 ## Not a provider SDK
 
-It is not a provider SDK for OpenAI, Anthropic, Google AI Studio, or other server-side models. Where a tool like Vercel's AI SDK focuses on building AI apps across model providers and frameworks (usually with a server in the loop), `web-ai-sdk` focuses on making the browser's own, on-device AI APIs easier to use directly from TypeScript.
+Provider SDKs connect applications to hosted models. They often support several providers and frameworks through a server.
 
-If your code calls a hosted model behind an API key, reach for a provider SDK. If your code wants to run on the model the browser ships, on-device, with no key and no server, that is what `web-ai-sdk` wraps.
+Use a provider SDK when your application calls a hosted model with an API key. Use `web-ai-sdk` for supported browser APIs.
 
-## Specialized built-ins, not just one model
+## Separate browser capabilities
 
-A single text-generation model abstraction can only express one of these surfaces, `LanguageModel` (Prompt). The other seven cannot be funneled through it, because each carries options a text-out contract has no room for.
+Prompt uses the general `LanguageModel` API. The other browser APIs use different inputs and return different results.
 
 - **Translator** takes a source and target language and caches a session per language pair.
 - **Summarizer** is shaped by type (key-points, TL;DR, headlines) and length.
@@ -23,15 +23,15 @@ A single text-generation model abstraction can only express one of these surface
 - **Detector** returns a confidence-scored, sorted list of language alternates.
 - **WebMCP** (`document.modelContext`) is an *agent* surface, not a model surface. Tools call into the page, and it does not generate text.
 
-That breadth is the point, not an accident. The model abstraction is one surface among eight, so `web-ai-sdk` is per-capability by design, a thin layer over each, built to get thinner as the platform matures.
+For this reason, the SDK uses one package per capability.
 
 ## What the SDK owns
 
-The Web AI surface is young and shifting. Every app that touches it re-implements the same lifecycle, so `web-ai-sdk` owns it once:
+The SDK handles lifecycle code for each native API:
 
-- Feature detection and availability checks, with a no-op fallback when an API is missing
-- Session creation, reuse, and cleanup
-- Streaming with chunk smoothing and `AbortSignal` wiring
-- Opt-in result caching
+- feature detection and availability checks;
+- session creation, reuse, and cleanup;
+- stream normalization and `AbortSignal` wiring;
+- opt-in result caching.
 
-You build against one stable, typed surface instead of coupling your whole app to today's experimental API shape. See [Architecture](/docs/architecture/) for how the packages are organized and [Browser support](/docs/browser-support/) for where each one runs today.
+See [Architecture](/docs/architecture/) for package boundaries. See [Browser support](/docs/browser-support/) for current availability.

--- a/apps/site/src/features/docs/components/BrowserTableHeading.astro
+++ b/apps/site/src/features/docs/components/BrowserTableHeading.astro
@@ -1,0 +1,25 @@
+---
+type Browser = "chrome" | "edge" | "safari" | "firefox";
+
+interface Props {
+  browsers: Browser[];
+  label: string;
+}
+
+const { browsers, label } = Astro.props;
+---
+
+<span class="browser-table-heading">
+  {
+    browsers.map((browser) => (
+      <img
+        src={`/browser-icons/${browser}.svg`}
+        width="18"
+        height="18"
+        alt=""
+        aria-hidden="true"
+      />
+    ))
+  }
+  <span class="browser-table-heading__label">{label}</span>
+</span>

--- a/apps/site/src/features/docs/components/Head.astro
+++ b/apps/site/src/features/docs/components/Head.astro
@@ -57,3 +57,6 @@ const ld = {
 
 <Default><slot /></Default>
 {data && <script is:inline type="application/ld+json" set:html={JSON.stringify(ld)} />}
+<script>
+  import "../scripts/table-scroll.js";
+</script>

--- a/apps/site/src/features/docs/components/PackageIndex.astro
+++ b/apps/site/src/features/docs/components/PackageIndex.astro
@@ -1,0 +1,170 @@
+---
+const packages = [
+  {
+    name: "all",
+    description: "Install all eight packages together.",
+    href: "/docs/guides/meta-package/",
+  },
+  {
+    name: "prompt",
+    description: "Send prompts and manage sessions, streams, and abort signals.",
+    href: "/docs/guides/prompt/",
+  },
+  {
+    name: "webmcp",
+    description: "Register browser tools and clean them up safely.",
+    href: "/docs/guides/webmcp/",
+  },
+  {
+    name: "summarizer",
+    description: "Create summaries, key points, teasers, and headlines.",
+    href: "/docs/guides/summarizer/",
+  },
+  {
+    name: "translator",
+    description: "Translate text between languages with reusable sessions.",
+    href: "/docs/guides/translator/",
+  },
+  {
+    name: "detector",
+    description: "Detect languages and receive confidence scores.",
+    href: "/docs/guides/detector/",
+  },
+  {
+    name: "writer",
+    description: "Draft text with a configurable tone, format, and length.",
+    href: "/docs/guides/writer/",
+  },
+  {
+    name: "rewriter",
+    description: "Change the tone or length of existing text.",
+    href: "/docs/guides/rewriter/",
+  },
+  {
+    name: "proofreader",
+    description: "Correct grammar, spelling, and punctuation.",
+    href: "/docs/guides/proofreader/",
+  },
+];
+---
+
+<ul class="package-index not-content" aria-label="Packages">
+  {
+    packages.map(({ name, description, href }) => (
+      <li>
+        <a class="package-link" href={href}>
+          <span class="package-name">
+            <span class="package-scope">@web-ai-sdk/</span>
+            {name}
+          </span>
+          <span class="package-description">{description}</span>
+          <span class="package-arrow" aria-hidden="true">→</span>
+        </a>
+      </li>
+    ))
+  }
+</ul>
+
+<style>
+  .package-index {
+    margin: 1.5rem 0 2.5rem;
+    padding: 0;
+    list-style: none;
+    border-block: 1px solid var(--sl-color-hairline);
+  }
+
+  .package-index li {
+    margin: 0;
+  }
+
+  .package-index li + li {
+    border-block-start: 1px solid var(--sl-color-hairline);
+  }
+
+  .package-link {
+    display: grid;
+    grid-template-columns: minmax(14rem, 0.85fr) minmax(0, 1.5fr) auto;
+    gap: 1.5rem;
+    align-items: center;
+    padding: 1rem;
+    color: var(--sl-color-white);
+    text-decoration: none;
+    transition: background-color 150ms ease;
+  }
+
+  :global(.sl-markdown-content) .package-link {
+    text-decoration: none;
+  }
+
+  .package-link:hover {
+    background: color-mix(
+      in srgb,
+      var(--sl-color-text-accent) 5%,
+      transparent
+    );
+  }
+
+  .package-link:focus-visible {
+    outline: 2px solid var(--sl-color-text-accent);
+    outline-offset: -2px;
+  }
+
+  .package-name {
+    min-width: 0;
+    font-family: var(--sl-font-mono);
+    font-size: 0.875rem;
+    font-weight: 600;
+    letter-spacing: -0.01em;
+  }
+
+  .package-scope {
+    color: var(--sl-color-gray-3);
+    font-weight: 400;
+  }
+
+  .package-description {
+    color: var(--sl-color-gray-2);
+    font-size: 0.9375rem;
+    line-height: 1.45;
+  }
+
+  .package-arrow {
+    color: var(--sl-color-gray-3);
+    font-family: var(--sl-font-mono);
+    font-size: 1.125rem;
+    transition:
+      color 150ms ease,
+      transform 150ms ease;
+  }
+
+  .package-link:hover .package-arrow {
+    color: var(--sl-color-white);
+    transform: translateX(0.2rem);
+  }
+
+  @media (max-width: 44.999rem) {
+    .package-link {
+      grid-template-columns: minmax(0, 1fr) auto;
+      gap: 0.3rem 1rem;
+      padding: 0.875rem 0.75rem;
+    }
+
+    .package-description {
+      grid-column: 1;
+      grid-row: 2;
+      font-size: 0.875rem;
+    }
+
+    .package-arrow {
+      grid-column: 2;
+      grid-row: 1 / span 2;
+    }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .package-link,
+    .package-arrow {
+      transition: none;
+    }
+  }
+</style>

--- a/apps/site/src/features/docs/components/PromptDemo.tsx
+++ b/apps/site/src/features/docs/components/PromptDemo.tsx
@@ -34,16 +34,16 @@ export const PromptDemo = ({
           api="Prompt API"
           chrome={
             <>
-              Prompt API unavailable. Stable in Chrome 148+; on Chrome 138–147
-              enable <code>chrome://flags/#prompt-api-for-gemini-nano</code> and
-              reload.
+              Prompt API unavailable. It is stable in Chrome 148+; see Browser
+              support for the current hardware and operating-system
+              requirements.
             </>
           }
           edge={
             <>
               Prompt API unavailable. In Edge Canary/Dev 138+, open{" "}
-              <code>edge://flags/</code>, search for "Prompt API for Phi mini",
-              enable it, and reload.
+              <code>edge://flags/</code>, search for "Prompt API for on-device
+              language model", enable it, and reload.
             </>
           }
         />

--- a/apps/site/src/features/docs/components/ProofreaderDemo.tsx
+++ b/apps/site/src/features/docs/components/ProofreaderDemo.tsx
@@ -27,8 +27,8 @@ export const ProofreaderDemo = () => {
           api="Proofreader API"
           chrome={
             <>
-              Proofreader API unavailable. Open in Chrome with the Proofreader
-              API flag / origin trial enabled to exercise.
+              Chrome labels Proofreader a Developer trial. For localhost, enable{" "}
+              <code>chrome://flags/#proofreader-api</code> and reload.
             </>
           }
           edge={

--- a/apps/site/src/features/docs/components/RewriterDemo.tsx
+++ b/apps/site/src/features/docs/components/RewriterDemo.tsx
@@ -31,15 +31,15 @@ export const RewriterDemo = ({ language = "en" }: { language?: string }) => {
           api="Rewriter API"
           chrome={
             <>
-              Rewriter API unavailable. Open in Chrome with the Rewriter API
-              flag / origin trial enabled to exercise.
+              Chrome labels Rewriter a Developer trial. For localhost, enable
+              the current Rewriter setup listed in Browser support.
             </>
           }
           edge={
             <>
               Rewriter API unavailable. In Edge Canary/Dev 138+, open{" "}
-              <code>edge://flags/</code>, search for "Rewriter API for Phi
-              mini", enable it, and reload.
+              <code>edge://flags/</code>, search for "Rewriter API for on-device
+              language model", enable it, and reload.
             </>
           }
         />

--- a/apps/site/src/features/docs/components/SocialIcons.astro
+++ b/apps/site/src/features/docs/components/SocialIcons.astro
@@ -1,0 +1,98 @@
+---
+import * as ui from "../../../shared/ui.js";
+
+const baseUrl = new URL(import.meta.env.BASE_URL, "https://web-ai-sdk.dev");
+const playgroundHref = new URL("playground/", baseUrl).pathname;
+const repoHref = new URL(
+  "obetomuniz/web-ai-sdk",
+  "https://github.com/",
+).toString();
+---
+
+<a
+  class={`${ui.navCtaPrimary} playground-link`}
+  href={playgroundHref}
+  aria-label="Open Playground"
+  title="Playground"
+>
+  <span class={ui.navPlaygroundLabel}>Playground</span>
+  <svg
+    class={ui.navPlaygroundMark}
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    stroke-width="2"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+    aria-hidden="true"
+  >
+    <rect x="3" y="4" width="18" height="16" rx="2"></rect>
+    <path d="m7 9 3 3-3 3"></path>
+    <path d="M13 15h4"></path>
+  </svg>
+</a>
+
+<a
+  href={repoHref}
+  target="_blank"
+  rel="noopener noreferrer"
+  class="social-link sl-flex"
+  aria-label="View the GitHub repository"
+  title="GitHub"
+>
+  <svg class="github-icon" viewBox="0 0 24 24" aria-hidden="true">
+    <path d="M10.226 17.284c-2.965-.36-5.054-2.493-5.054-5.256 0-1.123.404-2.336 1.078-3.144-.292-.741-.247-2.314.09-2.965.898-.112 2.111.36 2.83 1.01.853-.269 1.752-.404 2.853-.404 1.1 0 1.999.135 2.807.382.696-.629 1.932-1.1 2.83-.988.315.606.36 2.179.067 2.942.72.854 1.101 2 1.101 3.167 0 2.763-2.089 4.852-5.098 5.234.763.494 1.28 1.572 1.28 2.807v2.336c0 .674.561 1.056 1.235.786 4.066-1.55 7.255-5.615 7.255-10.646C23.5 6.188 18.334 1 11.978 1 5.62 1 .5 6.188.5 12.545c0 4.986 3.167 9.12 7.435 10.669.606.225 1.19-.18 1.19-.786V20.63a2.9 2.9 0 0 1-1.078.224c-1.483 0-2.359-.808-2.987-2.313-.247-.607-.517-.966-1.034-1.033-.27-.023-.359-.135-.359-.27 0-.27.45-.471.898-.471.652 0 1.213.404 1.797 1.235.45.651.921.943 1.483.943.561 0 .92-.202 1.437-.719.382-.381.674-.718.944-.943"></path>
+  </svg>
+</a>
+
+<style>
+  .playground-link:focus-visible {
+    outline: 2px solid var(--sl-color-text-accent);
+    outline-offset: 2px;
+  }
+
+  .social-link {
+    color: var(--sl-color-text-accent);
+    padding: 0.5em;
+    margin: -0.5em;
+  }
+
+  .social-link:hover {
+    color: var(--sl-color-white);
+  }
+
+  .github-icon {
+    width: 1em;
+    height: 1em;
+    fill: currentColor;
+  }
+
+  :global(:root[data-theme="light"]) .playground-link {
+    border-color: #16161a;
+    background: #16161a;
+    color: #fafafa;
+  }
+
+  :global(:root[data-theme="light"]) .playground-link:hover {
+    border-color: #000000;
+    background: #000000;
+  }
+
+  @media (max-width: 49.999rem) {
+    :global(.right-group) {
+      display: flex;
+    }
+
+    :global(.right-group > :not(.social-icons)) {
+      display: none;
+    }
+
+    :global(.right-group .social-icons) {
+      gap: 0.75rem;
+    }
+
+    :global(.right-group .social-icons::after) {
+      display: none;
+    }
+  }
+</style>

--- a/apps/site/src/features/docs/components/WebMCPDemo.tsx
+++ b/apps/site/src/features/docs/components/WebMCPDemo.tsx
@@ -112,14 +112,14 @@ export const WebMCPDemo = () => {
           api="WebMCP"
           chrome={
             <>
-              Enable <code>chrome://flags/#enable-webmcp-testing</code> in
-              Chrome 146+ and reload to exercise the tools.
+              Enable <code>chrome://flags/#enable-webmcp-testing</code> for
+              local Chrome development, or use the Chrome origin trial from 149.
             </>
           }
           edge={
             <>
-              Enable <code>edge://flags/#enable-webmcp-testing</code> in Edge
-              147+ and reload to exercise the tools.
+              Microsoft lists WebMCP in the Edge 150 origin trials. Register an
+              origin-trial token to exercise the tools.
             </>
           }
         />

--- a/apps/site/src/features/docs/components/WriterDemo.tsx
+++ b/apps/site/src/features/docs/components/WriterDemo.tsx
@@ -32,15 +32,15 @@ export const WriterDemo = ({ language = "en" }: { language?: string }) => {
           api="Writer API"
           chrome={
             <>
-              Writer API unavailable. Open in Chrome with the Writer API flag /
-              origin trial enabled to exercise.
+              Chrome labels Writer a Developer trial. For localhost, enable the
+              current Writer setup listed in Browser support.
             </>
           }
           edge={
             <>
               Writer API unavailable. In Edge Canary/Dev 138+, open{" "}
-              <code>edge://flags/</code>, search for "Writer API for Phi mini",
-              enable it, and reload.
+              <code>edge://flags/</code>, search for "Writer API for on-device
+              language model", enable it, and reload.
             </>
           }
         />

--- a/apps/site/src/features/docs/scripts/table-scroll.ts
+++ b/apps/site/src/features/docs/scripts/table-scroll.ts
@@ -1,0 +1,67 @@
+const TABLE_SELECTOR =
+  ".sl-markdown-content table:not(.options-table table):not([data-scroll-table])";
+const SCROLL_THRESHOLD = 1;
+
+function syncScrollState(container: HTMLElement, viewport: HTMLElement) {
+  const maxScrollLeft = viewport.scrollWidth - viewport.clientWidth;
+  const canScroll = maxScrollLeft > SCROLL_THRESHOLD;
+
+  container.toggleAttribute(
+    "data-shadow-left",
+    canScroll && viewport.scrollLeft > SCROLL_THRESHOLD,
+  );
+  container.toggleAttribute(
+    "data-shadow-right",
+    canScroll && viewport.scrollLeft < maxScrollLeft - SCROLL_THRESHOLD,
+  );
+
+  if (canScroll) {
+    viewport.tabIndex = 0;
+    viewport.setAttribute("role", "region");
+    viewport.setAttribute("aria-label", "Scrollable table");
+  } else {
+    viewport.removeAttribute("tabindex");
+    viewport.removeAttribute("role");
+    viewport.removeAttribute("aria-label");
+  }
+}
+
+function enhanceTable(table: HTMLTableElement) {
+  table.dataset.scrollTable = "";
+
+  const container = document.createElement("div");
+  container.className = "table-scroll";
+
+  const viewport = document.createElement("div");
+  viewport.className = "table-scroll__viewport";
+
+  table.before(container);
+  container.append(viewport);
+  viewport.append(table);
+
+  let frame = 0;
+  const scheduleSync = () => {
+    cancelAnimationFrame(frame);
+    frame = requestAnimationFrame(() => syncScrollState(container, viewport));
+  };
+
+  viewport.addEventListener("scroll", scheduleSync, { passive: true });
+
+  const observer = new ResizeObserver(scheduleSync);
+  observer.observe(viewport);
+  observer.observe(table);
+
+  scheduleSync();
+}
+
+function enhanceTables() {
+  document
+    .querySelectorAll<HTMLTableElement>(TABLE_SELECTOR)
+    .forEach(enhanceTable);
+}
+
+if (document.readyState === "loading") {
+  document.addEventListener("DOMContentLoaded", enhanceTables, { once: true });
+} else {
+  enhanceTables();
+}

--- a/apps/site/src/features/docs/scripts/table-scroll.ts
+++ b/apps/site/src/features/docs/scripts/table-scroll.ts
@@ -55,9 +55,21 @@ function enhanceTable(table: HTMLTableElement) {
 }
 
 function enhanceTables() {
-  document
-    .querySelectorAll<HTMLTableElement>(TABLE_SELECTOR)
-    .forEach(enhanceTable);
+  let tables: HTMLTableElement[] | NodeListOf<HTMLTableElement>;
+
+  try {
+    tables = document.querySelectorAll<HTMLTableElement>(TABLE_SELECTOR);
+  } catch {
+    tables = Array.from(
+      document.querySelectorAll<HTMLTableElement>(".sl-markdown-content table"),
+    ).filter(
+      (table) =>
+        !table.closest(".options-table") &&
+        !table.hasAttribute("data-scroll-table"),
+    );
+  }
+
+  tables.forEach(enhanceTable);
 }
 
 if (document.readyState === "loading") {

--- a/apps/site/src/features/docs/styles/web-ai-sdk.css
+++ b/apps/site/src/features/docs/styles/web-ai-sdk.css
@@ -149,31 +149,201 @@
   font-weight: 500;
 }
 
-/* Markdown tables: full-width, auto-laid-out, with type signatures kept on
-   one line via `<code>` rather than the whole cell. The Description column
-   inherits the remaining horizontal space so long descriptions never get
-   squeezed into a narrow gutter.
-   Starlight's default sets `display: block; overflow: auto` on tables,
-   which kills the natural table-layout that distributes width across
-   columns. We restore `display: table` here so `width: 100%` and column
-   sharing actually work, and only fall back to block + scroll on narrow
-   viewports where overflow is genuinely needed. */
+/* Keep the docs shell open and continuous. Starlight frames the page title and
+   both side columns with hairlines by default. */
+.content-panel + .content-panel,
+.sidebar-pane,
+.right-sidebar {
+  border: 0;
+}
+
+.page > .header {
+  border-bottom: 1px solid var(--sl-color-hairline-shade);
+  background: color-mix(
+    in oklch,
+    var(--sl-color-bg-nav) 78%,
+    transparent
+  );
+  backdrop-filter: blur(14px) saturate(1.2);
+}
+
+.page > .header .site-title {
+  font-family: var(--sl-font-mono);
+  font-size: 0.875rem;
+  font-weight: 500;
+  letter-spacing: -0.01em;
+}
+
+.page > .header .site-title span::after {
+  content: "";
+  display: inline-block;
+  width: 0.5em;
+  height: 0.08em;
+  margin-inline-start: 0.06em;
+  border-radius: 1px;
+  background: var(--sl-color-text-accent);
+  vertical-align: baseline;
+  animation: docs-caret-blink 1.1s steps(2) infinite;
+}
+
+/* Keep the mobile table of contents compact and give its two labels a clear
+   hierarchy: the toggle is a control; the adjacent text is page context. */
+@media (max-width: 49.999rem) {
+  mobile-starlight-toc summary {
+    gap: 0.75rem;
+    height: 2.75rem;
+    padding: 0.375rem 1rem;
+    font-size: 0.75rem;
+  }
+
+  mobile-starlight-toc .toggle {
+    gap: 0.5rem;
+    padding: 0.4375rem 0.5rem 0.4375rem 0.625rem;
+    border-color: var(--sl-color-hairline);
+    border-radius: 0.375rem;
+    font-family: var(--sl-font-mono);
+    font-size: 0.75rem;
+    letter-spacing: -0.01em;
+  }
+
+  mobile-starlight-toc .display-current {
+    color: var(--sl-color-gray-3);
+    font-size: 0.75rem;
+    line-height: 1.4;
+  }
+}
+
+@keyframes docs-caret-blink {
+  50% {
+    opacity: 0;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .page > .header .site-title span::after {
+    animation: none;
+  }
+}
+
+.sidebar-pane ul ul li {
+  border-inline-start: 0;
+}
+
+/* Standard tables keep their table layout inside a dedicated horizontal
+   viewport. Cells stay on one line; wider tables scroll instead of wrapping
+   compact values into uneven rows. */
+.table-scroll {
+  --table-edge-shadow: rgba(0, 0, 0, 0.72);
+  --table-row-rule: rgba(255, 255, 255, 0.055);
+  position: relative;
+  isolation: isolate;
+  width: 100%;
+  max-width: 100%;
+  overflow: hidden;
+}
+
+:root[data-theme="light"] .table-scroll {
+  --table-edge-shadow: rgba(0, 0, 0, 0.2);
+  --table-row-rule: rgba(0, 0, 0, 0.075);
+}
+
+.table-scroll::before,
+.table-scroll::after {
+  content: "";
+  position: absolute;
+  z-index: 1;
+  inset-block: 0;
+  width: 1.75rem;
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 150ms ease;
+}
+
+.table-scroll::before {
+  inset-inline-start: 0;
+  background: linear-gradient(to right, var(--table-edge-shadow), transparent);
+}
+
+.table-scroll::after {
+  inset-inline-end: 0;
+  background: linear-gradient(to left, var(--table-edge-shadow), transparent);
+}
+
+.table-scroll[data-shadow-left]::before,
+.table-scroll[data-shadow-right]::after {
+  opacity: 1;
+}
+
+.table-scroll__viewport {
+  max-width: 100%;
+  overflow-x: auto;
+  overscroll-behavior-inline: contain;
+  scrollbar-width: thin;
+  scrollbar-color: var(--sl-color-gray-4) transparent;
+  -webkit-overflow-scrolling: touch;
+}
+
+.table-scroll__viewport:focus-visible {
+  outline: 2px solid var(--sl-color-text-accent);
+  outline-offset: 2px;
+}
+
 .sl-markdown-content table:not(:where(.not-content *, .options-table *)) {
   display: table;
   width: 100%;
+  min-width: 40rem;
+  margin: 0;
   border-collapse: collapse;
   table-layout: auto;
-  overflow: visible;
 }
-.sl-markdown-content table th,
-.sl-markdown-content table td {
+
+.sl-markdown-content table:has(tr > :nth-child(3)):not(
+    :where(.not-content *, .options-table *)
+  ) {
+  min-width: 48rem;
+}
+
+.sl-markdown-content table:has(tr > :nth-child(4)):not(
+    :where(.not-content *, .options-table *)
+  ) {
+  min-width: 60rem;
+}
+.sl-markdown-content table th:not(:where(.not-content *, .options-table *)),
+.sl-markdown-content table td:not(:where(.not-content *, .options-table *)) {
   vertical-align: top;
-  white-space: normal;
+  white-space: nowrap;
   padding: 0.6rem 0.75rem;
+  border-color: var(--table-row-rule);
 }
-/* Keep inline code chips whole. Cells around them wrap naturally so the
-   Required chip can sit on the same line as the name without forcing the
-   whole row to a single line. */
+
+.browser-table-heading {
+  display: inline-flex;
+  width: 100%;
+  min-height: 1.125rem;
+  align-items: center;
+  justify-content: center;
+  gap: 0.625rem;
+}
+
+.browser-table-heading img {
+  width: 1.125rem;
+  height: 1.125rem;
+  flex: none;
+  object-fit: contain;
+}
+
+.browser-table-heading__label {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+/* Keep inline code chips whole. */
 .sl-markdown-content table code {
   white-space: nowrap;
 }
@@ -192,16 +362,11 @@
   color: var(--sl-color-text-accent);
   white-space: nowrap;
 }
-/* Mobile: tables overflow horizontally rather than crushing the
-   Description column. The block + overflow combo only kicks in below
-   720px where the native table layout no longer has the budget to
-   honor all columns at a readable width. Options tables (the card-style
-   override below) opt out — they're already viewport-friendly. */
-@media (max-width: 720px) {
-  .sl-markdown-content table:not(:where(.not-content *, .options-table *)) {
-    display: block;
-    overflow-x: auto;
-    -webkit-overflow-scrolling: touch;
+
+@media (prefers-reduced-motion: reduce) {
+  .table-scroll::before,
+  .table-scroll::after {
+    transition: none;
   }
 }
 

--- a/apps/site/src/features/home/components/DetectorDemo.tsx
+++ b/apps/site/src/features/home/components/DetectorDemo.tsx
@@ -20,7 +20,6 @@ import {
 } from "../../../shared/ui.js";
 import {
   DownloadNotice,
-  detectModelName,
   ErrorNotice,
   StatusBar,
   UnavailableNotice,
@@ -81,10 +80,7 @@ export const DetectorDemo = () => {
       </div>
       <div className={cardBody}>
         {available === false && (
-          <UnavailableNotice
-            api="Language Detector API"
-            flagSearch="language detection"
-          />
+          <UnavailableNotice api="Language Detector API" />
         )}
         <DownloadNotice progress={null} />
         <ErrorNotice error={error?.message ?? null} />
@@ -147,7 +143,7 @@ export const DetectorDemo = () => {
             </span>
           )}
         </div>
-        <StatusBar stats={stats} label={`model: ${detectModelName()}`} />
+        <StatusBar stats={stats} label="runtime: language-detection model" />
       </div>
     </div>
   );

--- a/apps/site/src/features/home/components/HowItWorks.tsx
+++ b/apps/site/src/features/home/components/HowItWorks.tsx
@@ -431,10 +431,7 @@ const TABS: Tab[] = [
       },
       {
         t: [
-          [
-            "com",
-            "  // Chrome streams deltas; Edge / Phi-Silica streams cumulative.",
-          ],
+          ["com", "  // Browser streams may be delta- or cumulative-shaped."],
         ],
       },
       {
@@ -448,7 +445,7 @@ const TABS: Tab[] = [
         t: [
           [
             "com",
-            "  // strip Edge soft-block placeholders (C0 / C1 control chars)",
+            "  // strip non-printing control characters before rendering",
           ],
         ],
       },

--- a/apps/site/src/features/home/components/PackageExplorer.tsx
+++ b/apps/site/src/features/home/components/PackageExplorer.tsx
@@ -52,30 +52,27 @@ const PACKAGE_ROWS: PackageInfo[] = [
   {
     slug: "prompt",
     title: "prompt",
-    tag: "Talk to the on-device language model. Sessions, streaming, and AbortSignals; done.",
+    tag: "Send prompts and manage independent sessions, streams, and abort signals.",
     bullets: [
-      [
-        "Session reuse.",
-        "Cached by config so re-renders do not churn the model.",
-      ],
+      ["Session reuse.", "Compatible calls reuse a cached base session."],
       [
         "Streaming first.",
-        "AsyncIterable out of the box; React hook gives you a string.",
+        "The vanilla session yields deltas. The React hook exposes cumulative text.",
       ],
       [
         "Clean lifecycle.",
-        "AbortController on unmount, retry on session-lost.",
+        "React cleanup aborts work and destroys the session.",
       ],
     ],
   },
   {
     slug: "webmcp",
     title: "webmcp",
-    tag: "Register tools the browser's model context can call. Real agents, real cleanup, no boilerplate.",
+    tag: "Register tools for the browser's model context and clean them up safely.",
     bullets: [
       [
         "Declarative tools.",
-        "Register from React; AbortSignal cleanup on unmount.",
+        "Register from React and clean up with an AbortSignal.",
       ],
       [
         "Last writer wins.",
@@ -83,7 +80,7 @@ const PACKAGE_ROWS: PackageInfo[] = [
       ],
       [
         "SDK-first surface.",
-        "Register, discover, and execute without raw browser globals.",
+        "Register, discover, and execute through typed functions.",
       ],
     ],
   },
@@ -93,27 +90,21 @@ const PACKAGE_ROWS: PackageInfo[] = [
     tag: "Key-points, TL;DR, headlines. Configurable type and length.",
     bullets: [
       ["Four shapes.", "key-points, tl;dr, teaser, headline."],
+      ["Three lengths.", "Choose short, medium, or long output."],
       [
-        "Three lengths.",
-        "short, medium, long. Deterministic with the same seed.",
+        "Streaming summaries.",
+        "Receive cumulative text as the model responds.",
       ],
-      ["Streaming summaries.", "Pipe chunks straight into your UI."],
     ],
   },
   {
     slug: "translator",
     title: "translator",
-    tag: "Pair-based translation with block-level round-trip. Walks the DOM, swaps text, keeps markup intact.",
+    tag: "Translate a string between a source and target language.",
     bullets: [
-      [
-        "Pair caching.",
-        "Sessions cached per source to target pair. Switching is instant.",
-      ],
-      [
-        "Block round-trip.",
-        "Walks the DOM, swaps text, keeps the markup intact.",
-      ],
-      ["Graceful fallback.", "No-op fallback when the API is missing."],
+      ["Pair caching.", "Sessions are cached by source and target language."],
+      ["String input.", "The SDK does not walk or mutate the DOM."],
+      ["Typed fallback.", "Unavailable environments return a state or error."],
     ],
   },
   {
@@ -123,53 +114,47 @@ const PACKAGE_ROWS: PackageInfo[] = [
     bullets: [
       [
         "Top candidate or full list.",
-        "Use the best guess, or inspect every alternate above your threshold.",
+        "Use the top result or inspect all results above a threshold.",
       ],
       [
         "Bias hints.",
-        "Pass expectedInputLanguages to break ties between similar languages.",
+        "Pass expectedInputLanguages when you know the likely languages.",
       ],
       [
         "Wire the others.",
-        "Detect first, then summarize, translate, or prompt with the result.",
+        "Application code can pass the result to another capability.",
       ],
     ],
   },
   {
     slug: "writer",
     title: "writer",
-    tag: "Draft new content from a task description. Tone, format, length; streamed straight into your UI.",
+    tag: "Draft text from a task description. Configure tone, format, and length.",
     bullets: [
       [
         "Task in, prose out.",
-        "Give it a prompt; get back a paragraph, email, or post.",
+        "Pass a writing task and receive generated text.",
       ],
+      ["Tone and length.", "Choose a tone and output length."],
       [
-        "Tone and length.",
-        "formal, neutral, casual, across short, medium, and long.",
-      ],
-      [
-        "Markdown safe.",
-        "Trims edges only, so formatting and line breaks survive.",
+        "Output cleanup.",
+        "The wrapper trims outer whitespace and preserves internal formatting.",
       ],
     ],
   },
   {
     slug: "rewriter",
     title: "rewriter",
-    tag: "Tone-shift and reshape text you already have. More formal, shorter, or longer; one call.",
+    tag: "Change the tone or length of existing text.",
     bullets: [
       [
         "Relative adjustments.",
         "more-formal, more-casual, shorter, longer, as-is.",
       ],
-      [
-        "Streaming first.",
-        "Pipe the revised text in as the model produces it.",
-      ],
+      ["Streaming first.", "Receive cumulative text as the model responds."],
       [
         "Same lifecycle.",
-        "Session reuse, AbortSignals, opt-in caching; shared with Writer.",
+        "Reuse sessions, abort work, and opt in to result caching.",
       ],
     ],
   },

--- a/apps/site/src/features/home/components/PromptDemo.tsx
+++ b/apps/site/src/features/home/components/PromptDemo.tsx
@@ -21,7 +21,6 @@ import {
 } from "../../../shared/ui.js";
 import {
   DownloadNotice,
-  detectModelName,
   MarkdownOutput,
   StatusBar,
   UnavailableNotice,
@@ -80,9 +79,7 @@ export const PromptDemo = () => {
         <span>session: cached · balanced</span>
       </div>
       <div className={cardBody}>
-        {available === false && (
-          <UnavailableNotice api="Prompt API" flagSearch="Prompt API" />
-        )}
+        {available === false && <UnavailableNotice api="Prompt API" />}
         <DownloadNotice progress={progress} />
         <div className={fieldSpaced}>
           <label className={label} htmlFor="prompt-demo-input">
@@ -133,7 +130,7 @@ export const PromptDemo = () => {
               : "Output will stream here…"
           }
         />
-        <StatusBar stats={stats} label={`model: ${detectModelName()}`} />
+        <StatusBar stats={stats} label="runtime: browser-provided model" />
       </div>
     </div>
   );

--- a/apps/site/src/features/home/components/ProofreaderDemo.tsx
+++ b/apps/site/src/features/home/components/ProofreaderDemo.tsx
@@ -93,9 +93,7 @@ export const ProofreaderDemo = () => {
         <span>{corrections} fixes</span>
       </div>
       <div className={cardBody}>
-        {available === false && (
-          <UnavailableNotice api="Proofreader API" flagSearch="Proofreader" />
-        )}
+        {available === false && <UnavailableNotice api="Proofreader API" />}
         <DownloadNotice progress={progress} />
         <ErrorNotice error={error} />
         <div className={fieldSpaced}>
@@ -125,7 +123,7 @@ export const ProofreaderDemo = () => {
           streaming={running}
           placeholder={
             available === false
-              ? "Enable the Proofreader API flag in Chrome to check grammar."
+              ? "Open this demo in a supported Proofreader API setup."
               : "Run to correct grammar, spelling, and punctuation."
           }
         />

--- a/apps/site/src/features/home/components/RewriterDemo.tsx
+++ b/apps/site/src/features/home/components/RewriterDemo.tsx
@@ -109,9 +109,7 @@ export const RewriterDemo = () => {
         </span>
       </div>
       <div className={cardBody}>
-        {available === false && (
-          <UnavailableNotice api="Rewriter API" flagSearch="Rewriter" />
-        )}
+        {available === false && <UnavailableNotice api="Rewriter API" />}
         <DownloadNotice progress={progress} />
         <ErrorNotice error={error} />
         <div className={fieldSpaced}>
@@ -164,7 +162,7 @@ export const RewriterDemo = () => {
           streaming={streaming}
           placeholder={
             available === false
-              ? "Enable the Rewriter API flag in Chrome to rewrite."
+              ? "Open this demo in a supported Rewriter API setup to rewrite."
               : "Run to rewrite the text above."
           }
         />

--- a/apps/site/src/features/home/components/SummarizerDemo.tsx
+++ b/apps/site/src/features/home/components/SummarizerDemo.tsx
@@ -27,7 +27,6 @@ import {
   DownloadNotice,
   ErrorNotice,
   InfoNotice,
-  isDesktopChromium,
   MarkdownOutput,
   StatusBar,
   UnavailableNotice,
@@ -35,15 +34,14 @@ import {
   useStreamStats,
 } from "./shared.js";
 
-const SAMPLE_ARTICLE = `The Summarizer API ships as part of the browser's built-in AI surface. The model runs locally; there's no network round-trip, no API key, and no per-call cost. Latency is bounded by the device. On a recent M-series Mac, an 800-word article summarizes in under 600 ms. On a mid-tier Pixel, the same call takes about 1.4 seconds. The API exposes four summary types (key-points, tl;dr, teaser, headline) and three length presets. Output is deterministic with the same input and seed. The downside: model weights are large, so the first call on a cold profile downloads ~1.7 GB. Subsequent calls are instant.`;
+const SAMPLE_ARTICLE = `The Summarizer API is part of the browser's built-in AI surface. Applications should pass only the text that is relevant to the user's task, show model-download and generation progress, and treat every result as untrusted content. The API exposes multiple summary types and length presets. A lifecycle wrapper can handle feature detection, session reuse, streaming normalization, abort signals, and optional result caching. The application still owns text extraction, rendering, sanitization, cache freshness, fallback UI, and the decision to preserve or replace the original content.`;
 
 type SummaryType = "key-points" | "tldr" | "headline";
 type SummaryLength = "short" | "medium" | "long";
 type SummaryPreference = "auto" | "speed" | "capability";
 
 const preferenceInfo = (preference: SummaryPreference): string | null => {
-  if (!isDesktopChromium()) return null;
-  return `preference: ${preference} is experimental. Enable the Summarizer API performance preference flag, restart your browser, and reload for model tiering.`;
+  return `preference: ${preference} is experimental and may be unavailable in the current browser implementation.`;
 };
 
 const ChipSelect = <T extends string>({

--- a/apps/site/src/features/home/components/WebMCPDemo.tsx
+++ b/apps/site/src/features/home/components/WebMCPDemo.tsx
@@ -415,9 +415,7 @@ Reply with ONLY valid JSON of the shape {"tool":"name_or_null","args":{},"reason
         </span>
       </div>
       <div className={cardBody}>
-        {available === false && (
-          <UnavailableNotice api="WebMCP" flagSearch="WebMCP" />
-        )}
+        {available === false && <UnavailableNotice api="WebMCP" />}
         <DownloadNotice progress={progress} />
         <fieldset className={fieldset}>
           <legend className={fieldLegend}>demo tools</legend>

--- a/apps/site/src/features/home/components/WriterDemo.tsx
+++ b/apps/site/src/features/home/components/WriterDemo.tsx
@@ -109,9 +109,7 @@ export const WriterDemo = () => {
         </span>
       </div>
       <div className={cardBody}>
-        {available === false && (
-          <UnavailableNotice api="Writer API" flagSearch="Writer" />
-        )}
+        {available === false && <UnavailableNotice api="Writer API" />}
         <DownloadNotice progress={progress} />
         <ErrorNotice error={error} />
         <div className={fieldSpaced}>
@@ -164,7 +162,7 @@ export const WriterDemo = () => {
           streaming={streaming}
           placeholder={
             available === false
-              ? "Enable the Writer API flag in Chrome to draft."
+              ? "Open this demo in a supported Writer API setup to draft."
               : "Run to draft content from the task above."
           }
         />

--- a/apps/site/src/features/home/components/shared.tsx
+++ b/apps/site/src/features/home/components/shared.tsx
@@ -7,6 +7,8 @@ import {
   outputBox,
 } from "../../../shared/ui.js";
 
+const browserSupportHref = `${import.meta.env.BASE_URL}docs/browser-support/`;
+
 interface DownloadProgressEvent extends Event {
   readonly loaded: number;
 }
@@ -243,10 +245,7 @@ export const UnavailableNotice = ({ api }: { api: string }) => {
     <div className="block rounded-sm border border-[color-mix(in_oklch,var(--color-warn)_40%,var(--color-hairline))] bg-surface px-3 py-[9px] font-mono text-[11.5px] text-warn">
       <span>
         {api} unavailable. See the{" "}
-        <a
-          className="underline underline-offset-2"
-          href="/docs/browser-support/"
-        >
+        <a className="underline underline-offset-2" href={browserSupportHref}>
           sourced browser-support guide
         </a>{" "}
         for current channels, trials, flags, and hardware requirements.

--- a/apps/site/src/features/home/components/shared.tsx
+++ b/apps/site/src/features/home/components/shared.tsx
@@ -1,8 +1,4 @@
 import { type ReactNode, useCallback, useRef, useState } from "react";
-import {
-  detectBrowser,
-  isDesktopWebAIBrowser,
-} from "../../../shared/browser.js";
 import { ModelMarkdown } from "../../../shared/components/ModelMarkdown.js";
 import {
   caret,
@@ -22,20 +18,17 @@ interface CreateMonitor {
 }
 
 /**
- * Wire a Chrome Built-in AI `monitor` callback to React state. Returns the
+ * Wire a Built-in AI `monitor` callback to React state. Returns the
  * monitor function to pass into `createOptions.monitor`, plus the current
  * progress (a fraction from 0..1) or `null` when no download is in flight.
- *
- * Chrome fires `downloadprogress` events with `loaded` as a 0..1 fraction
- * during the ~1.7 GB Gemini Nano download on a fresh profile.
  */
 export const useDownloadMonitor = () => {
   const [progress, setProgress] = useState<number | null>(null);
 
   const monitor = useCallback((m: CreateMonitor) => {
-    // Chrome emits a single `downloadprogress` with loaded=1 on warm starts
-    // (model already cached) to signal readiness. Suppress that case so the
-    // notice only surfaces for a real download in progress.
+    // Some implementations emit a single `downloadprogress` with loaded=1 on
+    // warm starts. Suppress that case so the notice only surfaces for a real
+    // download in progress.
     let firstEvent = true;
     m.addEventListener("downloadprogress", (e) => {
       if (firstEvent && e.loaded >= 1) {
@@ -245,73 +238,19 @@ export const MarkdownOutput = ({
   );
 };
 
-/** Desktop Chrome or Edge — excludes mobile UAs and other Chromium forks. */
-export const isDesktopChromium = isDesktopWebAIBrowser;
-
-export const detectModelName = (): string => {
-  if (typeof globalThis === "undefined") return "on-device LM";
-  const g = globalThis as Record<string, unknown>;
-  const present =
-    "LanguageModel" in g || "Summarizer" in g || "Translator" in g;
-  if (!present) return "on-device LM";
-  const browser = detectBrowser();
-  if (browser === "edge") return "Phi-4-mini";
-  if (browser === "chrome") return "Gemini Nano";
-  return "on-device LM";
-};
-
-export const UnavailableNotice = ({
-  api,
-  flagSearch,
-}: {
-  api: string;
-  flagSearch?: string;
-}) => {
-  const browser = detectBrowser();
-
-  // Safari, Firefox, and mobile browsers (including Chrome and Edge on
-  // iOS/Android, which report as "other") don't implement the Web AI
-  // APIs, so Chrome/Edge flag instructions would mislead. These APIs are
-  // desktop-only today; say so plainly.
-  if (browser === "other") {
-    return (
-      <div className="block rounded-sm border border-[color-mix(in_oklch,var(--color-warn)_40%,var(--color-hairline))] bg-surface px-3 py-[9px] font-mono text-[11.5px] text-warn">
-        <span>
-          {api} isn't supported in this browser yet. The Web AI APIs currently
-          run only on desktop Chrome and Edge (mobile browsers, including Chrome
-          and Edge on iOS and Android, aren't supported yet). Open this page on
-          desktop Chrome or Edge to try the demo.
-        </span>
-      </div>
-    );
-  }
-
-  const scheme = browser === "edge" ? "edge://" : "chrome://";
-  const browserName =
-    browser === "edge" ? "Edge Canary/Dev 138+" : "Chrome 138+";
+export const UnavailableNotice = ({ api }: { api: string }) => {
   return (
     <div className="block rounded-sm border border-[color-mix(in_oklch,var(--color-warn)_40%,var(--color-hairline))] bg-surface px-3 py-[9px] font-mono text-[11.5px] text-warn">
       <span>
-        {api} unavailable in this browser.
-        {flagSearch ? (
-          <>
-            {" "}
-            Open <code>{`${scheme}flags/`}</code> in {browserName}, search for{" "}
-            <code>{flagSearch}</code>, enable it, and reload.
-          </>
-        ) : (
-          ` Open in ${browserName} to try it.`
-        )}
+        {api} unavailable. See the{" "}
+        <a
+          className="underline underline-offset-2"
+          href="/docs/browser-support/"
+        >
+          sourced browser-support guide
+        </a>{" "}
+        for current channels, trials, flags, and hardware requirements.
       </span>
-      {browser === "edge" && (
-        <span className="mt-1.5 block text-[11px] text-fg-4">
-          If the flag is enabled but the model still won't run, check{" "}
-          <code>edge://on-device-internals</code>; the foundational model AND
-          the supplementary safety models (GENERALIZED_SAFETY, TEXT_SAFETY,
-          LANGUAGE_DETECTION) all need to show "Ready". Edge fails closed and
-          blocks all output when any safety model is missing.
-        </span>
-      )}
     </div>
   );
 };

--- a/apps/site/src/features/playground/README.md
+++ b/apps/site/src/features/playground/README.md
@@ -4,9 +4,8 @@ This document describes the internal architecture of the Playground at
 `/playground/`. It is maintainer documentation for the site application, not
 part of the public SDK documentation.
 
-The Playground is a consumer of `web-ai-sdk`. It demonstrates how the SDK
-packages can be composed into a local-first agent experience without moving
-application orchestration or UI concerns into the framework-agnostic wrappers.
+The Playground consumes `web-ai-sdk`. It combines the packages in a local-first
+agent application. Orchestration and UI code stay outside the SDK wrappers.
 
 ## Goals
 
@@ -28,10 +27,8 @@ application orchestration or UI concerns into the framework-agnostic wrappers.
 | Components | Composer, conversation navigation, transcript presentation, runtime metadata, and panel controls |
 | Astro boot shell | Immediate read-only rendering of the last persisted conversation before React is interactive |
 
-The Playground should use `@web-ai-sdk/*` whenever the SDK already owns the
-browser API lifecycle. Consumer-specific behavior such as chaining multiple
-packages, choosing tools for a mode, or persisting conversations stays in this
-feature.
+Use `@web-ai-sdk/*` for browser API lifecycle management. Keep package
+composition, mode tools, and conversation persistence in this feature.
 
 ## Directory map
 
@@ -71,71 +68,55 @@ Playground
     └── RuntimePanel
 ```
 
-`Playground` coordinates cross-cutting workflow state. Each child owns one
-recognizable product region, while shared stateful behavior lives in a named
-hook or domain module. Small visual primitives such as `PanelToggle` remain
-implementation details of those primary components.
+`Playground` coordinates shared workflow state. Each child owns one product
+region. Named hooks and domain modules contain shared stateful behavior.
 
 ## Technical decisions
 
 ### 1. The Playground is application code, not a new SDK abstraction
 
-The SDK wrappers remain small and framework-agnostic. The Playground is where
-multiple wrappers are intentionally composed into a product experience. This
-keeps the core packages reusable and prevents a demo-specific agent model from
-becoming public API.
+The SDK wrappers remain small and framework-agnostic. The Playground combines
+them into an application. Playground-specific behavior is not public SDK API.
 
 ### 2. Conversations are local-first
 
-Conversation state is loaded synchronously from `localStorage` in the React
-state initializer. Writes happen after state changes, and conversations sort by
-`updatedAt` so the most recently active work remains first.
+The React state initializer loads conversations from `localStorage`. It writes
+after state changes and sorts conversations by `updatedAt`.
 
-Persisted data is treated as recoverable input rather than trusted application
-state. Invalid conversations and turns are discarded individually. One
-malformed entry must not erase every valid conversation.
+Treat persisted data as untrusted input. Discard invalid conversations and
+turns individually. One malformed entry must not erase valid conversations.
 
 The persistence schema is shared conceptually by the Astro boot shell and the
 React application. A schema change must update both readers and the
 `agentThreads` regression tests.
 
-### 3. The cached conversation is the loading state
+### 3. Show the cached conversation during loading
 
-The page does not display a spinner or an empty conversation while JavaScript
-boots. `PlaygroundFallback.astro` reads the same browser storage synchronously
-and renders a read-only representation of the last active conversation.
+Do not show a spinner or empty conversation while JavaScript loads.
+`PlaygroundFallback.astro` renders the last active conversation from storage.
 
-React replaces that shell in `useLayoutEffect`, before the browser paints an
-intermediate interactive state. The boot shell is `inert` and must not acquire
-business logic or handle user actions. Its only job is to preserve the first
-paint until React owns the page.
+React replaces the shell in `useLayoutEffect`. The shell is `inert`; it must not
+contain business logic or handle input.
 
-The boot renderer and React renderer use different runtime libraries because
-the boot shell must execute inline before the island loads. They must continue
-to support the same safe Markdown subset and storage shape. Visual parity is
-covered through build-preview reload QA.
+The boot and React renderers use different runtime libraries. They must support
+the same safe Markdown subset and storage shape. Check visual parity in a build
+preview.
 
 ### 4. Availability checks are optimistic
 
-Prompt API probing is asynchronous, but a probe is not evidence that the model
-is unavailable. The initial state therefore behaves as ready and only surfaces
-a warning after Chrome reports a definitive unavailable, downloadable, or
-downloading state.
+Prompt API detection is asynchronous. Treat the initial state as ready. Show a
+warning only after the browser reports a known unavailable or download state.
 
-This prevents the composer and runtime status from flashing between enabled
-and disabled during page load. Downloading states are polled because Chrome can
-transition without a page reload.
+This prevents status changes during page load. Poll download states because the
+browser can update them without a reload.
 
-### 5. Every run owns its original conversation
+### 5. Keep each run with its original conversation
 
-When a message starts, the Playground captures its conversation id, turn id,
-and whether it is the first turn. Completion appends and titles the captured
-conversation rather than whichever conversation happens to be selected later.
+When a message starts, capture its conversation ID, turn ID, and first-turn
+state. Append the result to that conversation, even if the selection changes.
 
-Conversation switching, deletion, mode changes, and WebMCP mutations are
-blocked while a response is running. This is an integrity boundary, not merely
-a UI choice. Without it, asynchronous completion could write model output into
-the wrong conversation or reset the wrong model session.
+Block conversation changes and WebMCP mutations while a response runs. This
+prevents output from reaching the wrong conversation or model session.
 
 ### 6. Modes configure behavior without deleting history
 
@@ -179,17 +160,14 @@ Scrolling upward disables following immediately. It resumes when the user
 returns near the bottom or activates the latest-message control. Reduced-motion
 preferences use immediate scrolling.
 
-### 10. Examples have an immediate deterministic baseline
+### 10. Show curated examples first
 
-Every mode ships curated examples, so the composer never waits for generated
-suggestions on first render. Generated examples are requested only when the
-user explicitly activates the generate control. Recent conversation turns
-provide context for that request without triggering it automatically.
+Every mode includes curated examples. Generate new examples only when the user
+requests them. Use recent turns as context for that request.
 
-Generation is cancelled when the mode, conversation, or active run changes.
-Outputs are filtered for concrete goals and reject placeholder resources such
-as root GitHub URLs or `example.com`. Contextual fallbacks ensure that model
-failure does not leave the composer empty or introduce a layout shift.
+Cancel generation when the mode, conversation, or active run changes. Reject
+placeholder resources such as root GitHub URLs or `example.com`. Use contextual
+fallbacks when generation fails.
 
 ### 11. Responsive panels slide instead of compressing content
 
@@ -260,8 +238,7 @@ pnpm build
 pnpm --filter @web-ai-sdk-apps/site exec astro preview --port 4173
 ```
 
-Use Chrome for final Playground QA because the on-device APIs are exposed
-there. Verify at minimum:
+Use a supported browser for final Playground QA. Verify at minimum:
 
 - persisted reload without an empty-state flash;
 - desktop, intermediate, and mobile layouts;

--- a/apps/site/src/features/playground/experimental/agent/loop.ts
+++ b/apps/site/src/features/playground/experimental/agent/loop.ts
@@ -541,7 +541,7 @@ export function createAgentLoop(options: CreateAgentOptions = {}): Agent {
           let answer: string;
           if (tools.length > 0 && looksLikeUnparsedToolCall(reply, tools)) {
             answer =
-              "The model tried to call a tool in a format I couldn't parse this time (its tool-call format varies between runs). Re-run - it usually works on another try.";
+              "The model returned an invalid tool call. Run the request again.";
           } else {
             answer = stripToolCode(reply) || reply.trim();
           }
@@ -1363,7 +1363,7 @@ function composeSignals(
 
 function makeUnavailableAgent(tools: readonly AgentTool[]): Agent {
   const text =
-    "The on-device model isn't available yet. Confirm the Prompt API model is downloaded in a supported Chrome build, then reload the playground.";
+    "The on-device model is unavailable. Confirm that the Prompt API model is downloaded, then reload the Playground.";
   const failure: AgentFailure = {
     name: "PromptUnavailableError",
     message: "Prompt API is unavailable in this environment.",

--- a/apps/site/src/features/playground/lib/promptReadiness.test.ts
+++ b/apps/site/src/features/playground/lib/promptReadiness.test.ts
@@ -4,19 +4,19 @@ import { promptReadinessMessage } from "./promptReadiness.js";
 describe("promptReadinessMessage", () => {
   it("guides Chrome users through local model troubleshooting", () => {
     expect(promptReadinessMessage("unavailable", "chrome")).toBe(
-      "Chrome can run the Prompt API, but it is not available here. Check Chrome's version, built-in AI settings, and model status, then reload.",
+      "The Prompt API is unavailable. Check Chrome's version, AI settings, and model status. Then reload.",
     );
   });
 
   it("guides Edge users through its preview setup", () => {
     expect(promptReadinessMessage("unavailable", "edge")).toBe(
-      "Edge can run the Prompt API in Canary and Dev, but it is not available here. Check Edge's AI settings and model status, then reload.",
+      "The Prompt API is unavailable. Check Edge's channel, AI settings, and model status. Then reload.",
     );
   });
 
   it("does not send unsupported browsers to Chrome settings", () => {
     expect(promptReadinessMessage("unavailable", "other")).toBe(
-      "This browser does not support the on-device Prompt API. Open the playground in desktop Chrome or Edge.",
+      "This browser does not support the Prompt API. Open the Playground in desktop Chrome or Edge.",
     );
   });
 });

--- a/apps/site/src/features/playground/lib/promptReadiness.ts
+++ b/apps/site/src/features/playground/lib/promptReadiness.ts
@@ -39,10 +39,10 @@ function browserName(browser: WebAIBrowser): string {
 
 function unavailableMessage(browser: WebAIBrowser): string {
   if (browser === "chrome") {
-    return "Chrome can run the Prompt API, but it is not available here. Check Chrome's version, built-in AI settings, and model status, then reload.";
+    return "The Prompt API is unavailable. Check Chrome's version, AI settings, and model status. Then reload.";
   }
   if (browser === "edge") {
-    return "Edge can run the Prompt API in Canary and Dev, but it is not available here. Check Edge's AI settings and model status, then reload.";
+    return "The Prompt API is unavailable. Check Edge's channel, AI settings, and model status. Then reload.";
   }
-  return "This browser does not support the on-device Prompt API. Open the playground in desktop Chrome or Edge.";
+  return "This browser does not support the Prompt API. Open the Playground in desktop Chrome or Edge.";
 }

--- a/apps/site/src/pages/index.astro
+++ b/apps/site/src/pages/index.astro
@@ -51,14 +51,14 @@ const ogImageUrl = new URL("og-image.png", SITE_ORIGIN).toString();
 const navItems = [
   {
     id: "why-raw",
-    label: "Why not raw?",
-    summary: "The thin lifecycle layer the SDK owns.",
+    label: "Why a wrapper?",
+    summary: "Lifecycle work handled by the SDK.",
     tick: "h-4",
   },
   {
     id: "why-sdk",
     label: "Why per-capability",
-    summary: "One focused package for each browser AI surface.",
+    summary: "One package for each browser capability.",
     tick: "h-6",
   },
   {
@@ -88,7 +88,7 @@ const navItems = [
   {
     id: "philosophy",
     label: "Why composable",
-    summary: "Lifecycle primitives that fit your own UI.",
+    summary: "SDK and application responsibilities.",
     tick: "h-4",
   },
   {
@@ -518,21 +518,21 @@ const browserColumns = [
         <div class={ui.container}>
           <div class={`${ui.sectionHead} ${ui.sectionAnchor}`} id="why-raw">
             <div>
-              <div class={ui.sectionEyebrow}>the question</div>
-              <h2 class="mt-2">Why not just use the APIs directly?</h2>
+              <div class={ui.sectionEyebrow}>purpose</div>
+              <h2 class="mt-2">Why use a wrapper?</h2>
             </div>
             <a class={ui.permalink} href="#why-raw"><span aria-hidden="true">↑</span><span class={ui.srOnly}>Link to the why-not-the-raw-APIs section</span></a>
           </div>
           <div class={`${ui.whyRawGrid} ${ui.reveal}`} data-reveal>
             <p class={ui.whyRawLead}>
-              You can, and nothing here stops you. The Web AI surface is the foundation.
+              You can use the browser APIs directly.
             </p>
             <div>
               <p class={ui.whyRawText}>
-                web-ai-sdk owns the thin, repetitive lifecycle layer you would otherwise rewrite in every app: capability checks, model downloads, session reuse, streaming with chunk smoothing, AbortSignal cleanup, opt-in result caching, and feature-detected fallbacks. Drop down to the raw APIs whenever you want.
+                web-ai-sdk handles capability checks, session reuse, stream normalization, abort signals, cleanup, and optional result caching.
               </p>
               <a class={`${ui.pkgDocs} mt-5`} href="#philosophy">
-                <span class={ui.silverText}>See why it's composable</span>
+                <span class={ui.silverText}>See package boundaries</span>
               </a>
             </div>
           </div>
@@ -550,9 +550,9 @@ const browserColumns = [
           </div>
           <div class={`${ui.twoCol} ${ui.reveal}`} data-reveal>
             <div>
-              <h3 class={ui.philosophyTitle}>One model surface.</h3>
+              <h3 class={ui.philosophyTitle}>Prompt.</h3>
               <p class={ui.philosophyText}>
-                A single text-generation model abstraction reaches exactly one of these built-ins, <code>LanguageModel</code> (Prompt). Useful, but one surface, not the whole product.
+                Prompt wraps the general <code>LanguageModel</code> API.
               </p>
               <ul class={ui.philosophyList}>
                 <li>Prompt / LanguageModel only</li>
@@ -560,9 +560,9 @@ const browserColumns = [
               </ul>
             </div>
             <div>
-              <h3 class={ui.philosophyTitle}>Seven surfaces beyond it.</h3>
+              <h3 class={ui.philosophyTitle}>Other capabilities.</h3>
               <p class={ui.philosophyText}>
-                The rest carry options a text-out contract cannot hold, so each gets its own thin package.
+                The other APIs use different options and result types. Each has its own package.
               </p>
               <ul class={ui.philosophyList}>
                 <li>Translator (source + target language, pair-cached sessions)</li>
@@ -583,8 +583,8 @@ const browserColumns = [
           <div class={`${ui.sectionHead} ${ui.sectionAnchor}`} id="matrix">
             <div>
               <div class={ui.sectionEyebrow}>capability matrix</div>
-              <h2 class="mt-2">One lifecycle layer, eight surfaces.</h2>
-              <p class="mt-3.5">The same guarantees, applied per API. Not every capability needs every feature; the matrix below tracks what each package actually does.</p>
+              <h2 class="mt-2">Lifecycle features by package.</h2>
+              <p class="mt-3.5">Each package implements only the lifecycle features supported by its browser API.</p>
             </div>
             <a class={ui.permalink} href="#matrix"><span aria-hidden="true">↑</span><span class={ui.srOnly}>Link to Capability matrix section</span></a>
           </div>
@@ -629,7 +629,7 @@ const browserColumns = [
           <div class={`${ui.sectionHead} ${ui.sectionAnchor}`} id="packages">
             <div>
               <div class={ui.sectionEyebrow}>packages</div>
-              <h2 class="mt-2">Composable wrappers. One philosophy.</h2>
+              <h2 class="mt-2">Packages.</h2>
             </div>
             <a class={ui.permalink} href="#packages"><span aria-hidden="true">↑</span><span class={ui.srOnly}>Link to Packages section</span></a>
           </div>
@@ -644,7 +644,7 @@ const browserColumns = [
             <div>
               <div class={ui.sectionEyebrow}>support</div>
               <h2 class="mt-2">Browser support.</h2>
-              <p class="mt-3.5">Web AI support lands capability by capability and vendor by vendor. The wrappers feature-detect their native API and expose an explicit unavailable path; check the linked vendor source before choosing your fallback.</p>
+              <p class="mt-3.5">Support differs by capability and browser. Each status links to a vendor source. The wrappers expose an unavailable state for fallback UI.</p>
             </div>
             <a class={ui.permalink} href="#support"><span aria-hidden="true">↑</span><span class={ui.srOnly}>Link to Browser support section</span></a>
           </div>
@@ -701,8 +701,8 @@ const browserColumns = [
           <div class={`${ui.sectionHead} ${ui.sectionAnchor}`} id="how">
             <div>
               <div class={ui.sectionEyebrow}>how it works</div>
-              <h2 class="mt-2">Same task. Three levels of abstraction.</h2>
-              <p class="mt-3.5">All three tabs do the same thing: detect an article's language and summarize it into key-points. Same result, less to wire up.</p>
+              <h2 class="mt-2">Compare three API levels.</h2>
+              <p class="mt-3.5">Each tab detects an article's language and creates a key-point summary. Compare the raw API, vanilla SDK, and React code.</p>
             </div>
             <a class={ui.permalink} href="#how"><span aria-hidden="true">↑</span><span class={ui.srOnly}>Link to How it works section</span></a>
           </div>
@@ -716,16 +716,16 @@ const browserColumns = [
         <div class={ui.container}>
           <div class={`${ui.sectionHead} ${ui.sectionAnchor}`} id="philosophy">
             <div>
-              <div class={ui.sectionEyebrow}>philosophy</div>
-              <h2 class="mt-2">Why composable.</h2>
+              <div class={ui.sectionEyebrow}>scope</div>
+              <h2 class="mt-2">Responsibilities.</h2>
             </div>
             <a class={ui.permalink} href="#philosophy"><span aria-hidden="true">↑</span><span class={ui.srOnly}>Link to Philosophy section</span></a>
           </div>
           <div class={`${ui.twoCol} ${ui.reveal}`} data-reveal>
             <div>
-              <h3 class={ui.philosophyTitle}>We handle the rough edges.</h3>
+              <h3 class={ui.philosophyTitle}>SDK responsibilities.</h3>
               <p class={ui.philosophyText}>
-                The Web AI surface is young. Capability checks, model downloads, abortable streams, session lifetimes, and delta/cumulative stream normalization are all things you would otherwise re-implement in every component.
+                The SDK handles browser API lifecycles. This includes support checks, sessions, streams, abort signals, and cleanup.
               </p>
               <ul class={ui.philosophyList}>
                 <li>Feature detection per package</li>
@@ -736,9 +736,9 @@ const browserColumns = [
               </ul>
             </div>
             <div>
-              <h3 class={ui.philosophyTitle}>You compose the stack.</h3>
+              <h3 class={ui.philosophyTitle}>Application responsibilities.</h3>
               <p class={ui.philosophyText}>
-                We ship the lifecycle layer: state machines, streams, abort signals. Framework adapters, polyfills, and UI primitives stay optional so they do not constrain the design system.
+                Application code owns UI, persistence, DOM traversal, fallbacks, and cross-capability workflows.
               </p>
               <ul class={ui.philosophyList}>
                 <li>Framework-agnostic core</li>
@@ -813,10 +813,10 @@ const browserColumns = [
         <div class={ui.container}>
           <div class={`${ui.ctaGlow} ${ui.sectionAnchor} ${ui.reveal}`} data-reveal id="start">
             <div class={ui.ctaBlock}>
-              <div class={`${ui.sectionEyebrow} mb-5 justify-center`}>ship it</div>
-              <h2 class={`${ui.ctaBlockTitle} ${ui.gradientText}`}>Try it in your project.</h2>
+              <div class={`${ui.sectionEyebrow} mb-5 justify-center`}>install</div>
+              <h2 class={`${ui.ctaBlockTitle} ${ui.gradientText}`}>Add it to your project.</h2>
               <p class={ui.ctaBlockText}>
-                One install, all eight blocks. Or pick the individual <code>@web-ai-sdk/*</code> packages. Ships ESM, CJS, and types. Tree-shakable.
+                Install <code>@web-ai-sdk/all</code> or select an individual package. Each package includes ESM, CJS, and TypeScript declarations.
               </p>
               <InstallPill pkg="@web-ai-sdk/all" className="mx-auto" client:visible />
               <div class={ui.ctaLinks}>

--- a/apps/site/src/pages/index.astro
+++ b/apps/site/src/pages/index.astro
@@ -203,10 +203,9 @@ const structuredData = {
 };
 
 // Sources we cite for each availability claim, so readers can verify per cell.
-// Chrome → Chrome for Developers; Edge → Microsoft Learn. WebMCP on Edge has no
-// official Microsoft page yet, so that one cell links nowhere (see note below).
+// Chrome → Chrome for Developers; Edge → Microsoft Learn.
 const chromeDocs: Record<string, string> = {
-  prompt: "https://developer.chrome.com/docs/extensions/ai/prompt-api",
+  prompt: "https://developer.chrome.com/docs/ai/prompt-api",
   summarizer: "https://developer.chrome.com/docs/ai/summarizer-api",
   translator: "https://developer.chrome.com/docs/ai/translator-api",
   detector: "https://developer.chrome.com/docs/ai/language-detection",
@@ -230,7 +229,8 @@ const edgeDocs: Record<string, string | undefined> = {
     "https://learn.microsoft.com/en-us/microsoft-edge/web-platform/writing-assistance-apis",
   proofreader:
     "https://learn.microsoft.com/en-us/microsoft-edge/web-platform/proofreader-api",
-  webmcp: undefined,
+  webmcp:
+    "https://learn.microsoft.com/en-us/microsoft-edge/web-platform/release-notes/150",
 };
 
 interface SupportRow {
@@ -242,14 +242,30 @@ interface SupportRow {
 }
 
 const supportRows: SupportRow[] = [
-  { pkg: "prompt", chrome: "148+ stable", edge: "138+ flag, Canary/Dev" },
+  {
+    pkg: "prompt",
+    chrome: "148+ stable",
+    edge: "138+ Canary/Dev flag; OT 150",
+  },
   { pkg: "summarizer", chrome: "138+ stable", edge: "138+ stable" },
   { pkg: "translator", chrome: "138+ stable", edge: "148+ stable" },
   { pkg: "detector", chrome: "138+ stable", edge: "148+ stable" },
-  { pkg: "writer", chrome: "137+ flag, OT", edge: "138+ flag, Canary/Dev" },
-  { pkg: "rewriter", chrome: "137+ flag, OT", edge: "138+ flag, Canary/Dev" },
-  { pkg: "proofreader", chrome: "141+ flag, OT", edge: "142+ flag, Canary/Dev" },
-  { pkg: "webmcp", chrome: "146+ flag, OT 149+", edge: "147+ flag" },
+  {
+    pkg: "writer",
+    chrome: "Developer trial, local flag",
+    edge: "138+ Canary/Dev flag",
+  },
+  {
+    pkg: "rewriter",
+    chrome: "Developer trial, local flag",
+    edge: "138+ Canary/Dev flag",
+  },
+  {
+    pkg: "proofreader",
+    chrome: "Developer trial, local flag",
+    edge: "142+ Canary/Dev flag",
+  },
+  { pkg: "webmcp", chrome: "OT 149+, local flag", edge: "OT 150" },
 ].map((row) => ({
   ...row,
   chromeHref: chromeDocs[row.pkg],
@@ -261,7 +277,11 @@ const supportVersionTone = (value: string) => {
   // Canary/Dev previews are also flag-gated; keep the preview tone so the
   // channel requirement reads as the primary signal, not the flag.
   if (value.includes("Canary/Dev")) return ui.supportVersionPreview;
-  if (value.includes("flag") || value.includes("OT"))
+  if (
+    value.includes("Developer trial") ||
+    value.includes("flag") ||
+    value.includes("OT")
+  )
     return ui.supportVersionFlag;
   return ui.supportVersionPreview;
 };
@@ -624,7 +644,7 @@ const browserColumns = [
             <div>
               <div class={ui.sectionEyebrow}>support</div>
               <h2 class="mt-2">Browser support.</h2>
-              <p class="mt-3.5">Web AI support lands engine by engine, and it is desktop-only for now: mobile browsers, including Chrome and Edge on iOS and Android, are not supported yet. Where it is not there yet, you get a feature-detected no-op so your code does not crash.</p>
+              <p class="mt-3.5">Web AI support lands capability by capability and vendor by vendor. The wrappers feature-detect their native API and expose an explicit unavailable path; check the linked vendor source before choosing your fallback.</p>
             </div>
             <a class={ui.permalink} href="#support"><span aria-hidden="true">↑</span><span class={ui.srOnly}>Link to Browser support section</span></a>
           </div>
@@ -670,7 +690,7 @@ const browserColumns = [
               </table>
             </div>
             <div class={ui.supportNote}>
-              Each version links to its source. <strong>stable</strong> = on by default; <strong>Canary/Dev</strong> = preview channel, needs the matching flag; <strong>flag</strong> = normal channel, behind a flag; <strong>OT</strong> = <a class="underline underline-offset-2" href="https://developer.chrome.com/docs/web-platform/origin-trials" target="_blank" rel="noreferrer">origin trial</a>. WebMCP/Edge is empirical (no official page yet).
+              Each status links to its vendor source. <strong>stable</strong> = documented as on by default; <strong>Canary/Dev</strong> = Edge preview channel with the documented flag; <strong>Developer trial</strong> = Chrome's current status label, not an active public token program; <strong>OT</strong> = <a class="underline underline-offset-2" href="https://developer.chrome.com/docs/web-platform/origin-trials" target="_blank" rel="noreferrer">origin trial</a>. Historical Writer/Rewriter (137–148) and Proofreader (141–145) Chrome origin-trial windows have ended.
             </div>
           </div>
         </div>
@@ -705,7 +725,7 @@ const browserColumns = [
             <div>
               <h3 class={ui.philosophyTitle}>We handle the rough edges.</h3>
               <p class={ui.philosophyText}>
-                The Web AI surface is young. Capability checks, model downloads, abortable streams, session lifetimes, and DOM-rebuild safety are all things you would otherwise re-implement in every component.
+                The Web AI surface is young. Capability checks, model downloads, abortable streams, session lifetimes, and delta/cumulative stream normalization are all things you would otherwise re-implement in every component.
               </p>
               <ul class={ui.philosophyList}>
                 <li>Feature detection per package</li>

--- a/apps/site/src/pages/index.astro
+++ b/apps/site/src/pages/index.astro
@@ -628,7 +628,7 @@ const browserColumns = [
         <div class={ui.container}>
           <div class={`${ui.sectionHead} ${ui.sectionAnchor}`} id="packages">
             <div>
-              <div class={ui.sectionEyebrow}>packages</div>
+              <div class={ui.sectionEyebrow}>SDK catalog</div>
               <h2 class="mt-2">Packages.</h2>
             </div>
             <a class={ui.permalink} href="#packages"><span aria-hidden="true">↑</span><span class={ui.srOnly}>Link to Packages section</span></a>

--- a/apps/site/src/shared/ui.ts
+++ b/apps/site/src/shared/ui.ts
@@ -228,7 +228,7 @@ export const navCenterPlaceholder =
   "h-10 w-48 justify-self-center max-[640px]:hidden";
 
 const navCtaBase =
-  "inline-flex min-h-9 items-center justify-center whitespace-nowrap rounded-sm border px-3 py-2 font-mono text-[12.5px] transition-all max-[640px]:size-9 max-[640px]:p-0";
+  "inline-flex min-h-9 items-center justify-center whitespace-nowrap rounded-sm border px-3 py-2 font-mono text-[12.5px] leading-[1.55] no-underline transition-all max-[640px]:size-9 max-[640px]:p-0";
 
 export const navCta = `${navCtaBase} border-hairline-2 text-fg-2 hover:border-accent-line hover:text-fg`;
 

--- a/packages/detector/README.md
+++ b/packages/detector/README.md
@@ -2,11 +2,11 @@
 
 web-ai-sdk building block for [the Web's Built-in Language Detector API](https://developer.chrome.com/docs/ai/language-detection). Detect the language of any text on-device, with confidence scores and a sorted list of alternates. Session reuse, pluggable result caching, AbortSignal-driven cleanup.
 
-**Docs:** <https://web-ai-sdk.dev/docs/guides/detector/> · **React:** [`useDetector`](https://web-ai-sdk.dev/docs/react/use-detector/)
+**Docs:** <https://web-ai-sdk.dev/docs/guides/detector/> · **React:** [`useDetector`](https://web-ai-sdk.dev/docs/react/use-detector/) · **Production:** [Checklist](https://web-ai-sdk.dev/docs/production-checklist/)
 
 ## Status
 
-Language Detector ships stable in Chrome 138+ and Edge 148+ on desktop, with no flag required (per the [Edge Language Detector API docs](https://learn.microsoft.com/en-us/microsoft-edge/web-platform/languagedetector-api)). On any other browser this library is a no-op for the React hook (it stays in `"unavailable"`). The vanilla `detect()` throws `DetectorUnavailableError` so callers can branch explicitly.
+Language Detector ships stable in Chrome 138+ and shipped in Edge 148, with no flag required, per the [Chrome status table](https://developer.chrome.com/docs/ai/built-in-apis) and [Edge 148 release notes](https://learn.microsoft.com/en-us/microsoft-edge/web-platform/release-notes/148). On browsers without `LanguageDetector`, the React hook stays `"unavailable"`; vanilla `detect()` throws `DetectorUnavailableError` so callers can branch explicitly.
 
 ## Install
 

--- a/packages/detector/README.md
+++ b/packages/detector/README.md
@@ -1,12 +1,14 @@
 # @web-ai-sdk/detector
 
-web-ai-sdk building block for [the Web's Built-in Language Detector API](https://developer.chrome.com/docs/ai/language-detection). Detect the language of any text on-device, with confidence scores and a sorted list of alternates. Session reuse, pluggable result caching, AbortSignal-driven cleanup.
+This package wraps the Web's Built-in [Language Detector API](https://developer.chrome.com/docs/ai/language-detection). It returns confidence scores and sorted alternatives. It also supports session reuse, optional result caching, and abort signals.
 
 **Docs:** <https://web-ai-sdk.dev/docs/guides/detector/> · **React:** [`useDetector`](https://web-ai-sdk.dev/docs/react/use-detector/) · **Production:** [Checklist](https://web-ai-sdk.dev/docs/production-checklist/)
 
 ## Status
 
-Language Detector ships stable in Chrome 138+ and shipped in Edge 148, with no flag required, per the [Chrome status table](https://developer.chrome.com/docs/ai/built-in-apis) and [Edge 148 release notes](https://learn.microsoft.com/en-us/microsoft-edge/web-platform/release-notes/148). On browsers without `LanguageDetector`, the React hook stays `"unavailable"`; vanilla `detect()` throws `DetectorUnavailableError` so callers can branch explicitly.
+Language Detector is stable in Chrome 138+ and shipped in Edge 148. It does not require a flag. See the [Chrome status table](https://developer.chrome.com/docs/ai/built-in-apis) and [Edge 148 release notes](https://learn.microsoft.com/en-us/microsoft-edge/web-platform/release-notes/148).
+
+Without `LanguageDetector`, React reports `"unavailable"` and `detect()` throws `DetectorUnavailableError`.
 
 ## Install
 
@@ -15,7 +17,7 @@ pnpm add @web-ai-sdk/detector
 # or: npm i @web-ai-sdk/detector / bun add @web-ai-sdk/detector
 ```
 
-The React adapter ships as a subpath export, with no extra install. `react` is a peer dependency only when you import the `/react` entry.
+The React adapter uses the `/react` subpath. `react` is an optional peer dependency.
 
 ## Vanilla TypeScript / DOM
 

--- a/packages/detector/src/api.ts
+++ b/packages/detector/src/api.ts
@@ -1,7 +1,6 @@
 /**
- * Adapter over the global `LanguageDetector` API exposed by Chrome (behind
- * `chrome://flags/#language-detection-api`). Feature-detected; on browsers
- * without it, every entry point returns `null` so callers can stay
+ * Adapter over the global `LanguageDetector` API. Feature-detected; on
+ * browsers without it, every entry point returns `null` so callers can stay
  * declarative.
  *
  * Spec: https://developer.chrome.com/docs/ai/language-detection

--- a/packages/detector/src/index.ts
+++ b/packages/detector/src/index.ts
@@ -159,8 +159,8 @@ export const detect = async (options: DetectOptions): Promise<DetectResult> => {
     ...(options.monitor ? { monitor: options.monitor } : {}),
   };
 
-  // Pass the same shape to availability() as we do to create() so engines
-  // that warn on mismatch (Edge) stay quiet.
+  // Pass the same shape to availability() as we do to create() so the probe
+  // applies to the requested configuration.
   const availability = await api
     .availability(
       expectedInputLanguages ? { expectedInputLanguages } : undefined,

--- a/packages/prompt/README.md
+++ b/packages/prompt/README.md
@@ -1,12 +1,12 @@
 # @web-ai-sdk/prompt
 
-web-ai-sdk building block for the Web's Built-in [Prompt API](https://developer.chrome.com/docs/extensions/ai/prompt-api) (`LanguageModel`). One-shot `ask()` for embeds and widgets, plus a thin `createSession()` primitive (and React `useSession`) for chat-shaped apps that need independent per-conversation sessions and delta-shaped streaming. The wrapper smooths cross-browser quirks (delta-vs-cumulative chunks, control-character cleanup, abort wiring); UI state and conversation history are the consumer's concern.
+web-ai-sdk building block for the Web's Built-in [Prompt API](https://developer.chrome.com/docs/ai/prompt-api) (`LanguageModel`). One-shot `ask()` for embeds and widgets, plus a thin `createSession()` primitive (and React `useSession`) for chat-shaped apps that need independent per-conversation sessions and delta-shaped streaming. The wrapper smooths cross-browser quirks (delta-vs-cumulative chunks, control-character cleanup, abort wiring); UI state and conversation history are the consumer's concern.
 
-**Docs:** <https://web-ai-sdk.dev/docs/guides/prompt/> · **React:** [`usePrompt`](https://web-ai-sdk.dev/docs/react/use-prompt/) · [`useSession`](https://web-ai-sdk.dev/docs/react/use-session/)
+**Docs:** <https://web-ai-sdk.dev/docs/guides/prompt/> · **React:** [`usePrompt`](https://web-ai-sdk.dev/docs/react/use-prompt/) · [`useSession`](https://web-ai-sdk.dev/docs/react/use-session/) · **Production:** [Checklist](https://web-ai-sdk.dev/docs/production-checklist/)
 
 ## Status
 
-Prompt API ships stable in Chrome 148+ — no flag required. Chrome 138–147 still works with `chrome://flags/#prompt-api-for-gemini-nano` enabled. On Edge it remains a developer preview in Canary/Dev 138+ behind `edge://flags/#prompt-api-for-phi-mini`, with Phi-4-mini's stricter safety pipeline often refusing output (see [Browser support](https://web-ai-sdk.dev/browser-support)). On any other browser this library is a no-op for the React hook (it stays in `"unavailable"`). The vanilla `ask()` throws `PromptUnavailableError` so callers can branch explicitly.
+Prompt API [ships stable in Chrome 148+](https://developer.chrome.com/docs/ai/prompt-api) with no flag required. On Edge it is a [developer preview](https://learn.microsoft.com/en-us/microsoft-edge/web-platform/prompt-api) in Canary/Dev 138.0.3309.2+ behind "Prompt API for on-device language model." Phi-4-mini is the documented default and requires a High-or-greater device performance class; Canary/Dev 150.0.4070+ can optionally use the prerelease Aion-1.0-Instruct model on Medium/Low devices behind the additional "Enable prerelease on-device language model" flag. See [Browser support](https://web-ai-sdk.dev/docs/browser-support/) for the sourced matrix. On browsers without `LanguageModel`, the React hook stays `"unavailable"`; vanilla `ask()` throws `PromptUnavailableError` so callers can branch explicitly.
 
 ## Install
 
@@ -62,7 +62,7 @@ Every `createSession()` call returns an independent `LanguageModelInstance` with
 
 Calling `createSession()` starts `LanguageModel.create()` immediately. The first `send`, `sendStreaming`, or `clone` only awaits that already-started creation, so creating a base session as soon as the user's intent is clear is a valid prewarming primitive. The synchronous `Session` wrapper is returned before native creation necessarily resolves; see [Context-window introspection](#context-window-introspection) for the resulting getter-readiness distinction.
 
-**Concurrency note.** Each session is an independent `LanguageModel` instance: independent history, system prompt, sampling, and lifecycle. The underlying on-device model is single-instance, so the browser currently schedules `sendStreaming` calls across sessions FIFO. Overlapping sends do not interleave token-by-token in Chrome 148 / Edge 138 — the second send waits for the first to drain. This is a constraint of the runtime, not of the API; code written against `createSession()` becomes faster automatically if a future release exposes parallel inference.
+**Concurrency note.** Each session has independent history, system prompts, sampling, and lifecycle. Scheduling across different native sessions is browser-defined, so do not depend on token-level interleaving or a particular parallelism policy.
 
 ## React
 
@@ -131,7 +131,7 @@ export function Chat({ persona }: { persona: string }) {
 }
 ```
 
-`useSession` is lifecycle-only: it starts in `"loading"` while the native `LanguageModel.create()` call is in flight, moves to `"ready"` when `session` is usable, destroys the session on unmount, and recreates it when any primitive option changes. It deliberately does **not** track `response` / `history` / streaming status — that's your UI state, you own it. Each `useSession()` call owns its own underlying `LanguageModelInstance`, so component state and `abort()` / `destroy()` stay scoped to the owning component. Token-level interleaving across sessions is browser-defined (see the Concurrency note above) — Chrome 148 / Edge 138 currently drain through one underlying model FIFO.
+`useSession` is lifecycle-only: it starts in `"loading"` while the native `LanguageModel.create()` call is in flight, moves to `"ready"` when `session` is usable, destroys the session on unmount, and recreates it when any primitive option changes. It deliberately does **not** track `response` / `history` / streaming status — that's your UI state, you own it. Each `useSession()` call owns its own underlying `LanguageModelInstance`, so component state and `abort()` / `destroy()` stay scoped to the owning component. Scheduling across sessions remains browser-defined (see the Concurrency note above).
 
 ## API
 
@@ -248,15 +248,15 @@ const tools: LanguageModelTool[] = [
 const session = createSession({ systemPrompt, tools });
 ```
 
-This is **pass-through only**: the SDK forwards `tools` and never calls `execute` itself. Whether the model actually invokes a tool depends on the browser. Native execution is **not** wired on current stable Chrome — the option is accepted but is a silent no-op, and the model may surface its tool call as plain text (a `tool_code` block) that your code must parse. The passthrough begins working automatically on browsers that ship native execution; until then, `responseConstraint` remains the robust default. The heuristic `tool_code` parser and the tool-execution loop are deliberately left in the consumer layer.
+This is **pass-through only**: the SDK forwards `tools` and never calls `execute` itself. Native tool execution depends on the browser implementation, so treat it as experimental and provide a fallback. Parsing model-emitted tool-like text and running a manual execution loop are deliberately left in the consumer layer.
 
-`tools` works on `ask()` too (`ask({ input, tools })`), with one caveat: `ask()` may keep warm base sessions through an LRU keyed by `JSON.stringify(createOptions)`, and `JSON.stringify` drops functions — so a tool's `execute` doesn't contribute to the key, only its `name` / `description` / `inputSchema` do. Each `ask()` prompt still runs on a clone or fresh one-shot instance. It's harmless today (the SDK never runs `execute`), but it matters once native execution lands, so prefer `createSession()` for tool-bearing sessions — it bypasses the cache and matches the base-session + per-run-`clone()` pattern.
+`tools` works on `ask()` too (`ask({ input, tools })`), with one caveat: `ask()` may keep warm base sessions through an LRU keyed by `JSON.stringify(createOptions)`, and `JSON.stringify` drops functions — so a tool's `execute` doesn't contribute to the key, only its `name` / `description` / `inputSchema` do. Each `ask()` prompt still runs on a clone or fresh one-shot instance. Prefer `createSession()` for tool-bearing sessions: it bypasses the cache and matches the base-session + per-run-`clone()` pattern.
 
 To declare the native tool modalities, pass them through the advanced `expectedInputs` / `expectedOutputs` fields (`{ type: "tool-response" }` / `{ type: "tool-call" }`).
 
 ### Session resilience: base + per-task `clone()`
 
-For agents and multi-task flows, reusing one long-lived session lets history accumulate (later runs "echo" earlier ones, and you eventually hit `QuotaExceededError`), while recreating a session per task pays the cold start and can hit Chrome's single-instance degradation. The spec's [recommended pattern](https://developer.chrome.com/docs/ai/session-management) is to keep one warm **base** session (system prompt only) and `clone()` it per task: the clone inherits the system prompt and history without re-parsing or another `create()`, then gets independent history and lifecycle.
+For agents and multi-task flows, reusing one long-lived session lets unrelated history accumulate, while recreating a session per task repeats creation and instruction processing. Chrome's [session-management guidance](https://developer.chrome.com/docs/ai/session-management) recommends keeping one warm **base** session (system prompt only) and calling `clone()` per task: the clone inherits the system prompt without unrelated task history, then gets independent history and lifecycle.
 
 ```ts
 // As soon as the workflow is chosen, begin native creation with final instructions.
@@ -335,7 +335,7 @@ They compose: prefill the opening brace, set `responseConstraint` for the full s
 - `session.contextWindow` — max input tokens for the session (the context window).
 - `session.contextUsage` — input tokens used so far. On a fresh base-clone this reflects the inherited history (≈ the system prompt), the right baseline to budget a turn against.
 
-These mirror the Prompt API's `contextWindow` / `contextUsage` (the renamed successors of `inputQuota` / `inputUsage`); the wrapper reads the new names and falls back to the deprecated ones on older Chrome builds.
+These mirror the Prompt API's `contextWindow` / `contextUsage`; the wrapper also reads the deprecated `inputQuota` / `inputUsage` names for compatibility.
 
 ```ts
 const base = createSession({ systemPrompt }); // native creation starts here

--- a/packages/prompt/README.md
+++ b/packages/prompt/README.md
@@ -1,12 +1,20 @@
 # @web-ai-sdk/prompt
 
-web-ai-sdk building block for the Web's Built-in [Prompt API](https://developer.chrome.com/docs/ai/prompt-api) (`LanguageModel`). One-shot `ask()` for embeds and widgets, plus a thin `createSession()` primitive (and React `useSession`) for chat-shaped apps that need independent per-conversation sessions and delta-shaped streaming. The wrapper smooths cross-browser quirks (delta-vs-cumulative chunks, control-character cleanup, abort wiring); UI state and conversation history are the consumer's concern.
+This package wraps the Web's Built-in [Prompt API](https://developer.chrome.com/docs/ai/prompt-api) (`LanguageModel`). Use `ask()` for one-shot prompts. Use `createSession()` or React `useSession()` for conversations and delta streams.
+
+The package normalizes stream chunks, removes selected control characters, and wires abort signals. Application code owns UI state and message history.
 
 **Docs:** <https://web-ai-sdk.dev/docs/guides/prompt/> · **React:** [`usePrompt`](https://web-ai-sdk.dev/docs/react/use-prompt/) · [`useSession`](https://web-ai-sdk.dev/docs/react/use-session/) · **Production:** [Checklist](https://web-ai-sdk.dev/docs/production-checklist/)
 
 ## Status
 
-Prompt API [ships stable in Chrome 148+](https://developer.chrome.com/docs/ai/prompt-api) with no flag required. On Edge it is a [developer preview](https://learn.microsoft.com/en-us/microsoft-edge/web-platform/prompt-api) in Canary/Dev 138.0.3309.2+ behind "Prompt API for on-device language model." Phi-4-mini is the documented default and requires a High-or-greater device performance class; Canary/Dev 150.0.4070+ can optionally use the prerelease Aion-1.0-Instruct model on Medium/Low devices behind the additional "Enable prerelease on-device language model" flag. See [Browser support](https://web-ai-sdk.dev/docs/browser-support/) for the sourced matrix. On browsers without `LanguageModel`, the React hook stays `"unavailable"`; vanilla `ask()` throws `PromptUnavailableError` so callers can branch explicitly.
+Prompt API is [stable in Chrome 148+](https://developer.chrome.com/docs/ai/prompt-api). It does not require a flag.
+
+Edge provides a [Canary/Dev preview](https://learn.microsoft.com/en-us/microsoft-edge/web-platform/prompt-api) from 138.0.3309.2. Enable "Prompt API for on-device language model." Edge uses Phi-4-mini by default on High-class devices.
+
+Canary/Dev 150.0.4070+ can use prerelease Aion-1.0-Instruct on Medium/Low devices. This path requires the "Enable prerelease on-device language model" flag.
+
+See [Browser support](https://web-ai-sdk.dev/docs/browser-support/) for the full matrix. Without `LanguageModel`, React reports `"unavailable"` and `ask()` throws `PromptUnavailableError`.
 
 ## Install
 
@@ -15,7 +23,7 @@ pnpm add @web-ai-sdk/prompt
 # or: npm i @web-ai-sdk/prompt / bun add @web-ai-sdk/prompt
 ```
 
-The React adapter ships as a subpath export, with no extra install. `react` is a peer dependency only when you import the `/react` entry.
+The React adapter uses the `/react` subpath. `react` is an optional peer dependency.
 
 ## Vanilla TypeScript / DOM
 
@@ -58,9 +66,15 @@ const text = await session.send("And what about the Prompt API?");
 session.destroy();
 ```
 
-Every `createSession()` call returns an independent `LanguageModelInstance` with its own history, system prompt, sampling, and lifecycle — `abort()` / `destroy()` on one session never touch another. Concurrent `send` / `sendStreaming` calls on the **same** session are NOT queued — the underlying `LanguageModel` is sequential per instance and will reject the overlapping call with `InvalidStateError`. Either `await` the previous send or call `session.abort()` before issuing a new turn. Multi-turn conversation context is tracked by the native instance itself; UI message lists are your data model.
+Each `createSession()` call returns an independent `LanguageModelInstance`. It has its own history, system prompt, sampling, and lifecycle.
 
-Calling `createSession()` starts `LanguageModel.create()` immediately. The first `send`, `sendStreaming`, or `clone` only awaits that already-started creation, so creating a base session as soon as the user's intent is clear is a valid prewarming primitive. The synchronous `Session` wrapper is returned before native creation necessarily resolves; see [Context-window introspection](#context-window-introspection) for the resulting getter-readiness distinction.
+Calls on the same session are not queued. An overlapping `send()` or `sendStreaming()` call fails with `InvalidStateError`. Await the current call or call `session.abort()` first.
+
+The native instance tracks conversation context. Your application owns the UI message list.
+
+`createSession()` starts `LanguageModel.create()` immediately. Create a base session when the workflow becomes known to start preparation early.
+
+The synchronous `Session` wrapper can return before native creation finishes. The first `send()`, `sendStreaming()`, or `clone()` waits for it. See [Context-window introspection](#context-window-introspection) for getter readiness.
 
 **Concurrency note.** Each session has independent history, system prompts, sampling, and lifecycle. Scheduling across different native sessions is browser-defined, so do not depend on token-level interleaving or a particular parallelism policy.
 
@@ -131,7 +145,9 @@ export function Chat({ persona }: { persona: string }) {
 }
 ```
 
-`useSession` is lifecycle-only: it starts in `"loading"` while the native `LanguageModel.create()` call is in flight, moves to `"ready"` when `session` is usable, destroys the session on unmount, and recreates it when any primitive option changes. It deliberately does **not** track `response` / `history` / streaming status — that's your UI state, you own it. Each `useSession()` call owns its own underlying `LanguageModelInstance`, so component state and `abort()` / `destroy()` stay scoped to the owning component. Scheduling across sessions remains browser-defined (see the Concurrency note above).
+`useSession` manages lifecycle only. It reports `"loading"` during native creation and `"ready"` when the session is usable. It destroys the session on unmount and recreates it when a primitive option changes.
+
+The hook does not track responses, history, or streaming status. Keep that state in your component. Each hook call owns one native instance. Scheduling across instances is browser-defined.
 
 ## API
 
@@ -248,15 +264,21 @@ const tools: LanguageModelTool[] = [
 const session = createSession({ systemPrompt, tools });
 ```
 
-This is **pass-through only**: the SDK forwards `tools` and never calls `execute` itself. Native tool execution depends on the browser implementation, so treat it as experimental and provide a fallback. Parsing model-emitted tool-like text and running a manual execution loop are deliberately left in the consumer layer.
+The SDK only forwards `tools`; it does not call `execute`. Native tool execution depends on the browser. Treat it as experimental and provide a fallback.
 
-`tools` works on `ask()` too (`ask({ input, tools })`), with one caveat: `ask()` may keep warm base sessions through an LRU keyed by `JSON.stringify(createOptions)`, and `JSON.stringify` drops functions — so a tool's `execute` doesn't contribute to the key, only its `name` / `description` / `inputSchema` do. Each `ask()` prompt still runs on a clone or fresh one-shot instance. Prefer `createSession()` for tool-bearing sessions: it bypasses the cache and matches the base-session + per-run-`clone()` pattern.
+Your application must parse tool-like model output and run any manual execution loop.
+
+`tools` also works with `ask({ input, tools })`. Its base-session cache key uses `JSON.stringify(createOptions)`, which excludes functions. A tool's `execute` function does not affect the key; its metadata does.
+
+Each `ask()` call still uses a clone or fresh instance. Prefer `createSession()` for tool-based sessions because it bypasses this cache.
 
 To declare the native tool modalities, pass them through the advanced `expectedInputs` / `expectedOutputs` fields (`{ type: "tool-response" }` / `{ type: "tool-call" }`).
 
 ### Session resilience: base + per-task `clone()`
 
-For agents and multi-task flows, reusing one long-lived session lets unrelated history accumulate, while recreating a session per task repeats creation and instruction processing. Chrome's [session-management guidance](https://developer.chrome.com/docs/ai/session-management) recommends keeping one warm **base** session (system prompt only) and calling `clone()` per task: the clone inherits the system prompt without unrelated task history, then gets independent history and lifecycle.
+Do not reuse one session across unrelated tasks. Its history will continue to grow. Creating a new session for every task repeats setup work.
+
+Chrome's [session-management guidance](https://developer.chrome.com/docs/ai/session-management) recommends a warm base session with only the system prompt. Call `clone()` for each task. Each clone inherits the prompt but has independent history and lifecycle.
 
 ```ts
 // As soon as the workflow is chosen, begin native creation with final instructions.
@@ -324,13 +346,15 @@ const json = await session.send([
 
 They compose: prefill the opening brace, set `responseConstraint` for the full shape.
 
-**Spec rule:** `prefix: true` is only valid on the **trailing** `assistant` message. Anywhere else (a non-final message, a non-assistant role) the browser throws a `"SyntaxError"` `DOMException`. The SDK does **not** catch this, so it propagates to your `send` / `sendStreaming` caller.
+**Spec rule:** `prefix: true` is valid only on the final `assistant` message. Other uses cause a `"SyntaxError"` `DOMException`. The SDK passes this error to the caller.
 
 > **Note on `content`:** `LanguageModelMessage.content` is currently `string` only. Multimodal `ContentPart[]` content (images, audio) is tracked as a future enhancement; no timeline is promised.
 
 ### Context-window introspection
 
-`Session` surfaces the live token budget the native instance reports, so consumers can size work to the actual context window instead of hardcoding a char cap. Calling `createSession()` starts native creation eagerly, but the wrapper returns synchronously: both getters remain `undefined` while that creation promise is in flight. The first `send` awaits the already-started creation; alternatively, read the getters on a session from `clone()`, whose instance is live the moment `clone()` resolves. In React, `useSession` does not report `"ready"` until the same native creation has resolved.
+`Session` exposes the token budget reported by the native instance. Use it to size input for the current context window.
+
+Both getters are `undefined` until native creation finishes. The first `send()` waits for creation. A resolved `clone()` is ready immediately. In React, `useSession` reports `"ready"` after creation finishes.
 
 - `session.contextWindow` — max input tokens for the session (the context window).
 - `session.contextUsage` — input tokens used so far. On a fresh base-clone this reflects the inherited history (≈ the system prompt), the right baseline to budget a turn against.
@@ -351,7 +375,9 @@ if (quota) {
 // (older browsers / pre-creation).
 ```
 
-`session.onContextOverflow(listener)` subscribes to the native `contextoverflow` event, which fires when a turn pushes usage past the window and the oldest history is dropped. Use it to compact or fork a fresh `clone()` before hitting `QuotaExceededError`. It returns an idempotent cleanup function, and is a no-op (returns a no-op cleanup) when the instance doesn't expose the event.
+`session.onContextOverflow(listener)` subscribes to the native `contextoverflow` event. The event fires when a turn exceeds the window and drops the oldest history.
+
+Use it to compact history or create a fresh clone before `QuotaExceededError`. It returns an idempotent cleanup function. Unsupported instances return a no-op cleanup.
 
 ```ts
 const stop = session.onContextOverflow(() => {
@@ -371,7 +397,9 @@ interface UseSessionReturn {
 }
 ```
 
-Lifecycle-only: feature detection + create + destroy on unmount + recreate when any primitive option (`systemPrompt`, `samplingMode`, `temperature`, `topK`, `language`) changes. Object options (`expectedInputs`, `createOptions`) participate by reference; memoize them or accept the recreate cost. UI state is your concern — iterate `session.sendStreaming()` and accumulate text into your own component state.
+The hook detects support, creates a session, and destroys it on unmount. It recreates the session when a primitive option changes.
+
+Object options participate by reference. Memoize them to avoid recreation. Store streamed output and other UI state in your component.
 
 ### `isAvailable(): boolean`
 
@@ -385,7 +413,7 @@ Forwards to `LanguageModel.availability()`. Returns `null` if the global is miss
 
 Two layers, same as `@web-ai-sdk/summarizer`:
 
-- **Session cache** (internal, in-memory, on by default for `ask()` only): a bounded LRU of warm base `LanguageModel` instances keyed by stringified create-options. Cold-start ≈ 1-3s; when `clone()` is supported, warm calls can skip re-parsing the same base instructions while still prompting on an isolated clone. `createSession()` bypasses this cache entirely.
+- **Session cache** (internal, in-memory, on for `ask()`): a bounded LRU of base instances keyed by serialized creation options. When supported, each call uses an isolated clone. `createSession()` bypasses this cache.
 - **Result cache** (opt-in): pass a `cache` (anything matching `{ get, set }`) to memoize final responses by `(input, systemPrompt, samplingMode / temperature / topK)`. Omit it for a fresh model call every time.
 
 ```ts
@@ -406,9 +434,11 @@ ask({ input: "hi", cache: myMap, cacheKey: "greeting" });
 
 The vanilla `ask()` throws `PromptUnavailableError` when the API is missing or reports `availability: "unavailable"`. The React hook absorbs this and returns `status: "unavailable"` instead.
 
-`createSession()` starts native creation immediately and returns a `Session` wrapper synchronously. If the underlying `create()` rejects, the error surfaces when the first `send`, `sendStreaming`, or `clone` awaits that already-started work. In React, `useSession()` waits for native creation before reporting `"ready"` and reports `"unavailable"` with `error` if creation fails.
+`createSession()` starts native creation and returns a `Session` wrapper immediately. If creation fails, the first `send()`, `sendStreaming()`, or `clone()` reports the error.
 
-`AbortSignal` is supported on every surface. Aborting mid-stream resolves cleanly; the result cache is not written for aborted runs. Aborts reject with `PromptAbortError` (exported; `instanceof PromptAbortError` works, and its `name` is `"AbortError"`), thrown by both `ask()` and sessions.
+In React, `useSession()` waits for creation before reporting `"ready"`. It reports `"unavailable"` and stores the error when creation fails.
+
+Every API accepts `AbortSignal`. An aborted run does not write to the result cache. Both `ask()` and sessions reject with the exported `PromptAbortError`. Its `name` is `"AbortError"`.
 
 ## License
 

--- a/packages/prompt/src/api.ts
+++ b/packages/prompt/src/api.ts
@@ -1,6 +1,5 @@
 /**
- * Adapter over the global `LanguageModel` API exposed by Chrome (behind
- * `chrome://flags/#prompt-api-for-gemini-nano`). Feature-detected; on browsers
+ * Adapter over the global `LanguageModel` API. Feature-detected; on browsers
  * without it, every entry point returns `null` so callers can stay declarative.
  *
  * Spec: https://github.com/webmachinelearning/prompt-api
@@ -81,16 +80,12 @@ export interface LanguageModelCreateOptions {
   expectedInputs?: LanguageModelExpectedInput[];
   expectedOutputs?: LanguageModelExpectedOutput[];
   signal?: AbortSignal;
-  /** Observe the first-call model download (~1.7 GB on a fresh profile). */
+  /** Observe model-download progress when creation requires one. */
   monitor?: (m: CreateMonitor) => void;
   /**
-   * @experimental Forwards `tools` to the browser's Prompt API
-   * (function calling). Whether the model actually INVOKES them depends
-   * on the browser: native execution is NOT wired on current stable
-   * Chrome — the option is accepted but a no-op, and the model may
-   * surface its tool call as TEXT (`tool_code`) that the caller must
-   * parse. Pass-through only: the SDK does not execute the tools. Will
-   * begin working automatically on browsers that ship native execution.
+   * @experimental Forwards `tools` to the browser's Prompt API (function
+   * calling). Support remains browser-defined. Pass-through only: the SDK does
+   * not execute tools or parse text that resembles a tool call.
    */
   tools?: LanguageModelTool[];
 }

--- a/packages/prompt/src/index.ts
+++ b/packages/prompt/src/index.ts
@@ -98,13 +98,9 @@ export interface AskOptions {
   /** Advanced: full `expectedOutputs` passthrough. Overrides the `language` hint. */
   expectedOutputs?: LanguageModelExpectedOutput[];
   /**
-   * @experimental Forwards `tools` to the browser's Prompt API
-   * (function calling). Whether the model actually INVOKES them depends
-   * on the browser: native execution is NOT wired on current stable
-   * Chrome — the option is accepted but a no-op, and the model may
-   * surface its tool call as TEXT (`tool_code`) that the caller must
-   * parse. Pass-through only: the SDK does not execute the tools. Will
-   * begin working automatically on browsers that ship native execution.
+   * @experimental Forwards `tools` to the browser's Prompt API (function
+   * calling). Support remains browser-defined. Pass-through only: the SDK does
+   * not execute tools or parse text that resembles a tool call.
    */
   tools?: LanguageModelTool[];
   /** Observe the first-call model download. */

--- a/packages/prompt/src/react/index.ts
+++ b/packages/prompt/src/react/index.ts
@@ -154,11 +154,9 @@ export interface UseSessionReturn {
  * or when any primitive option (`systemPrompt`, `samplingMode`,
  * `temperature`, `topK`, `language`, `enabled`, `monitor`) changes.
  *
- * Token-level interleaving across sessions is browser-defined: the
- * underlying on-device model is single-instance, so Chrome 148 / Edge 138
- * currently serialize `sendStreaming` calls across sessions FIFO. The
- * second component's send waits for the first to drain. The API is
- * forward-compatible for runtimes that expose parallel inference.
+ * Token-level interleaving across independent sessions is browser-defined.
+ * Components should not depend on parallel inference or a particular
+ * scheduling order.
  *
  * The hook intentionally does **not** track `output` / `history` /
  * streaming status. Iterate `session.sendStreaming()` yourself and keep UI

--- a/packages/prompt/src/session.ts
+++ b/packages/prompt/src/session.ts
@@ -79,10 +79,8 @@ export const buildLangHints = (
  *     U+2060..U+206F)
  *   - BOM (U+FEFF)
  *
- * Edge's safety pipeline has been observed returning runs of `` (CANCEL)
- * as a "soft block" placeholder instead of throwing or returning empty;
- * these strip away here so callers can treat empty-after-clean as "model
- * returned nothing meaningful."
+ * Stripping these characters lets callers treat empty-after-clean as "model
+ * returned nothing meaningful" without exposing invisible control text.
  */
 const NON_PRINTING = new RegExp(
   "[" +
@@ -114,11 +112,10 @@ export const cleanResponse = (raw: string): string =>
   stripNonPrinting(raw).trim();
 
 /**
- * The W3C Web AI streaming contract is ambiguous between "delta" (each chunk
- * is new content) and "cumulative" (each chunk is the full text so far).
- * Chrome ships delta; some Edge backends (notably Phi-Silica on Copilot+
- * PCs) ship cumulative. Detect per-chunk: if the chunk starts with the prior
- * buffer, treat as cumulative (replace); otherwise treat as delta (append).
+ * Browser implementations may emit "delta" chunks (each chunk is new content)
+ * or "cumulative" chunks (each chunk is the full text so far). Detect the
+ * shape per chunk: if it starts with the prior buffer, replace; otherwise
+ * append.
  *
  * Returns `{ buffer, delta }` so streaming surfaces can decide whether to
  * hand callers cumulative text (`buffer`) or the new piece (`delta`).
@@ -172,18 +169,14 @@ export interface CreateSessionOptions {
   /** Advanced: full `expectedOutputs` passthrough. Overrides the `language` hint. */
   expectedOutputs?: LanguageModelExpectedOutput[];
   /**
-   * @experimental Forwards `tools` to the browser's Prompt API
-   * (function calling). Whether the model actually INVOKES them depends
-   * on the browser: native execution is NOT wired on current stable
-   * Chrome — the option is accepted but a no-op, and the model may
-   * surface its tool call as TEXT (`tool_code`) that the caller must
-   * parse. Pass-through only: the SDK does not execute the tools. Will
-   * begin working automatically on browsers that ship native execution.
+   * @experimental Forwards `tools` to the browser's Prompt API (function
+   * calling). Support remains browser-defined. Pass-through only: the SDK does
+   * not execute tools or parse text that resembles a tool call.
    */
   tools?: LanguageModelTool[];
   /**
-   * Observe the first-call model download (~1.7 GB on a fresh profile).
-   * Forwarded to `LanguageModel.create()`. When both this and
+   * Observe model-download progress when creation requires one. Forwarded to
+   * `LanguageModel.create()`. When both this and
    * `createOptions.monitor` are set, the top-level `monitor` wins.
    */
   monitor?: (m: CreateMonitor) => void;
@@ -626,7 +619,7 @@ const wrapInstance = (
     },
     get contextWindow() {
       // Prefer the current canonical name; fall back to the deprecated
-      // `inputQuota` so older Chrome builds still report a budget.
+      // `inputQuota` so older implementations still report a budget.
       return liveInstance?.contextWindow ?? liveInstance?.inputQuota;
     },
     get contextUsage() {
@@ -648,13 +641,9 @@ const wrapInstance = (
  * its own history, system prompt, sampling, and lifecycle. `abort()` /
  * `destroy()` on one session never affect another.
  *
- * Token-level interleaving across sessions is implementation-defined and
- * currently bottlenecked by the browser's FIFO scheduler — the underlying
- * on-device model is single-instance, so Chrome 148 / Edge 138 drain one
- * `sendStreaming` call fully before starting the next, even across
- * independent sessions. The API is forward-compatible: code written against
- * `createSession()` becomes faster automatically if a future release
- * exposes parallel inference.
+ * Token-level interleaving across independent sessions is browser-defined.
+ * Consumers should not depend on parallel inference or a particular scheduling
+ * order.
  *
  * Concurrent `send` / `sendStreaming` calls on the same session are NOT
  * queued; the native `LanguageModel` is sequential per instance and will

--- a/packages/proofreader/README.md
+++ b/packages/proofreader/README.md
@@ -2,13 +2,11 @@
 
 web-ai-sdk building block for the Web's Built-in [Proofreader API](https://developer.chrome.com/docs/ai/proofreader-api). Corrects grammar, spelling, and punctuation and returns per-issue corrections with offsets, plus session reuse and opt-in result caching.
 
-**Docs:** <https://web-ai-sdk.dev/docs/guides/proofreader/> · **React:** [`useProofreader`](https://web-ai-sdk.dev/docs/react/use-proofreader/)
+**Docs:** <https://web-ai-sdk.dev/docs/guides/proofreader/> · **React:** [`useProofreader`](https://web-ai-sdk.dev/docs/react/use-proofreader/) · **Production:** [Checklist](https://web-ai-sdk.dev/docs/production-checklist/)
 
 ## Status
 
-The Proofreader API is in an origin trial in Chrome 141 to 145, behind `chrome://flags/#proofreader-api-for-gemini-nano` on localhost (`chrome://flags/#optimization-guide-on-device-model` must also be enabled). In Edge it's a developer preview in Canary/Dev 142+ behind "Proofreader API for Phi mini". On any other browser this library is a no-op for the React hook (it stays in `"unavailable"`). The vanilla `proofread()` throws `ProofreaderUnavailableError` so callers can branch explicitly.
-
-The API is **English-only** today. `expectedInputLanguages` accepts an array, but a request for an unsupported language causes the underlying `create()` to reject (surfaced here as `ProofreaderUnavailableError`); pass `["en"]` or omit it.
+Chrome's current [Built-in AI status table](https://developer.chrome.com/docs/ai/built-in-apis) labels Proofreader a **Developer trial**. Its public origin-trial window ran from Chrome 141 through 145 and has ended; the [Proofreader docs](https://developer.chrome.com/docs/ai/proofreader-api) list `chrome://flags/#proofreader-api` for localhost testing. In Edge it is a [developer preview](https://learn.microsoft.com/en-us/microsoft-edge/web-platform/proofreader-api) in Canary/Dev 142+ behind "Proofreader API for Phi mini," with a documented High-or-greater device performance class requirement. On browsers without `Proofreader`, the React hook stays `"unavailable"`; vanilla `proofread()` throws `ProofreaderUnavailableError` so callers can branch explicitly.
 
 ## Install
 
@@ -71,8 +69,8 @@ interface ProofreadCorrection {
   startIndex: number;     // inclusive offset into the original input
   endIndex: number;       // exclusive offset into the original input
   correction: string;     // suggested replacement
-  type?: string;          // not emitted by Chrome's current build
-  explanation?: string;   // not emitted by Chrome's current build
+  type?: string;          // optional platform metadata
+  explanation?: string;   // optional platform metadata
 }
 
 interface ProofreadOutput {

--- a/packages/proofreader/README.md
+++ b/packages/proofreader/README.md
@@ -1,12 +1,16 @@
 # @web-ai-sdk/proofreader
 
-web-ai-sdk building block for the Web's Built-in [Proofreader API](https://developer.chrome.com/docs/ai/proofreader-api). Corrects grammar, spelling, and punctuation and returns per-issue corrections with offsets, plus session reuse and opt-in result caching.
+This package wraps the Web's Built-in [Proofreader API](https://developer.chrome.com/docs/ai/proofreader-api). It returns corrected text and an offset for each issue. It also provides session reuse and optional result caching.
 
 **Docs:** <https://web-ai-sdk.dev/docs/guides/proofreader/> · **React:** [`useProofreader`](https://web-ai-sdk.dev/docs/react/use-proofreader/) · **Production:** [Checklist](https://web-ai-sdk.dev/docs/production-checklist/)
 
 ## Status
 
-Chrome's current [Built-in AI status table](https://developer.chrome.com/docs/ai/built-in-apis) labels Proofreader a **Developer trial**. Its public origin-trial window ran from Chrome 141 through 145 and has ended; the [Proofreader docs](https://developer.chrome.com/docs/ai/proofreader-api) list `chrome://flags/#proofreader-api` for localhost testing. In Edge it is a [developer preview](https://learn.microsoft.com/en-us/microsoft-edge/web-platform/proofreader-api) in Canary/Dev 142+ behind "Proofreader API for Phi mini," with a documented High-or-greater device performance class requirement. On browsers without `Proofreader`, the React hook stays `"unavailable"`; vanilla `proofread()` throws `ProofreaderUnavailableError` so callers can branch explicitly.
+Chrome labels Proofreader a **Developer trial** in its [status table](https://developer.chrome.com/docs/ai/built-in-apis). The public origin trial for Chrome 141–145 has ended. For localhost, enable `chrome://flags/#proofreader-api`.
+
+Edge provides a [Canary/Dev preview](https://learn.microsoft.com/en-us/microsoft-edge/web-platform/proofreader-api) from 142. Enable "Proofreader API for Phi mini." Edge requires a High device-performance class or greater.
+
+Without `Proofreader`, React reports `"unavailable"` and `proofread()` throws `ProofreaderUnavailableError`.
 
 ## Install
 
@@ -15,7 +19,7 @@ pnpm add @web-ai-sdk/proofreader
 # or: npm i @web-ai-sdk/proofreader / bun add @web-ai-sdk/proofreader
 ```
 
-The React adapter ships as a subpath export, with no extra install. `react` is a peer dependency only when you import the `/react` entry.
+The React adapter uses the `/react` subpath. `react` is an optional peer dependency.
 
 ## Vanilla TypeScript / DOM
 

--- a/packages/proofreader/src/api.ts
+++ b/packages/proofreader/src/api.ts
@@ -1,8 +1,6 @@
 /**
- * Adapter over the global `Proofreader` API exposed by Chrome (behind
- * `chrome://flags/#proofreader-api-for-gemini-nano`). Feature-detected; on
- * browsers without it, every entry point returns `null` so callers can stay
- * declarative.
+ * Adapter over the global `Proofreader` API. Feature-detected; on browsers
+ * without it, every entry point returns `null` so callers can stay declarative.
  *
  * Spec: https://developer.chrome.com/docs/ai/proofreader-api
  */
@@ -25,9 +23,9 @@ export interface ProofreadCorrection {
   endIndex: number;
   /** The suggested replacement for `input.slice(startIndex, endIndex)`. */
   correction: string;
-  /** Error label (e.g. `"spelling"`). Not emitted by Chrome's current build. */
+  /** Optional error label (for example, `"spelling"`). */
   type?: string;
-  /** Plain-language explanation. Not emitted by Chrome's current build. */
+  /** Optional plain-language explanation. */
   explanation?: string;
 }
 

--- a/packages/rewriter/README.md
+++ b/packages/rewriter/README.md
@@ -1,12 +1,16 @@
 # @web-ai-sdk/rewriter
 
-web-ai-sdk building block for the Web's Built-in [Rewriter API](https://developer.chrome.com/docs/ai/rewriter-api). Revises and restructures existing text with tone / length adjustments, session reuse, streaming, and opt-in result caching.
+This package wraps the Web's Built-in [Rewriter API](https://developer.chrome.com/docs/ai/rewriter-api). It changes the tone or length of text. It also provides session reuse, streaming, and optional result caching.
 
 **Docs:** <https://web-ai-sdk.dev/docs/guides/rewriter/> · **React:** [`useRewriter`](https://web-ai-sdk.dev/docs/react/use-rewriter/) · **Production:** [Checklist](https://web-ai-sdk.dev/docs/production-checklist/)
 
 ## Status
 
-Chrome's current [Built-in AI status table](https://developer.chrome.com/docs/ai/built-in-apis) labels Rewriter a **Developer trial**. Its public joint origin-trial window with Writer ran from Chrome 137 through 148 and has ended; the [Rewriter docs](https://developer.chrome.com/docs/ai/rewriter-api) list the current localhost flags. In Edge it is a [developer preview](https://learn.microsoft.com/en-us/microsoft-edge/web-platform/writing-assistance-apis) in Canary/Dev 138.0.3309.2+ behind "Rewriter API for on-device language model." On browsers without `Rewriter`, the React hook stays `"unavailable"`; vanilla `rewrite()` throws `RewriterUnavailableError` so callers can branch explicitly.
+Chrome labels Rewriter a **Developer trial** in its [status table](https://developer.chrome.com/docs/ai/built-in-apis). The public origin trial for Chrome 137–148 has ended. See the [Rewriter guide](https://developer.chrome.com/docs/ai/rewriter-api) for current localhost flags.
+
+Edge provides a [Canary/Dev preview](https://learn.microsoft.com/en-us/microsoft-edge/web-platform/writing-assistance-apis) from 138.0.3309.2. Enable "Rewriter API for on-device language model."
+
+Without `Rewriter`, React reports `"unavailable"` and `rewrite()` throws `RewriterUnavailableError`.
 
 ## Install
 
@@ -15,7 +19,7 @@ pnpm add @web-ai-sdk/rewriter
 # or: npm i @web-ai-sdk/rewriter / bun add @web-ai-sdk/rewriter
 ```
 
-The React adapter ships as a subpath export, with no extra install. `react` is a peer dependency only when you import the `/react` entry.
+The React adapter uses the `/react` subpath. `react` is an optional peer dependency.
 
 ## Vanilla TypeScript / DOM
 

--- a/packages/rewriter/README.md
+++ b/packages/rewriter/README.md
@@ -2,11 +2,11 @@
 
 web-ai-sdk building block for the Web's Built-in [Rewriter API](https://developer.chrome.com/docs/ai/rewriter-api). Revises and restructures existing text with tone / length adjustments, session reuse, streaming, and opt-in result caching.
 
-**Docs:** <https://web-ai-sdk.dev/docs/guides/rewriter/> · **React:** [`useRewriter`](https://web-ai-sdk.dev/docs/react/use-rewriter/)
+**Docs:** <https://web-ai-sdk.dev/docs/guides/rewriter/> · **React:** [`useRewriter`](https://web-ai-sdk.dev/docs/react/use-rewriter/) · **Production:** [Checklist](https://web-ai-sdk.dev/docs/production-checklist/)
 
 ## Status
 
-The Rewriter API is in a developer trial (origin trial) in Chrome 137 to 148. It shares the Writer's joint trial, so it's enabled via the same `chrome://flags/#writer-api-for-gemini-nano` flag on localhost (there is no separate Rewriter flag; `chrome://flags/#optimization-guide-on-device-model` must also be enabled). In Edge it's a developer preview in Canary/Dev 138+ behind "Rewriter API for Phi mini". On any other browser this library is a no-op for the React hook (it stays in `"unavailable"`). The vanilla `rewrite()` throws `RewriterUnavailableError` so callers can branch explicitly.
+Chrome's current [Built-in AI status table](https://developer.chrome.com/docs/ai/built-in-apis) labels Rewriter a **Developer trial**. Its public joint origin-trial window with Writer ran from Chrome 137 through 148 and has ended; the [Rewriter docs](https://developer.chrome.com/docs/ai/rewriter-api) list the current localhost flags. In Edge it is a [developer preview](https://learn.microsoft.com/en-us/microsoft-edge/web-platform/writing-assistance-apis) in Canary/Dev 138.0.3309.2+ behind "Rewriter API for on-device language model." On browsers without `Rewriter`, the React hook stays `"unavailable"`; vanilla `rewrite()` throws `RewriterUnavailableError` so callers can branch explicitly.
 
 ## Install
 

--- a/packages/rewriter/src/api.ts
+++ b/packages/rewriter/src/api.ts
@@ -1,9 +1,6 @@
 /**
- * Adapter over the global `Rewriter` API exposed by Chrome. The Rewriter
- * shares the Writer's joint origin trial and is enabled via the same
- * `chrome://flags/#writer-api-for-gemini-nano` flag (there is no separate
- * Rewriter flag). Feature-detected; on browsers without it, every entry
- * point returns `null` so callers can stay declarative.
+ * Adapter over the global `Rewriter` API. Feature-detected; on browsers
+ * without it, every entry point returns `null` so callers can stay declarative.
  *
  * Spec: https://developer.chrome.com/docs/ai/rewriter-api
  */

--- a/packages/rewriter/src/index.ts
+++ b/packages/rewriter/src/index.ts
@@ -218,10 +218,8 @@ export const rewrite = async (
     ...(options.signal ? { signal: options.signal } : {}),
   };
 
-  // The W3C Web AI streaming contract is ambiguous between "delta" (each
-  // chunk is new content) and "cumulative" (each chunk is the full text so
-  // far). Chrome ships delta; some backends ship cumulative. Detect
-  // per-chunk and merge accordingly.
+  // Browser implementations may emit delta or cumulative chunks. Detect the
+  // shape per chunk and merge accordingly.
   const mergeChunk = (buffer: string, chunk: string): string =>
     chunk.startsWith(buffer) ? chunk : buffer + chunk;
 

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -1,12 +1,12 @@
 # @web-ai-sdk/all
 
-One-install meta-package for web-ai-sdk, the TypeScript SDK for the Web AI surface. Pulls in every `@web-ai-sdk/*` building block: `prompt`, `summarizer`, `translator`, `detector`, `writer`, `rewriter`, `proofreader`, and `webmcp`, each as a regular dependency so consumers don't have to track them individually.
+Install all eight wrappers through one package: `prompt`, `summarizer`, `translator`, `detector`, `writer`, `rewriter`, `proofreader`, and `webmcp`.
 
 **Docs:** <https://web-ai-sdk.dev/docs/guides/meta-package/> · **Production:** [Checklist](https://web-ai-sdk.dev/docs/production-checklist/)
 
 ## Status
 
-Each underlying package tracks its browser capability independently: some APIs are stable, while others require a developer preview, developer trial, or origin trial. See the sourced [browser-support matrix](https://web-ai-sdk.dev/docs/browser-support/) and per-package READMEs for current details:
+Browser support differs by capability. See the [browser-support matrix](https://web-ai-sdk.dev/docs/browser-support/) and package READMEs for current status:
 
 - [`@web-ai-sdk/prompt`](https://github.com/obetomuniz/web-ai-sdk/tree/main/packages/prompt)
 - [`@web-ai-sdk/summarizer`](https://github.com/obetomuniz/web-ai-sdk/tree/main/packages/summarizer)

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -2,11 +2,11 @@
 
 One-install meta-package for web-ai-sdk, the TypeScript SDK for the Web AI surface. Pulls in every `@web-ai-sdk/*` building block: `prompt`, `summarizer`, `translator`, `detector`, `writer`, `rewriter`, `proofreader`, and `webmcp`, each as a regular dependency so consumers don't have to track them individually.
 
-**Docs:** <https://web-ai-sdk.dev/docs/guides/meta-package/>
+**Docs:** <https://web-ai-sdk.dev/docs/guides/meta-package/> · **Production:** [Checklist](https://web-ai-sdk.dev/docs/production-checklist/)
 
 ## Status
 
-Each underlying scoped package is independently supported in Chrome / Edge with the corresponding Web AI flag enabled. See the per-package READMEs for browser support details:
+Each underlying package tracks its browser capability independently: some APIs are stable, while others require a developer preview, developer trial, or origin trial. See the sourced [browser-support matrix](https://web-ai-sdk.dev/docs/browser-support/) and per-package READMEs for current details:
 
 - [`@web-ai-sdk/prompt`](https://github.com/obetomuniz/web-ai-sdk/tree/main/packages/prompt)
 - [`@web-ai-sdk/summarizer`](https://github.com/obetomuniz/web-ai-sdk/tree/main/packages/summarizer)

--- a/packages/summarizer/README.md
+++ b/packages/summarizer/README.md
@@ -1,12 +1,14 @@
 # @web-ai-sdk/summarizer
 
-web-ai-sdk building block for the Web's Built-in [Summarizer API](https://developer.chrome.com/docs/ai/summarizer-api). String-mode summarization with session reuse, output cleaning, streaming, and opt-in result caching.
+This package wraps the Web's Built-in [Summarizer API](https://developer.chrome.com/docs/ai/summarizer-api). It provides session reuse, output cleanup, streaming, and optional result caching.
 
 **Docs:** <https://web-ai-sdk.dev/docs/guides/summarizer/> · **React:** [`useSummarizer`](https://web-ai-sdk.dev/docs/react/use-summarizer/) · **Production:** [Checklist](https://web-ai-sdk.dev/docs/production-checklist/)
 
 ## Status
 
-Summarizer API is stable in Chrome 138+ and enabled by default in Edge 138+, per the [Chrome status table](https://developer.chrome.com/docs/ai/built-in-apis) and [Edge Writing Assistance API docs](https://learn.microsoft.com/en-us/microsoft-edge/web-platform/writing-assistance-apis). On browsers without `Summarizer`, the React hook stays `"unavailable"`; vanilla `summarize()` throws `SummarizerUnavailableError` so callers can branch explicitly.
+Summarizer is stable in Chrome 138+ and enabled by default in Edge 138+. See the [Chrome status table](https://developer.chrome.com/docs/ai/built-in-apis) and [Edge guide](https://learn.microsoft.com/en-us/microsoft-edge/web-platform/writing-assistance-apis).
+
+Without `Summarizer`, React reports `"unavailable"` and `summarize()` throws `SummarizerUnavailableError`.
 
 ## Install
 
@@ -15,7 +17,7 @@ pnpm add @web-ai-sdk/summarizer
 # or: npm i @web-ai-sdk/summarizer / bun add @web-ai-sdk/summarizer
 ```
 
-The React adapter ships as a subpath export, with no extra install. `react` is a peer dependency only when you import the `/react` entry.
+The React adapter uses the `/react` subpath. `react` is an optional peer dependency.
 
 ## Vanilla TypeScript / DOM
 

--- a/packages/summarizer/README.md
+++ b/packages/summarizer/README.md
@@ -2,11 +2,11 @@
 
 web-ai-sdk building block for the Web's Built-in [Summarizer API](https://developer.chrome.com/docs/ai/summarizer-api). String-mode summarization with session reuse, output cleaning, streaming, and opt-in result caching.
 
-**Docs:** <https://web-ai-sdk.dev/docs/guides/summarizer/> · **React:** [`useSummarizer`](https://web-ai-sdk.dev/docs/react/use-summarizer/)
+**Docs:** <https://web-ai-sdk.dev/docs/guides/summarizer/> · **React:** [`useSummarizer`](https://web-ai-sdk.dev/docs/react/use-summarizer/) · **Production:** [Checklist](https://web-ai-sdk.dev/docs/production-checklist/)
 
 ## Status
 
-Summarizer API is stable in Chrome 138+ and Edge 138+ on desktop (enabled by default since Edge 138, per the [Edge Writing Assistance APIs docs](https://learn.microsoft.com/en-us/microsoft-edge/web-platform/writing-assistance-apis)). On Edge the Phi-4-mini safety pipeline frequently returns "low quality output blocked"; the library wraps that as a typed error. On any other browser this library is a no-op for the React hook (it stays in `"unavailable"`). The vanilla `summarize()` throws `SummarizerUnavailableError` so callers can branch explicitly.
+Summarizer API is stable in Chrome 138+ and enabled by default in Edge 138+, per the [Chrome status table](https://developer.chrome.com/docs/ai/built-in-apis) and [Edge Writing Assistance API docs](https://learn.microsoft.com/en-us/microsoft-edge/web-platform/writing-assistance-apis). On browsers without `Summarizer`, the React hook stays `"unavailable"`; vanilla `summarize()` throws `SummarizerUnavailableError` so callers can branch explicitly.
 
 ## Install
 
@@ -130,7 +130,7 @@ The wrapper strips wrapping quotes / whitespace and collapses internal whitespac
 
 ## Language support
 
-The Web's Built-in Summarizer (Chrome 138+ and Edge 138+) accepts `expectedInputLanguages` / `outputLanguage` only for `["en", "es", "ja"]`. For other languages this library omits those hints and you steer output via `sharedContext` instead. Pass your own `supportedLanguages` if Chrome adds more.
+By default, the wrapper emits `expectedInputLanguages` / `outputLanguage` hints only for `["en", "es", "ja"]`. For other languages it omits those hints and you can steer output via `sharedContext` instead. Pass `supportedLanguages` explicitly when your target browser documents a broader set.
 
 ## License
 

--- a/packages/summarizer/src/api.ts
+++ b/packages/summarizer/src/api.ts
@@ -1,7 +1,6 @@
 /**
- * Adapter over the global `Summarizer` API exposed by Chrome 138+. Feature-
- * detected; on browsers without it, every entry point returns `null` so
- * callers can stay declarative.
+ * Adapter over the global `Summarizer` API. Feature-detected; on browsers
+ * without it, every entry point returns `null` so callers can stay declarative.
  *
  * Spec: https://developer.chrome.com/docs/ai/summarizer-api
  */
@@ -32,7 +31,7 @@ export interface SummarizerCreateOptions {
   expectedInputLanguages?: string[];
   expectedContextLanguages?: string[];
   outputLanguage?: string;
-  /** Observe the first-call model download (~1.7 GB on a fresh profile). */
+  /** Observe model-download progress when creation requires one. */
   monitor?: (m: CreateMonitor) => void;
 }
 
@@ -44,10 +43,8 @@ export type SummarizerAvailability =
 
 /**
  * Subset of `SummarizerCreateOptions` that the spec accepts when probing
- * availability. Edge enforces these strictly (e.g. fires a warning when
- * `outputLanguage` is missing); Chrome is more lenient. Pass the same
- * shape you'd pass to `create()` to get accurate, warning-free results
- * across browsers.
+ * availability. Pass the relevant creation shape so the result applies to the
+ * configuration you intend to create.
  */
 export interface SummarizerAvailabilityOptions {
   type?: SummarizerCreateOptions["type"];

--- a/packages/summarizer/src/index.ts
+++ b/packages/summarizer/src/index.ts
@@ -62,7 +62,7 @@ export interface SummarizeOptions {
   preference?: "auto" | "speed" | "capability";
   /** Native `sharedContext` string (a hint about who/what the summary is for). */
   sharedContext?: string;
-  /** Observe the first-call model download (~1.7 GB on a fresh profile). */
+  /** Observe model-download progress when creation requires one. */
   monitor?: (m: CreateMonitor) => void;
   /**
    * Result cache. Off by default; every call hits the model. Pass
@@ -166,13 +166,10 @@ export const summarize = async (
     ...(options.monitor ? { monitor: options.monitor } : {}),
   };
 
-  // We pass the same options shape to availability() as we do to create().
-  // Edge requires this for accurate results and warns when fields like
-  // outputLanguage are missing; Chrome is more lenient but accepts the same
-  // input. `preference` is a create-core option, so availability() accepts it
-  // too; forwarding it keeps the probe honest about the configuration we're
-  // actually about to create. The narrower SummarizerAvailabilityOptions shape
-  // still filters out create-only fields like `sharedContext`.
+  // Pass the relevant create options to availability() so the probe describes
+  // the configuration we are about to create. The narrower
+  // SummarizerAvailabilityOptions shape filters out create-only fields such as
+  // `sharedContext`.
   const availability = await api
     .availability({
       ...(baseCreateOptions.type ? { type: baseCreateOptions.type } : {}),
@@ -216,10 +213,8 @@ export const summarize = async (
   }
   if (options.signal?.aborted) throw new AbortError();
 
-  // The W3C Web AI streaming contract is ambiguous between "delta" (each
-  // chunk is new content) and "cumulative" (each chunk is the full text
-  // so far). Chrome ships delta; some Edge backends ship cumulative.
-  // Detect per-chunk and merge accordingly.
+  // Browser implementations may emit delta or cumulative chunks. Detect the
+  // shape per chunk and merge accordingly.
   const mergeChunk = (buffer: string, chunk: string): string =>
     chunk.startsWith(buffer) ? chunk : buffer + chunk;
 

--- a/packages/translator/README.md
+++ b/packages/translator/README.md
@@ -2,11 +2,11 @@
 
 web-ai-sdk building block for the Web's Built-in [Translator API](https://developer.chrome.com/docs/ai/translator-api). String-mode translation with pair-cached sessions, opt-in result caching, and AbortSignal-driven cleanup.
 
-**Docs:** <https://web-ai-sdk.dev/docs/guides/translator/> · **React:** [`useTranslator`](https://web-ai-sdk.dev/docs/react/use-translator/)
+**Docs:** <https://web-ai-sdk.dev/docs/guides/translator/> · **React:** [`useTranslator`](https://web-ai-sdk.dev/docs/react/use-translator/) · **Production:** [Checklist](https://web-ai-sdk.dev/docs/production-checklist/)
 
 ## Status
 
-Translator API is stable in Chrome 138+ and Edge 148+ on desktop, with no flag required (per the [Edge Translator API docs](https://learn.microsoft.com/en-us/microsoft-edge/web-platform/translator-api)). On any other browser this library is a no-op for the React hook (it stays in `"unavailable"`). The vanilla `translate()` throws `TranslatorUnavailableError` so callers can branch explicitly.
+Translator API is stable in Chrome 138+ and shipped in Edge 148, with no flag required, per the [Chrome status table](https://developer.chrome.com/docs/ai/built-in-apis) and [Edge 148 release notes](https://learn.microsoft.com/en-us/microsoft-edge/web-platform/release-notes/148). On browsers without `Translator`, the React hook stays `"unavailable"`; vanilla `translate()` throws `TranslatorUnavailableError` so callers can branch explicitly.
 
 ## Install
 

--- a/packages/translator/README.md
+++ b/packages/translator/README.md
@@ -1,12 +1,14 @@
 # @web-ai-sdk/translator
 
-web-ai-sdk building block for the Web's Built-in [Translator API](https://developer.chrome.com/docs/ai/translator-api). String-mode translation with pair-cached sessions, opt-in result caching, and AbortSignal-driven cleanup.
+This package wraps the Web's Built-in [Translator API](https://developer.chrome.com/docs/ai/translator-api). It caches sessions by language pair and supports optional result caching and abort signals.
 
 **Docs:** <https://web-ai-sdk.dev/docs/guides/translator/> · **React:** [`useTranslator`](https://web-ai-sdk.dev/docs/react/use-translator/) · **Production:** [Checklist](https://web-ai-sdk.dev/docs/production-checklist/)
 
 ## Status
 
-Translator API is stable in Chrome 138+ and shipped in Edge 148, with no flag required, per the [Chrome status table](https://developer.chrome.com/docs/ai/built-in-apis) and [Edge 148 release notes](https://learn.microsoft.com/en-us/microsoft-edge/web-platform/release-notes/148). On browsers without `Translator`, the React hook stays `"unavailable"`; vanilla `translate()` throws `TranslatorUnavailableError` so callers can branch explicitly.
+Translator is stable in Chrome 138+ and shipped in Edge 148. It does not require a flag. See the [Chrome status table](https://developer.chrome.com/docs/ai/built-in-apis) and [Edge 148 release notes](https://learn.microsoft.com/en-us/microsoft-edge/web-platform/release-notes/148).
+
+Without `Translator`, React reports `"unavailable"` and `translate()` throws `TranslatorUnavailableError`.
 
 ## Install
 
@@ -15,7 +17,7 @@ pnpm add @web-ai-sdk/translator
 # or: npm i @web-ai-sdk/translator / bun add @web-ai-sdk/translator
 ```
 
-The React adapter ships as a subpath export, with no extra install. `react` is a peer dependency only when you import the `/react` entry.
+The React adapter uses the `/react` subpath. `react` is an optional peer dependency.
 
 ## Vanilla TypeScript / DOM
 

--- a/packages/translator/src/api.ts
+++ b/packages/translator/src/api.ts
@@ -1,7 +1,7 @@
 /**
- * Adapter over the global `Translator` API exposed by Chrome 138+. The native
- * surface is feature-detected; on browsers without it, every entry point in
- * this module returns `null` / `undefined` so callers can stay declarative.
+ * Adapter over the global `Translator` API. The native surface is
+ * feature-detected; on browsers without it, every entry point in this module
+ * returns `null` / `undefined` so callers can stay declarative.
  *
  * Spec: https://developer.chrome.com/docs/ai/translator-api
  */

--- a/packages/webmcp/README.md
+++ b/packages/webmcp/README.md
@@ -8,7 +8,7 @@ An ergonomic, framework-agnostic adapter over the native browser API, with safe 
 
 ## Status
 
-WebMCP shipped as an early preview in Chrome 146+ behind `chrome://flags/#enable-webmcp-testing`; a public [origin trial](https://developer.chrome.com/docs/ai/webmcp) opens in Chrome 149. Edge added support in 147+ behind the matching `edge://flags/` toggle. On browsers without WebMCP, registration is a no-op and discovery returns an empty list; execution rejects with `WebMCPUnavailableError` so a missing capability cannot be confused with a navigation result. A WebMCP spec update changed `registerTool` to return a Promise (cross-origin iframe tool sharing made registration asynchronous); this adapter normalizes both the legacy synchronous shape and the async shape, so consumer code is unchanged.
+WebMCP is available through a public [Chrome origin trial from Chrome 149](https://developer.chrome.com/docs/ai/webmcp), with `chrome://flags/#enable-webmcp-testing` documented for local development. Microsoft lists WebMCP in the [Edge 150 origin trials](https://learn.microsoft.com/en-us/microsoft-edge/web-platform/release-notes/150). On browsers without WebMCP, registration is a no-op and discovery returns an empty list; execution rejects with `WebMCPUnavailableError` so a missing capability cannot be confused with a navigation result. A WebMCP spec update changed `registerTool` to return a Promise (cross-origin iframe tool sharing made registration asynchronous); this adapter normalizes both the legacy synchronous shape and the async shape, so consumer code is unchanged.
 
 ## Install
 
@@ -164,7 +164,7 @@ if (echo) {
 
 The native serialized string is returned unchanged. `null` means tool execution triggered a navigation. Pass `{ signal }` to cancel an in-flight call. Unsupported browsers reject with `WebMCPUnavailableError`.
 
-`executeTool()` is experimental: Chromium implements and publicly documents it, but it is not yet present in the published WebMCP community-draft IDL.
+`executeTool()` is experimental: Chrome [publicly documents it](https://developer.chrome.com/docs/ai/webmcp), but it is not yet present in the published WebMCP community-draft IDL.
 
 ### `subscribeToToolChanges(listener): () => void`
 
@@ -245,7 +245,7 @@ interface ToolDefinition<
 }
 ```
 
-`title` is for human-facing host UI. `description` is consumed by the agent host (Cursor / Claude / Chrome agent / etc.); write it as an instruction to an LLM about when to call the tool.
+`title` is for human-facing host UI. `description` is consumed by the agent host; write it as an instruction to an LLM about when to call the tool.
 
 The current WebMCP draft defines `readOnlyHint` and `untrustedContentHint`. The SDK also retains `destructiveHint`, `idempotentHint`, `openWorldHint`, and the `destructive` shorthand as source-compatible passthroughs for MCP-shaped and earlier WebMCP hosts; current-draft browsers may ignore those compatibility fields.
 

--- a/packages/webmcp/README.md
+++ b/packages/webmcp/README.md
@@ -1,14 +1,18 @@
 # @web-ai-sdk/webmcp
 
-web-ai-sdk building block for the W3C [WebMCP](https://webmachinelearning.github.io/webmcp/) API exposed at `document.modelContext`. (For backward compatibility with the previous shape of the API, this package also reads from `navigator.modelContext`.)
+This package wraps the W3C [WebMCP](https://webmachinelearning.github.io/webmcp/) API at `document.modelContext`. It also reads the previous `navigator.modelContext` shape for compatibility.
 
-An ergonomic, framework-agnostic adapter over the native browser API, with safe register/unregister cleanup, typed tool discovery and execution, and progressive fallback behavior for non-supporting browsers.
+The package provides typed registration, cleanup, discovery, and execution. It has no framework dependency.
 
 **Docs:** <https://web-ai-sdk.dev/docs/guides/webmcp/> · **React:** [`useWebMCP`](https://web-ai-sdk.dev/docs/react/use-web-mcp/)
 
 ## Status
 
-WebMCP is available through a public [Chrome origin trial from Chrome 149](https://developer.chrome.com/docs/ai/webmcp), with `chrome://flags/#enable-webmcp-testing` documented for local development. Microsoft lists WebMCP in the [Edge 150 origin trials](https://learn.microsoft.com/en-us/microsoft-edge/web-platform/release-notes/150). On browsers without WebMCP, registration is a no-op and discovery returns an empty list; execution rejects with `WebMCPUnavailableError` so a missing capability cannot be confused with a navigation result. A WebMCP spec update changed `registerTool` to return a Promise (cross-origin iframe tool sharing made registration asynchronous); this adapter normalizes both the legacy synchronous shape and the async shape, so consumer code is unchanged.
+Chrome provides a public [origin trial from Chrome 149](https://developer.chrome.com/docs/ai/webmcp). For local development, enable `chrome://flags/#enable-webmcp-testing`. Microsoft lists WebMCP in the [Edge 150 origin trials](https://learn.microsoft.com/en-us/microsoft-edge/web-platform/release-notes/150).
+
+Without WebMCP, registration is a no-op and discovery returns an empty list. Execution throws `WebMCPUnavailableError`.
+
+Current `registerTool` implementations can be synchronous or asynchronous. The package supports both forms.
 
 ## Install
 
@@ -103,9 +107,13 @@ export function WebMCP({ isSignedIn }: { isSignedIn: boolean }) {
 }
 ```
 
-`useWebMCP` accepts one tool or a readonly array. It registers on mount, unregisters on unmount, and cleans up immediately when `enabled` changes to `false`. Registration follows discoverable metadata and `exposedTo` values rather than object identity, while `execute` always uses the latest committed callback. Inline tool objects, arrays, and options are safe: changing React state alone does not rebuild the registration, but changing a tool's name, title, description, schema, annotations, or exposure does. Memoize tool arrays and large schemas when practical to avoid rebuilding and comparing their metadata on every render; correctness does not depend on memoization.
+`useWebMCP` accepts one tool or a readonly array. It registers on mount and unregisters on unmount. Setting `enabled` to `false` also removes the registration.
 
-The same hook retrieves every tool exposed to the current document and refreshes the returned list after native `toolchange` events. Its `refresh()` method performs an explicit fresh read. Call `useWebMCP({ fromOrigins })` without definitions for retrieval-only use. Inline `fromOrigins` arrays are safe; discovery restarts only when their values change.
+Registration follows tool metadata and `exposedTo` values, not object identity. `execute` always uses the latest callback. Inline objects and arrays are safe. Metadata changes rebuild the registration. Memoize large schemas and tool arrays to reduce comparison work.
+
+The hook also retrieves tools exposed to the current document. It refreshes after native `toolchange` events. Call `refresh()` for an explicit read.
+
+For retrieval only, call `useWebMCP({ fromOrigins })` without tool definitions. Inline `fromOrigins` arrays are safe; discovery restarts only when their values change.
 
 ## API
 
@@ -113,7 +121,7 @@ The same hook retrieves every tool exposed to the current document and refreshes
 
 Register a single tool. Returns a cleanup function. No-op on unsupported browsers.
 
-Registration is asynchronous under the hood (per the current spec); the returned cleanup is synchronous and safe to call before registration settles — it aborts the in-flight registration cleanly.
+Native registration is asynchronous. The returned cleanup is synchronous and can abort registration before it finishes.
 
 To register many at once, map and combine:
 
@@ -130,7 +138,9 @@ const cleanup = registerTool(tool, {
 });
 ```
 
-The SDK forwards the array unchanged alongside its internally owned `AbortSignal`. The browser validates each origin and rejects invalid or untrustworthy values; the wrapper preserves its non-throwing registration posture and logs that failure. Exposure is unnecessary for the owning document and should be limited to origins that genuinely need access.
+The SDK forwards the array with its own `AbortSignal`. The browser validates each origin. The wrapper logs validation failures without throwing.
+
+The owning document does not need exposure. List only origins that need access.
 
 ### `getTools(options?): Promise<RegisteredTool[]>`
 
@@ -145,7 +155,9 @@ const toolsAcrossFrames = await getTools({
 });
 ```
 
-The browser always includes eligible same-origin tools. `fromOrigins` additionally requests tools from listed secure origins; those tools must also have exposed themselves to the caller's origin. Unsupported browsers resolve to `[]`. Native permission, origin-validation, and document-state errors remain observable as rejected promises.
+The browser includes eligible same-origin tools. `fromOrigins` also requests tools from listed secure origins. Those tools must expose themselves to the caller's origin.
+
+Unsupported browsers return `[]`. Native permission, origin, and document-state errors reject the promise.
 
 ### `executeTool(tool, input?, options?): Promise<string | null>`
 

--- a/packages/webmcp/src/index.ts
+++ b/packages/webmcp/src/index.ts
@@ -145,8 +145,9 @@ export class WebMCPUnavailableError extends Error {
  * string required by the native API. The native serialized result is returned
  * unchanged; `null` means execution triggered a navigation.
  *
- * @experimental Tool execution is implemented and publicly documented by
- * Chromium but is not yet present in the published WebMCP community draft.
+ * @experimental Chrome publicly documents tool execution at
+ * https://developer.chrome.com/docs/ai/webmcp, but it is not yet present in
+ * the published WebMCP community draft.
  */
 export const executeTool = async (
   tool: RegisteredTool,
@@ -260,7 +261,7 @@ const registerOne = async (
   options?: RegisterToolOptions,
 ): Promise<boolean> => {
   // If we still hold a live controller for this name, evict it before the
-  // native register call so Chrome doesn't reject with InvalidStateError.
+  // native register call so the browser doesn't reject with InvalidStateError.
   const prior = ownedControllers.get(registered.name);
   if (prior && prior !== controller && !prior.signal.aborted) {
     prior.abort();
@@ -284,7 +285,7 @@ const registerOne = async (
       return false;
     }
 
-    // Duplicate: Chrome's AbortSignal-driven unregistration isn't guaranteed
+    // Duplicate: AbortSignal-driven unregistration isn't guaranteed
     // to have drained by the time our (now async) rejection landed. A fresh
     // re-register fired right after an abort can still race the queued
     // removal. Yield once and retry. If the retry also fails, log and give up.
@@ -339,8 +340,8 @@ export function registerTool(
  * Register a single tool. Returns a cleanup function that unregisters it.
  *
  * Cleanup is wired through an `AbortSignal` passed to the native
- * `registerTool`, matching the W3C convention used by the Chrome
- * implementation. Calling the returned cleanup twice is a no-op.
+ * `registerTool`, matching the W3C convention used by the native API. Calling
+ * the returned cleanup twice is a no-op.
  *
  * If WebMCP is unavailable, the call is a no-op and the cleanup is a no-op.
  */

--- a/packages/writer/README.md
+++ b/packages/writer/README.md
@@ -2,11 +2,11 @@
 
 web-ai-sdk building block for the Web's Built-in [Writer API](https://developer.chrome.com/docs/ai/writer-api). Generates new content from a writing task with session reuse, streaming, and opt-in result caching.
 
-**Docs:** <https://web-ai-sdk.dev/docs/guides/writer/> · **React:** [`useWriter`](https://web-ai-sdk.dev/docs/react/use-writer/)
+**Docs:** <https://web-ai-sdk.dev/docs/guides/writer/> · **React:** [`useWriter`](https://web-ai-sdk.dev/docs/react/use-writer/) · **Production:** [Checklist](https://web-ai-sdk.dev/docs/production-checklist/)
 
 ## Status
 
-The Writer API is in a developer trial (origin trial) in Chrome 137 to 148, behind `chrome://flags/#writer-api-for-gemini-nano` on localhost (`chrome://flags/#optimization-guide-on-device-model` must also be enabled). In Edge it's a developer preview in Canary/Dev 138+ behind "Writer API for Phi mini". On any other browser this library is a no-op for the React hook (it stays in `"unavailable"`). The vanilla `write()` throws `WriterUnavailableError` so callers can branch explicitly.
+Chrome's current [Built-in AI status table](https://developer.chrome.com/docs/ai/built-in-apis) labels Writer a **Developer trial**. Its public joint origin-trial window with Rewriter ran from Chrome 137 through 148 and has ended; the [Writer docs](https://developer.chrome.com/docs/ai/writer-api) list the current localhost flags. In Edge it is a [developer preview](https://learn.microsoft.com/en-us/microsoft-edge/web-platform/writing-assistance-apis) in Canary/Dev 138.0.3309.2+ behind "Writer API for on-device language model." On browsers without `Writer`, the React hook stays `"unavailable"`; vanilla `write()` throws `WriterUnavailableError` so callers can branch explicitly.
 
 ## Install
 

--- a/packages/writer/README.md
+++ b/packages/writer/README.md
@@ -1,12 +1,16 @@
 # @web-ai-sdk/writer
 
-web-ai-sdk building block for the Web's Built-in [Writer API](https://developer.chrome.com/docs/ai/writer-api). Generates new content from a writing task with session reuse, streaming, and opt-in result caching.
+This package wraps the Web's Built-in [Writer API](https://developer.chrome.com/docs/ai/writer-api). It provides session reuse, streaming, and optional result caching.
 
 **Docs:** <https://web-ai-sdk.dev/docs/guides/writer/> · **React:** [`useWriter`](https://web-ai-sdk.dev/docs/react/use-writer/) · **Production:** [Checklist](https://web-ai-sdk.dev/docs/production-checklist/)
 
 ## Status
 
-Chrome's current [Built-in AI status table](https://developer.chrome.com/docs/ai/built-in-apis) labels Writer a **Developer trial**. Its public joint origin-trial window with Rewriter ran from Chrome 137 through 148 and has ended; the [Writer docs](https://developer.chrome.com/docs/ai/writer-api) list the current localhost flags. In Edge it is a [developer preview](https://learn.microsoft.com/en-us/microsoft-edge/web-platform/writing-assistance-apis) in Canary/Dev 138.0.3309.2+ behind "Writer API for on-device language model." On browsers without `Writer`, the React hook stays `"unavailable"`; vanilla `write()` throws `WriterUnavailableError` so callers can branch explicitly.
+Chrome labels Writer a **Developer trial** in its [status table](https://developer.chrome.com/docs/ai/built-in-apis). The public origin trial for Chrome 137–148 has ended. See the [Writer guide](https://developer.chrome.com/docs/ai/writer-api) for current localhost flags.
+
+Edge provides a [Canary/Dev preview](https://learn.microsoft.com/en-us/microsoft-edge/web-platform/writing-assistance-apis) from 138.0.3309.2. Enable "Writer API for on-device language model."
+
+Without `Writer`, React reports `"unavailable"` and `write()` throws `WriterUnavailableError`.
 
 ## Install
 
@@ -15,7 +19,7 @@ pnpm add @web-ai-sdk/writer
 # or: npm i @web-ai-sdk/writer / bun add @web-ai-sdk/writer
 ```
 
-The React adapter ships as a subpath export, with no extra install. `react` is a peer dependency only when you import the `/react` entry.
+The React adapter uses the `/react` subpath. `react` is an optional peer dependency.
 
 ## Vanilla TypeScript / DOM
 

--- a/packages/writer/src/api.ts
+++ b/packages/writer/src/api.ts
@@ -1,8 +1,6 @@
 /**
- * Adapter over the global `Writer` API exposed by Chrome (behind
- * `chrome://flags/#writer-api-for-gemini-nano`). Feature-detected; on
- * browsers without it, every entry point returns `null` so callers can stay
- * declarative.
+ * Adapter over the global `Writer` API. Feature-detected; on browsers without
+ * it, every entry point returns `null` so callers can stay declarative.
  *
  * Spec: https://developer.chrome.com/docs/ai/writer-api
  */

--- a/packages/writer/src/index.ts
+++ b/packages/writer/src/index.ts
@@ -216,10 +216,8 @@ export const write = async (options: WriteOptions): Promise<WriteResult> => {
     ...(options.signal ? { signal: options.signal } : {}),
   };
 
-  // The W3C Web AI streaming contract is ambiguous between "delta" (each
-  // chunk is new content) and "cumulative" (each chunk is the full text so
-  // far). Chrome ships delta; some backends ship cumulative. Detect
-  // per-chunk and merge accordingly.
+  // Browser implementations may emit delta or cumulative chunks. Detect the
+  // shape per chunk and merge accordingly.
   const mergeChunk = (buffer: string, chunk: string): string =>
     chunk.startsWith(buffer) ? chunk : buffer + chunk;
 


### PR DESCRIPTION
## Summary

- Add a production checklist and update browser-support guidance from public vendor sources.
- Simplify docs, READMEs, home, demo, and Playground copy.
- Improve the docs package index, header, responsive tables, and mobile navigation.
- Compact AGENTS.md, CONTRIBUTING.md, DESIGN.md, and site guidance.

## Impact

The documentation now gives clearer production guidance and is easier to scan. Responsive tables and navigation improve small-screen use.

No runtime API behavior changes. Package source edits affect comments and public documentation only.

## Validation

- `pnpm gate`
- Desktop and mobile production-preview checks
- Chrome checks at 430 × 932
- Table scroll and edge-shadow checks

Closes #153.
