### PR TITLE
fix(site): align browser support tables

### DIFF
--- a/apps/site/src/features/docs/styles/web-ai-sdk.css
+++ b/apps/site/src/features/docs/styles/web-ai-sdk.css
@@ -472,6 +472,7 @@
 .browser-table-heading img {
   width: 1.125rem;
   height: 1.125rem;
+  margin: 0;
   flex: none;
   object-fit: contain;
 }

--- a/apps/site/src/pages/index.astro
+++ b/apps/site/src/pages/index.astro
@@ -320,10 +320,12 @@ const matrixColumns = [
 
 // Browser marks from SVG Logos via Iconify (CC0).
 const browserColumns = [
-  { name: "Chrome", icon: "/browser-icons/chrome.svg" },
-  { name: "Edge", icon: "/browser-icons/edge.svg" },
-  { name: "Safari", icon: "/browser-icons/safari.svg" },
-  { name: "Firefox", icon: "/browser-icons/firefox.svg" },
+  { name: "Chrome", icons: ["/browser-icons/chrome.svg"] },
+  { name: "Edge", icons: ["/browser-icons/edge.svg"] },
+  {
+    name: "Safari / Firefox",
+    icons: ["/browser-icons/safari.svg", "/browser-icons/firefox.svg"],
+  },
 ] as const;
 ---
 
@@ -657,7 +659,9 @@ const browserColumns = [
                     {browserColumns.map((browser) => (
                       <th class={`${ui.supportHead} ${ui.supportCenteredHead}`}>
                         <span class={ui.browserLabel}>
-                          <img class={ui.browserIcon} src={browser.icon} width="18" height="18" alt="" aria-hidden="true" />
+                          {browser.icons.map((icon) => (
+                            <img class={ui.browserIcon} src={icon} width="18" height="18" alt="" aria-hidden="true" />
+                          ))}
                           <span>{browser.name}</span>
                         </span>
                       </th>
@@ -682,7 +686,6 @@ const browserColumns = [
                           <span class={`${ui.supportVersion} ${supportVersionTone(row.edge)}`}>{row.edge}</span>
                         )}
                       </td>
-                      <td><span class={`${ui.supportPill} ${ui.supportPillWarn}`}>no-op fallback</span></td>
                       <td><span class={`${ui.supportPill} ${ui.supportPillWarn}`}>no-op fallback</span></td>
                     </tr>
                   ))}


### PR DESCRIPTION
## Summary

- Group Safari and Firefox in the homepage browser-support table.
- Align the Safari and Firefox icons in the docs table.
- Remove the extra Chrome and Edge header space.

## Validation

- Astro build
- Astro typecheck
- `git diff --check`