### PR TITLE
fix(site): align docs header and simplify docs copy

### DIFF
--- a/apps/site/astro.config.mjs
+++ b/apps/site/astro.config.mjs
@@ -57,7 +57,9 @@ export default defineConfig({
       disable404Route: true,
       components: {
         Head: "./src/features/docs/components/Head.astro",
+        SiteTitle: "./src/features/docs/components/SiteTitle.astro",
         SocialIcons: "./src/features/docs/components/SocialIcons.astro",
+        ThemeSelect: "./src/features/docs/components/ThemeToggle.astro",
       },
       favicon: "/favicon.svg",
       head: [

--- a/apps/site/src/content/docs/guides/detector.mdx
+++ b/apps/site/src/content/docs/guides/detector.mdx
@@ -13,9 +13,9 @@ Before shipping, review the [Production checklist](/docs/production-checklist/) 
 import { detect } from "@web-ai-sdk/detector";
 
 const result = await detect({ input: "Olá, mundo" });
-console.log(result.output?.language);   // → "pt"
-console.log(result.output?.confidence); // → 0.98
-console.log(result.output?.all);        // → [{ detectedLanguage, confidence }, ...]
+console.log(result.output?.language);   // result: "pt"
+console.log(result.output?.confidence); // result: 0.98
+console.log(result.output?.all);        // result: [{ detectedLanguage, confidence }, ...]
 ```
 
 `result.output` is the detection result with `language` (BCP-47), `confidence`, and `all` (full sorted candidates), or `null` for empty input or when the top confidence is below `minConfidence`. `result.cached` indicates whether the response came from the cache without invoking the model.
@@ -71,7 +71,7 @@ By default, `detect()` returns the highest-confidence candidate regardless of ho
 
 ```ts
 const result = await detect({ input: "??", minConfidence: 0.8 });
-// → { output: null, cached: false }
+// returns { output: null, cached: false }
 ```
 
 When `output` is `null` due to threshold, the full candidate list isn't returned. Lower `minConfidence` to `0` and inspect `result.output.all` if you need to see the alternates.

--- a/apps/site/src/content/docs/guides/prompt.mdx
+++ b/apps/site/src/content/docs/guides/prompt.mdx
@@ -190,7 +190,7 @@ const json = await session.send([
   { role: "user", content: "Describe a cat in one word of JSON." },
   { role: "assistant", content: '{"thought":"', prefix: true },
 ]);
-// model completes: feline"}  ->  you parse {"thought":"feline"}
+// The model completes the prefix with `feline"`; parse the JSON as {"thought":"feline"}.
 ```
 
 **Prefill vs `responseConstraint`**: both shape output, different trade-offs:

--- a/apps/site/src/content/docs/guides/proofreader.mdx
+++ b/apps/site/src/content/docs/guides/proofreader.mdx
@@ -19,7 +19,11 @@ const result = await proofread({
 
 console.log(result.output?.correctedInput);
 for (const c of result.output?.corrections ?? []) {
-  console.log(c.startIndex, c.endIndex, "→", c.correction);
+  console.log({
+    startIndex: c.startIndex,
+    endIndex: c.endIndex,
+    correction: c.correction,
+  });
 }
 ```
 

--- a/apps/site/src/content/docs/guides/summarizer.mdx
+++ b/apps/site/src/content/docs/guides/summarizer.mdx
@@ -59,7 +59,7 @@ interface SummarizeOptions {
 | `sharedContext` | `string` | Native `sharedContext` string (a hint about who/what the summary is for). |
 | `monitor` | `(m) => void` | Observe first-call model download progress. |
 | `cache` | `"session" \| "local" \| { get, set }` | Opt-in result cache. |
-| `cacheKey` | `string` | Override the default cache key (defaults to `JSON.stringify([pathname, trimmed input, normalizedLanguage, languageHints, type, length, format, preference, sharedContext])`; `normalizedLanguage` is `language`'s lowercase primary subtag (e.g. `pt-BR` → `pt`), and `languageHints` is a boolean for whether that language is in `supportedLanguages`). |
+| `cacheKey` | `string` | Override the default cache key (defaults to `JSON.stringify([pathname, trimmed input, normalizedLanguage, languageHints, type, length, format, preference, sharedContext])`; `normalizedLanguage` is `language`'s lowercase primary subtag (for example, `pt-BR` becomes `pt`), and `languageHints` is a boolean for whether that language is in `supportedLanguages`). |
 | `onUpdate` | `(text: string) => void` | Streaming update callback. Receives the cumulative buffer, not deltas. |
 | `signal` | `AbortSignal` | Abort signal. |
 

--- a/apps/site/src/content/docs/guides/translator.mdx
+++ b/apps/site/src/content/docs/guides/translator.mdx
@@ -18,8 +18,8 @@ const result = await translate({
   targetLanguage: "pt",
 });
 
-console.log(result.output);  // → "Olá, mundo."
-console.log(result.cached);  // → false
+console.log(result.output);  // result: "Olá, mundo."
+console.log(result.cached);  // result: false
 ```
 
 `result.output` is the translated text, or `null` when the input is empty or when `sourceLanguage` and `targetLanguage` match (the wrapper short-circuits same-language calls).

--- a/apps/site/src/content/docs/index.mdx
+++ b/apps/site/src/content/docs/index.mdx
@@ -1,19 +1,15 @@
 ---
-title: web-ai-sdk
+title: Documentation
 description: TypeScript lifecycle wrappers for browser AI APIs.
 template: splash
 hero:
+  title: web-ai-sdk
   tagline: TypeScript lifecycle wrappers for browser AI APIs. No runtime dependencies.
   actions:
     - text: Browser support
       link: /docs/browser-support/
-      icon: right-arrow
-    - text: Guides → Prompt
+    - text: Prompt guide
       link: /docs/guides/prompt/
-      variant: minimal
-    - text: GitHub
-      link: https://github.com/obetomuniz/web-ai-sdk
-      icon: external
       variant: minimal
 ---
 
@@ -44,7 +40,7 @@ You can use the browser APIs directly. The SDK handles lifecycle code that appli
 - delta and cumulative stream normalization;
 - `AbortSignal` wiring.
 
-[Read the architecture guide →](/docs/architecture/)
+[Architecture guide](/docs/architecture/)
 
 ## Packages
 

--- a/apps/site/src/content/docs/packages/detector.md
+++ b/apps/site/src/content/docs/packages/detector.md
@@ -32,9 +32,9 @@ The React adapter uses the `/react` subpath. `react` is an optional peer depende
 import { detect } from "@web-ai-sdk/detector";
 
 const result = await detect({ input: "Olá, mundo" });
-console.log(result.output?.language);   // → "pt"
-console.log(result.output?.confidence); // → 0.98
-console.log(result.output?.all);        // → full sorted list of candidates
+console.log(result.output?.language);   // result: "pt"
+console.log(result.output?.confidence); // result: 0.98
+console.log(result.output?.all);        // result: full sorted list of candidates
 ```
 
 ## React

--- a/apps/site/src/content/docs/packages/prompt.md
+++ b/apps/site/src/content/docs/packages/prompt.md
@@ -343,7 +343,7 @@ const json = await session.send([
   { role: "user", content: "Describe a cat in one word of JSON." },
   { role: "assistant", content: '{"thought":"', prefix: true },
 ]);
-// model completes: feline"}  ->  you parse {"thought":"feline"}
+// The model completes the prefix with `feline"`; parse the JSON as {"thought":"feline"}.
 ```
 
 **Prefill vs `responseConstraint`**: both shape output, different trade-offs:

--- a/apps/site/src/content/docs/packages/proofreader.md
+++ b/apps/site/src/content/docs/packages/proofreader.md
@@ -40,7 +40,11 @@ const result = await proofread({
 
 console.log(result.output?.correctedInput);
 for (const c of result.output?.corrections ?? []) {
-  console.log(c.startIndex, c.endIndex, "→", c.correction);
+  console.log({
+    startIndex: c.startIndex,
+    endIndex: c.endIndex,
+    correction: c.correction,
+  });
 }
 ```
 

--- a/apps/site/src/content/docs/packages/summarizer.md
+++ b/apps/site/src/content/docs/packages/summarizer.md
@@ -87,7 +87,7 @@ interface SummarizeOptions {
   sharedContext?: string;
   monitor?: (m: CreateMonitor) => void;
   cache?: "session" | "local" | { get, set };
-  cacheKey?: string; // default: JSON.stringify([pathname, trimmed input, normalizedLanguage, languageHints, type, length, format, preference, sharedContext]); normalizedLanguage = language's lowercase primary subtag (pt-BR → pt), languageHints = boolean (normalized language is in supportedLanguages)
+  cacheKey?: string; // default: JSON.stringify([pathname, trimmed input, normalizedLanguage, languageHints, type, length, format, preference, sharedContext]); normalizedLanguage = language's lowercase primary subtag (pt-BR becomes pt), languageHints = boolean (normalized language is in supportedLanguages)
   onUpdate?: (text: string) => void;
   signal?: AbortSignal;
 }

--- a/apps/site/src/content/docs/packages/translator.md
+++ b/apps/site/src/content/docs/packages/translator.md
@@ -37,8 +37,8 @@ const result = await translate({
   targetLanguage: "pt",
 });
 
-console.log(result.output); // -> "Olá, mundo."
-console.log(result.cached); // -> false
+console.log(result.output); // result: "Olá, mundo."
+console.log(result.cached); // result: false
 ```
 
 `result.output` is the translated text, or `null` when the input is empty or when `sourceLanguage` and `targetLanguage` normalize to the same base language.

--- a/apps/site/src/content/docs/react/use-prompt.mdx
+++ b/apps/site/src/content/docs/react/use-prompt.mdx
@@ -108,7 +108,7 @@ interface UsePromptReturn {
   error: Error | null;
   fromCache: boolean;
   ask(input: string): Promise<void>;  // cancels any in-flight request first
-  abort(): void;                      // cancel in-flight; status → "idle"
+  abort(): void;                      // cancel in-flight; status becomes "idle"
   reset(): void;                      // clear output without aborting
 }
 

--- a/apps/site/src/content/docs/react/use-web-mcp.mdx
+++ b/apps/site/src/content/docs/react/use-web-mcp.mdx
@@ -195,7 +195,7 @@ interface Tool {
   title?: string;
   description: string;
   execute: (input: unknown) => Promise<unknown> | unknown;
-  readOnly?: boolean;              // → annotations.readOnlyHint
+  readOnly?: boolean;              // maps to annotations.readOnlyHint
   destructive?: boolean;           // compatibility shorthand
   annotations?: ToolAnnotations;   // raw passthrough; merges on top of shorthand
   inputSchema?: object;            // JSON Schema

--- a/apps/site/src/features/docs/components/PackageIndex.astro
+++ b/apps/site/src/features/docs/components/PackageIndex.astro
@@ -58,7 +58,6 @@ const packages = [
             {name}
           </span>
           <span class="package-description">{description}</span>
-          <span class="package-arrow" aria-hidden="true">→</span>
         </a>
       </li>
     ))
@@ -83,7 +82,7 @@ const packages = [
 
   .package-link {
     display: grid;
-    grid-template-columns: minmax(14rem, 0.85fr) minmax(0, 1.5fr) auto;
+    grid-template-columns: minmax(14rem, 0.85fr) minmax(0, 1.5fr);
     gap: 1.5rem;
     align-items: center;
     padding: 1rem;
@@ -128,23 +127,9 @@ const packages = [
     line-height: 1.45;
   }
 
-  .package-arrow {
-    color: var(--sl-color-gray-3);
-    font-family: var(--sl-font-mono);
-    font-size: 1.125rem;
-    transition:
-      color 150ms ease,
-      transform 150ms ease;
-  }
-
-  .package-link:hover .package-arrow {
-    color: var(--sl-color-white);
-    transform: translateX(0.2rem);
-  }
-
   @media (max-width: 44.999rem) {
     .package-link {
-      grid-template-columns: minmax(0, 1fr) auto;
+      grid-template-columns: minmax(0, 1fr);
       gap: 0.3rem 1rem;
       padding: 0.875rem 0.75rem;
     }
@@ -155,15 +140,10 @@ const packages = [
       font-size: 0.875rem;
     }
 
-    .package-arrow {
-      grid-column: 2;
-      grid-row: 1 / span 2;
-    }
   }
 
   @media (prefers-reduced-motion: reduce) {
-    .package-link,
-    .package-arrow {
+    .package-link {
       transition: none;
     }
   }

--- a/apps/site/src/features/docs/components/SiteTitle.astro
+++ b/apps/site/src/features/docs/components/SiteTitle.astro
@@ -1,0 +1,50 @@
+---
+const { siteTitle, siteTitleHref } = (
+  Astro.locals as {
+    starlightRoute: { siteTitle: string; siteTitleHref: string };
+  }
+).starlightRoute;
+---
+
+<a href={siteTitleHref} class="docs-site-title">
+  <span translate="no">{siteTitle}</span>
+  <span class="docs-site-caret" aria-hidden="true"></span>
+</a>
+
+<style>
+  .docs-site-title {
+    display: flex;
+    align-items: baseline;
+    gap: 0.1em;
+    min-width: 0;
+    color: var(--sl-color-text-accent);
+    font-family: var(--sl-font-mono);
+    font-size: 0.875rem;
+    font-weight: 400;
+    letter-spacing: -0.01em;
+    line-height: 20px;
+    text-decoration: none;
+    white-space: nowrap;
+  }
+
+  .docs-site-title > span:first-child {
+    overflow: visible;
+  }
+
+  .docs-site-caret {
+    display: inline-block;
+    width: 0.5em;
+    height: 0.08em;
+    margin-inline-start: 0.06em;
+    border-radius: 1px;
+    background: currentColor;
+    vertical-align: baseline;
+    animation: docs-caret-blink 1.1s steps(2) infinite;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .docs-site-caret {
+      animation: none;
+    }
+  }
+</style>

--- a/apps/site/src/features/docs/components/SocialIcons.astro
+++ b/apps/site/src/features/docs/components/SocialIcons.astro
@@ -2,6 +2,7 @@
 import * as ui from "../../../shared/ui.js";
 
 const baseUrl = new URL(import.meta.env.BASE_URL, "https://web-ai-sdk.dev");
+const docsHref = new URL("docs/", baseUrl).pathname;
 const playgroundHref = new URL("playground/", baseUrl).pathname;
 const repoHref = new URL(
   "obetomuniz/web-ai-sdk",
@@ -33,14 +34,38 @@ const repoHref = new URL(
 </a>
 
 <a
+  class={ui.navIcon}
+  href={docsHref}
+  aria-label="Read the web-ai-sdk docs"
+  title="Docs"
+>
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    width="16"
+    height="16"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    stroke-width="2"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+    aria-hidden="true"
+  >
+    <path d="M12 7v14"></path>
+    <path d="M3 18a1 1 0 0 1-1-1V4a1 1 0 0 1 1-1h5a4 4 0 0 1 4 4 4 4 0 0 1 4-4h5a1 1 0 0 1 1 1v13a1 1 0 0 1-1 1h-6a3 3 0 0 0-3 3 3 3 0 0 0-3-3z"></path>
+  </svg>
+</a>
+
+<a
   href={repoHref}
   target="_blank"
   rel="noopener noreferrer"
-  class="social-link sl-flex"
+  class={`${ui.navCta} github-link`}
   aria-label="View the GitHub repository"
   title="GitHub"
 >
-  <svg class="github-icon" viewBox="0 0 24 24" aria-hidden="true">
+  <span class={ui.navGitHubLabel}>GitHub</span>
+  <svg class={ui.navGitHubMark} viewBox="0 0 24 24" aria-hidden="true">
     <path d="M10.226 17.284c-2.965-.36-5.054-2.493-5.054-5.256 0-1.123.404-2.336 1.078-3.144-.292-.741-.247-2.314.09-2.965.898-.112 2.111.36 2.83 1.01.853-.269 1.752-.404 2.853-.404 1.1 0 1.999.135 2.807.382.696-.629 1.932-1.1 2.83-.988.315.606.36 2.179.067 2.942.72.854 1.101 2 1.101 3.167 0 2.763-2.089 4.852-5.098 5.234.763.494 1.28 1.572 1.28 2.807v2.336c0 .674.561 1.056 1.235.786 4.066-1.55 7.255-5.615 7.255-10.646C23.5 6.188 18.334 1 11.978 1 5.62 1 .5 6.188.5 12.545c0 4.986 3.167 9.12 7.435 10.669.606.225 1.19-.18 1.19-.786V20.63a2.9 2.9 0 0 1-1.078.224c-1.483 0-2.359-.808-2.987-2.313-.247-.607-.517-.966-1.034-1.033-.27-.023-.359-.135-.359-.27 0-.27.45-.471.898-.471.652 0 1.213.404 1.797 1.235.45.651.921.943 1.483.943.561 0 .92-.202 1.437-.719.382-.381.674-.718.944-.943"></path>
   </svg>
 </a>
@@ -51,20 +76,8 @@ const repoHref = new URL(
     outline-offset: 2px;
   }
 
-  .social-link {
-    color: var(--sl-color-text-accent);
-    padding: 0.5em;
-    margin: -0.5em;
-  }
-
-  .social-link:hover {
-    color: var(--sl-color-white);
-  }
-
-  .github-icon {
-    width: 1em;
-    height: 1em;
-    fill: currentColor;
+  :global(.right-group .social-icons::after) {
+    display: none;
   }
 
   :global(:root[data-theme="light"]) .playground-link {
@@ -81,18 +94,11 @@ const repoHref = new URL(
   @media (max-width: 49.999rem) {
     :global(.right-group) {
       display: flex;
-    }
-
-    :global(.right-group > :not(.social-icons)) {
-      display: none;
+      gap: 0.5rem;
     }
 
     :global(.right-group .social-icons) {
       gap: 0.75rem;
-    }
-
-    :global(.right-group .social-icons::after) {
-      display: none;
     }
   }
 </style>

--- a/apps/site/src/features/docs/components/ThemeToggle.astro
+++ b/apps/site/src/features/docs/components/ThemeToggle.astro
@@ -1,0 +1,119 @@
+<starlight-theme-select>
+  <button
+    class="docs-theme-toggle"
+    type="button"
+    data-theme-toggle
+    aria-label="Switch to light theme"
+    aria-pressed="false"
+    title="Switch to light theme"
+  >
+    <svg
+      class="docs-theme-icon docs-theme-icon-sun"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      stroke-width="1.8"
+      stroke-linecap="round"
+      aria-hidden="true"
+    >
+      <circle cx="12" cy="12" r="3.5"></circle>
+      <path d="M12 2v2.5M12 19.5V22M4.93 4.93l1.77 1.77M17.3 17.3l1.77 1.77M2 12h2.5M19.5 12H22M4.93 19.07l1.77-1.77M17.3 6.7l1.77-1.77"></path>
+    </svg>
+    <svg
+      class="docs-theme-icon docs-theme-icon-moon"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      stroke-width="1.8"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      aria-hidden="true"
+    >
+      <path d="M20.5 15.2A8.5 8.5 0 0 1 8.8 3.5 8.5 8.5 0 1 0 20.5 15.2Z"></path>
+    </svg>
+  </button>
+</starlight-theme-select>
+
+<script>
+  const themeToggles = document.querySelectorAll<HTMLButtonElement>(
+    "[data-theme-toggle]",
+  );
+
+  const syncThemeToggles = () => {
+    const isLight = document.documentElement.dataset.theme === "light";
+    const nextTheme = isLight ? "dark" : "light";
+
+    for (const toggle of themeToggles) {
+      toggle.setAttribute("aria-pressed", String(isLight));
+      toggle.setAttribute("aria-label", `Switch to ${nextTheme} theme`);
+      toggle.setAttribute("title", `Switch to ${nextTheme} theme`);
+    }
+  };
+
+  for (const toggle of themeToggles) {
+    toggle.addEventListener("click", () => {
+      const nextTheme =
+        document.documentElement.dataset.theme === "light" ? "dark" : "light";
+
+      document.documentElement.dataset.theme = nextTheme;
+      localStorage.setItem("starlight-theme", nextTheme);
+      syncThemeToggles();
+    });
+  }
+
+  syncThemeToggles();
+</script>
+
+<style>
+  starlight-theme-select {
+    display: flex;
+  }
+
+  .docs-theme-toggle {
+    display: inline-flex;
+    width: 2rem;
+    height: 2rem;
+    align-items: center;
+    justify-content: center;
+    border: 0;
+    border-radius: 0.5rem;
+    padding: 0.5rem;
+    background: transparent;
+    color: var(--sl-color-gray-3);
+    cursor: pointer;
+    transition: color 0.2s ease, transform 0.2s ease;
+  }
+
+  .docs-theme-toggle:hover {
+    color: var(--sl-color-white);
+    transform: scale(1.1);
+  }
+
+  .docs-theme-toggle:focus-visible {
+    outline: 2px solid var(--sl-color-text-accent);
+    outline-offset: 2px;
+  }
+
+  .docs-theme-icon {
+    width: 1rem;
+    height: 1rem;
+  }
+
+  .docs-theme-icon-sun {
+    display: none;
+  }
+
+  :global(:root[data-theme="light"]) .docs-theme-icon-sun {
+    display: block;
+  }
+
+  :global(:root[data-theme="light"]) .docs-theme-icon-moon {
+    display: none;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .docs-theme-toggle {
+      transition: none;
+    }
+  }
+</style>

--- a/apps/site/src/features/docs/components/WebMCPDemo.tsx
+++ b/apps/site/src/features/docs/components/WebMCPDemo.tsx
@@ -90,7 +90,7 @@ export const WebMCPDemo = () => {
           pretty = raw;
         }
       }
-      append(`→ result: ${pretty}`);
+      append(`result: ${pretty}`);
     } catch (err) {
       append(`× error: ${(err as Error)?.message ?? String(err)}`);
     }

--- a/apps/site/src/features/docs/styles/web-ai-sdk.css
+++ b/apps/site/src/features/docs/styles/web-ai-sdk.css
@@ -115,6 +115,26 @@
 
 /* Light: Noir light. Near-black accent on bright surfaces. */
 :root[data-theme="light"] {
+  --color-bg: #f5f5f5;
+  --color-surface: #ffffff;
+  --color-surface-2: #ededed;
+  --color-surface-3: #e0e0e0;
+  --color-hairline: rgba(0, 0, 0, 0.12);
+  --color-hairline-2: rgba(0, 0, 0, 0.2);
+  --color-fg: #1c1c1c;
+  --color-fg-2: #4d4d4d;
+  --color-fg-3: #737373;
+  --color-fg-4: #999999;
+  --color-accent: #3b3b3b;
+  --color-accent-bright: #2b2b2b;
+  --color-accent-dim: #5e5e5e;
+  --color-accent-soft: rgba(0, 0, 0, 0.1);
+  --color-accent-line: rgba(0, 0, 0, 0.3);
+  --color-brand-dark: #ffffff;
+  --color-ok: #1f9d6b;
+  --color-info: #0066b8;
+  --color-warn: #9a6b00;
+  --color-err: #c2354a;
   --sl-color-text-accent: #16161a;
   --sl-color-accent: #16161a;
   --sl-color-accent-high: #000000;
@@ -167,23 +187,153 @@
   backdrop-filter: blur(14px) saturate(1.2);
 }
 
-.page > .header .site-title {
-  font-family: var(--sl-font-mono);
-  font-size: 0.875rem;
-  font-weight: 500;
-  letter-spacing: -0.01em;
+/* Use the same centered container and three-column rhythm as the home and
+   playground shells. The search sits in the shared center of the viewport. */
+@media (min-width: 50rem) {
+  .page > .header {
+    --sl-nav-height: calc(3.5rem + 1px);
+    --sl-nav-pad-y: 0;
+    --sl-nav-gap: 1rem;
+  }
+
+  .page > .header > .header {
+    grid-template-columns: minmax(0, 1fr) minmax(0, 27.5rem) minmax(0, 1fr);
+    max-width: 1180px;
+    margin-inline: auto;
+    padding-inline: 1.75rem;
+    gap: 1rem;
+  }
+
+  .page > .header .title-wrapper {
+    padding: 0.25rem;
+    margin: -0.25rem;
+  }
+
+  .page > .header .docs-site-title {
+    font-weight: 400;
+  }
+
+  .page > .header .sl-flex.print\:hidden {
+    justify-content: flex-start;
+  }
+
+  .page > .header .right-group {
+    justify-content: flex-end;
+    gap: 0.5rem;
+  }
+
+  .page > .header .social-icons {
+    gap: 0.5rem;
+  }
+
+  .page > .header .social-icons a {
+    letter-spacing: -0.005em;
+    font-feature-settings: "ss01", "cv11", "tnum";
+  }
+
+  .page > .header site-search button[data-open-modal] {
+    width: min(27.5rem, 100%);
+    max-width: none;
+    height: 2.375rem;
+    border-color: var(--sl-color-hairline-light);
+    border-radius: var(--radius-sm, 0.5rem);
+    padding: 0 0.625rem 0 0.875rem;
+    background-color: var(--sl-color-black);
+    font-family: var(--sl-font-sans);
+    font-size: 0.875rem;
+    line-height: 1.5;
+  }
+
+  .page > .header site-search button[data-open-modal] > :last-child {
+    margin-inline-start: auto;
+  }
 }
 
-.page > .header .site-title span::after {
-  content: "";
-  display: inline-block;
-  width: 0.5em;
-  height: 0.08em;
-  margin-inline-start: 0.06em;
-  border-radius: 1px;
-  background: var(--sl-color-text-accent);
-  vertical-align: baseline;
-  animation: docs-caret-blink 1.1s steps(2) infinite;
+/* Below the wide desktop state, keep the three-column header centered while
+   reducing the actions to the same icon-only treatment used on small screens. */
+@media (min-width: 50rem) and (max-width: 71.999rem) {
+  .page > .header .playground-link,
+  .page > .header .github-link {
+    width: 2rem;
+    height: 2rem;
+    min-width: 2rem;
+    min-height: 2rem;
+    padding: 0.5rem;
+    box-sizing: border-box;
+  }
+
+  .page > .header .playground-link > span:first-child,
+  .page > .header .github-link > span:first-child {
+    display: none;
+  }
+
+  .page > .header .playground-link > svg,
+  .page > .header .github-link > svg {
+    display: block;
+    width: 1rem;
+    height: 1rem;
+  }
+}
+
+/* The full search field has no room beside the compact actions at this width.
+   Keep its magnifier as the discoverable control and preserve its label in the
+   button's accessible name. */
+@media (min-width: 50rem) and (max-width: 54.999rem) {
+  .page > .header > .header {
+    grid-template-columns: minmax(0, 1fr) 2.375rem minmax(0, 1fr);
+  }
+
+  .page > .header site-search button[data-open-modal] {
+    width: 2.375rem;
+    padding: 0;
+    justify-content: center;
+  }
+
+  .page > .header site-search button[data-open-modal] > span,
+  .page > .header site-search button[data-open-modal] > kbd {
+    display: none;
+  }
+}
+
+@media (max-width: 49.999rem) {
+  .page > .header site-search button[data-open-modal] {
+    width: 2rem;
+    height: 2rem;
+    padding: 0;
+    justify-content: center;
+  }
+}
+
+/* Preserve the complete header at the narrowest phone widths. The controls
+   stay discoverable, while the reduced gaps leave room for the brand. */
+@media (max-width: 23.999rem) {
+  .page > .header > .header {
+    column-gap: 0.5rem;
+  }
+
+  .page > .header .right-group {
+    gap: 0.25rem;
+  }
+
+  .page > .header .social-icons {
+    gap: 0.5rem;
+  }
+
+  .page > .header .playground-link,
+  .page > .header .github-link {
+    width: 2rem;
+    height: 2rem;
+    min-width: 2rem;
+    min-height: 2rem;
+    padding: 0.5rem;
+    box-sizing: border-box;
+  }
+}
+
+.page > .header .docs-site-title:focus-visible,
+.page > .header site-search button[data-open-modal]:focus-visible {
+  outline: 2px solid var(--sl-color-text-accent);
+  outline-offset: 2px;
 }
 
 /* Keep the mobile table of contents compact and give its two labels a clear
@@ -216,12 +366,6 @@
 @keyframes docs-caret-blink {
   50% {
     opacity: 0;
-  }
-}
-
-@media (prefers-reduced-motion: reduce) {
-  .page > .header .site-title span::after {
-    animation: none;
   }
 }
 

--- a/packages/detector/README.md
+++ b/packages/detector/README.md
@@ -25,9 +25,9 @@ The React adapter uses the `/react` subpath. `react` is an optional peer depende
 import { detect } from "@web-ai-sdk/detector";
 
 const result = await detect({ input: "Olá, mundo" });
-console.log(result.output?.language);   // → "pt"
-console.log(result.output?.confidence); // → 0.98
-console.log(result.output?.all);        // → full sorted list of candidates
+console.log(result.output?.language);   // result: "pt"
+console.log(result.output?.confidence); // result: 0.98
+console.log(result.output?.all);        // result: full sorted list of candidates
 ```
 
 ## React

--- a/packages/prompt/README.md
+++ b/packages/prompt/README.md
@@ -336,7 +336,7 @@ const json = await session.send([
   { role: "user", content: "Describe a cat in one word of JSON." },
   { role: "assistant", content: '{"thought":"', prefix: true },
 ]);
-// model completes: feline"}  ->  you parse {"thought":"feline"}
+// The model completes the prefix with `feline"`; parse the JSON as {"thought":"feline"}.
 ```
 
 **Prefill vs `responseConstraint`**: both shape output, different trade-offs:

--- a/packages/proofreader/README.md
+++ b/packages/proofreader/README.md
@@ -33,7 +33,11 @@ const result = await proofread({
 
 console.log(result.output?.correctedInput);
 for (const c of result.output?.corrections ?? []) {
-  console.log(c.startIndex, c.endIndex, "→", c.correction);
+  console.log({
+    startIndex: c.startIndex,
+    endIndex: c.endIndex,
+    correction: c.correction,
+  });
 }
 ```
 

--- a/packages/summarizer/README.md
+++ b/packages/summarizer/README.md
@@ -80,7 +80,7 @@ interface SummarizeOptions {
   sharedContext?: string;
   monitor?: (m: CreateMonitor) => void;
   cache?: "session" | "local" | { get, set };
-  cacheKey?: string; // default: JSON.stringify([pathname, trimmed input, normalizedLanguage, languageHints, type, length, format, preference, sharedContext]); normalizedLanguage = language's lowercase primary subtag (pt-BR → pt), languageHints = boolean (normalized language is in supportedLanguages)
+  cacheKey?: string; // default: JSON.stringify([pathname, trimmed input, normalizedLanguage, languageHints, type, length, format, preference, sharedContext]); normalizedLanguage = language's lowercase primary subtag (pt-BR becomes pt), languageHints = boolean (normalized language is in supportedLanguages)
   onUpdate?: (text: string) => void;
   signal?: AbortSignal;
 }

--- a/packages/translator/README.md
+++ b/packages/translator/README.md
@@ -30,8 +30,8 @@ const result = await translate({
   targetLanguage: "pt",
 });
 
-console.log(result.output); // -> "Olá, mundo."
-console.log(result.cached); // -> false
+console.log(result.output); // result: "Olá, mundo."
+console.log(result.cached); // result: false
 ```
 
 `result.output` is the translated text, or `null` when the input is empty or when `sourceLanguage` and `targetLanguage` normalize to the same base language.


### PR DESCRIPTION
## Summary

- Align the docs header with the home and Playground navigation.
- Improve responsive behavior and theme controls.
- Remove arrow glyphs from docs links and examples.
- Keep package README and docs examples synchronized.

## Validation

- `astro build`
- `astro check`
- `git diff --check`
