### PR TITLE
feat(cache): add TTL and forced refresh to result caches

### DIFF
--- a/.changeset/large-caches-expire.md
+++ b/.changeset/large-caches-expire.md
@@ -1,0 +1,12 @@
+---
+"@web-ai-sdk/prompt": minor
+"@web-ai-sdk/summarizer": minor
+"@web-ai-sdk/translator": minor
+"@web-ai-sdk/detector": minor
+"@web-ai-sdk/writer": minor
+"@web-ai-sdk/rewriter": minor
+"@web-ai-sdk/proofreader": minor
+"@web-ai-sdk/all": minor
+---
+
+Add TTL and forced refresh to result caches. Built-in "session" / "local" entries now use a versioned envelope and expire after one hour (DEFAULT_CACHE_TTL_MS). New cacheTtl option overrides the TTL per call; new cacheRefresh option skips the cache read and replaces the value after a successful run. Legacy raw entries and malformed envelopes count as misses and are replaced. Custom { get, set } caches keep their contract and own their expiry policy.

--- a/apps/site/src/content/docs/guides/detector.mdx
+++ b/apps/site/src/content/docs/guides/detector.mdx
@@ -30,6 +30,8 @@ interface DetectOptions {
   monitor?: (m: CreateMonitor) => void;
   cache?: "session" | "local" | { get, set };
   cacheKey?: string;
+  cacheTtl?: number;      // built-in shortcut TTL in ms; default 1 hour
+  cacheRefresh?: boolean; // skip the cache read, write the fresh result
   signal?: AbortSignal;
 }
 ```
@@ -44,6 +46,8 @@ interface DetectOptions {
 | `monitor` | `(m) => void` | Observe the first-call model download. |
 | `cache` | `"session" \| "local" \| { get, set }` | Opt-in result cache. `"session"` / `"local"` wrap the matching web-storage; pass an object for a custom backend. |
 | `cacheKey` | `string` | Override the default cache key (JSON array string of `[input, sortedExpectedInputLanguages]`). |
+| `cacheTtl` | `number` | TTL in milliseconds for entries written by the built-in `"session"` / `"local"` shortcuts. Defaults to one hour. Ignored by custom `{ get, set }` caches. |
+| `cacheRefresh` | `boolean` | Skip the cache read and replace the cached value after a successful run. The refreshed run reports `cached: false`. |
 | `signal` | `AbortSignal` | Abort signal. |
 
 </div>
@@ -63,7 +67,7 @@ Chrome's `LanguageDetector` exposes `LanguageDetector.create({...})` to spin up 
 
 - **Feature detection.** `isAvailable()` / `checkAvailability()` return `false` / `null` on browsers without the API. The vanilla `detect()` throws `DetectorUnavailableError`; the React hook surfaces `status: "unavailable"`.
 - **Session reuse.** Internally caches `LanguageDetector.create()` by `expectedInputLanguages` shape. Cold-start is fast on this model (~100-300ms); warm calls are sub-50ms.
-- **Optional result cache.** Off by default. Pass `cache: "session"` to memoize results in `sessionStorage`, or `cache: "local"` for `localStorage`, or any `{ get, set }`-shaped object for a custom backend.
+- **Optional result cache.** Off by default. Pass `cache: "session"` to memoize results in `sessionStorage`, or `cache: "local"` for `localStorage`, or any `{ get, set }`-shaped object for a custom backend. Built-in `"session"` / `"local"` entries expire after one hour by default. Pass `cacheTtl` (milliseconds) to change the TTL per call. Pass `cacheRefresh: true` to skip the read and replace the cached value after a successful run. Custom `{ get, set }` caches own their expiry policy.
 
 ## Confidence threshold
 

--- a/apps/site/src/content/docs/guides/prompt.mdx
+++ b/apps/site/src/content/docs/guides/prompt.mdx
@@ -55,6 +55,8 @@ interface AskOptions {
   responseConstraint?: object;
   cache?: "session" | "local" | { get, set };
   cacheKey?: string;
+  cacheTtl?: number;      // built-in shortcut TTL in ms; default 1 hour
+  cacheRefresh?: boolean; // skip the cache read, write the fresh result
   onUpdate?: (text: string) => void;
   signal?: AbortSignal;
 }
@@ -78,6 +80,8 @@ interface AskOptions {
 | `responseConstraint` | `object` | JSON Schema for structured output. |
 | `cache` | `"session" \| "local" \| { get, set }` | Opt-in result cache. |
 | `cacheKey` | `string` | Override the default cache key (JSON string of the prompt and output-shaping options). |
+| `cacheTtl` | `number` | TTL in milliseconds for entries written by the built-in `"session"` / `"local"` shortcuts. Defaults to one hour. Ignored by custom `{ get, set }` caches. |
+| `cacheRefresh` | `boolean` | Skip the cache read and replace the cached value after a successful run. The refreshed run reports `cached: false`. |
 | `onUpdate` | `(text: string) => void` | Streaming update callback. Cumulative buffer, not deltas. |
 | `signal` | `AbortSignal` | Abort signal. |
 
@@ -245,7 +249,7 @@ Chrome's `LanguageModel` exposes `LanguageModel.create({...})` to spin up a sess
 
 - **Feature detection.** `isAvailable()` / `checkAvailability()` return `false` / `null` on browsers without the API. The vanilla `ask()` throws `PromptUnavailableError`; the React hook surfaces `status: "unavailable"`.
 - **Warm base reuse for `ask()`** (ergonomic default, scoped to `ask`). A bounded LRU caches base `LanguageModel.create()` calls by stringified create options. Each prompt still runs on an isolated clone, or on a fresh one-shot instance when `clone()` is unavailable. `createSession()` never touches this cache.
-- **Optional result cache for `ask()` (off by default).** Every call hits the model unless you opt in. Pass `cache: "session"` for `sessionStorage`, `cache: "local"` for `localStorage`, or any `{ get, set }`-shaped object to memoize responses by `(input, systemPrompt, samplingMode / temperature / topK)`.
+- **Optional result cache for `ask()` (off by default).** Every call hits the model unless you opt in. Pass `cache: "session"` for `sessionStorage`, `cache: "local"` for `localStorage`, or any `{ get, set }`-shaped object to memoize responses by `(input, systemPrompt, samplingMode / temperature / topK)`. Built-in `"session"` / `"local"` entries expire after one hour by default. Pass `cacheTtl` (milliseconds) to change the TTL per call. Pass `cacheRefresh: true` to skip the read and replace the cached value after a successful run. Custom `{ get, set }` caches own their expiry policy.
 - **Delta-vs-cumulative chunk detection.** Browser implementations may expose delta or cumulative chunks. The wrapper normalizes per chunk so `onUpdate` (cumulative) and `sendStreaming()` (deltas) have stable SDK semantics.
 
 The two cache-shaped items above are *ergonomic defaults scoped to `ask()`*, not opinions about how to use a language model. Multi-package compositions (agent loops, conversation history, tool dispatch) are not part of this package; see [Architecture](/docs/architecture/) for the split.

--- a/apps/site/src/content/docs/guides/proofreader.mdx
+++ b/apps/site/src/content/docs/guides/proofreader.mdx
@@ -38,6 +38,8 @@ interface ProofreadOptions {
   monitor?: (m: CreateMonitor) => void;
   cache?: "session" | "local" | { get, set };
   cacheKey?: string;
+  cacheTtl?: number;      // built-in shortcut TTL in ms; default 1 hour
+  cacheRefresh?: boolean; // skip the cache read, write the fresh result
   signal?: AbortSignal;
 }
 ```
@@ -51,6 +53,8 @@ interface ProofreadOptions {
 | `monitor` | `(m) => void` | Observe the first-call model download. |
 | `cache` | `"session" \| "local" \| { get, set }` | Opt-in result cache (stores the serialized output). |
 | `cacheKey` | `string` | Override the default cache key. |
+| `cacheTtl` | `number` | TTL in milliseconds for entries written by the built-in `"session"` / `"local"` shortcuts. Defaults to one hour. Ignored by custom `{ get, set }` caches. |
+| `cacheRefresh` | `boolean` | Skip the cache read and replace the cached value after a successful run. The refreshed run reports `cached: false`. |
 | `signal` | `AbortSignal` | Abort signal. |
 
 </div>

--- a/apps/site/src/content/docs/guides/rewriter.mdx
+++ b/apps/site/src/content/docs/guides/rewriter.mdx
@@ -39,6 +39,8 @@ interface RewriteOptions {
   monitor?: (m: CreateMonitor) => void;
   cache?: "session" | "local" | { get, set };
   cacheKey?: string;
+  cacheTtl?: number;              // built-in shortcut TTL in ms; default 1 hour
+  cacheRefresh?: boolean;         // skip the cache read, write the fresh result
   onUpdate?: (text: string) => void;
   signal?: AbortSignal;
 }
@@ -59,6 +61,8 @@ interface RewriteOptions {
 | `monitor` | `(m) => void` | Observe the first-call model download. |
 | `cache` | `"session" \| "local" \| { get, set }` | Opt-in result cache. |
 | `cacheKey` | `string` | Override the default cache key. |
+| `cacheTtl` | `number` | TTL in milliseconds for entries written by the built-in `"session"` / `"local"` shortcuts. Defaults to one hour. Ignored by custom `{ get, set }` caches. |
+| `cacheRefresh` | `boolean` | Skip the cache read and replace the cached value after a successful run. The refreshed run reports `cached: false`. |
 | `onUpdate` | `(text: string) => void` | Streaming update callback. Receives the cumulative buffer, not deltas. |
 | `signal` | `AbortSignal` | Abort signal. |
 

--- a/apps/site/src/content/docs/guides/summarizer.mdx
+++ b/apps/site/src/content/docs/guides/summarizer.mdx
@@ -40,6 +40,8 @@ interface SummarizeOptions {
   monitor?: (m: CreateMonitor) => void;
   cache?: "session" | "local" | { get, set };
   cacheKey?: string;
+  cacheTtl?: number;      // built-in shortcut TTL in ms; default 1 hour
+  cacheRefresh?: boolean; // skip the cache read, write the fresh result
   onUpdate?: (text: string) => void;
   signal?: AbortSignal;
 }
@@ -60,6 +62,8 @@ interface SummarizeOptions {
 | `monitor` | `(m) => void` | Observe first-call model download progress. |
 | `cache` | `"session" \| "local" \| { get, set }` | Opt-in result cache. |
 | `cacheKey` | `string` | Override the default cache key (defaults to `JSON.stringify([pathname, trimmed input, normalizedLanguage, languageHints, type, length, format, preference, sharedContext])`; `normalizedLanguage` is `language`'s lowercase primary subtag (for example, `pt-BR` becomes `pt`), and `languageHints` is a boolean for whether that language is in `supportedLanguages`). |
+| `cacheTtl` | `number` | TTL in milliseconds for entries written by the built-in `"session"` / `"local"` shortcuts. Defaults to one hour. Ignored by custom `{ get, set }` caches. |
+| `cacheRefresh` | `boolean` | Skip the cache read and replace the cached value after a successful run. The refreshed run reports `cached: false`. |
 | `onUpdate` | `(text: string) => void` | Streaming update callback. Receives the cumulative buffer, not deltas. |
 | `signal` | `AbortSignal` | Abort signal. |
 
@@ -86,6 +90,8 @@ interface SummarizeResult {
 **Session cache** (internal, in-memory, always on): a bounded LRU of `Summarizer` instances so the second call with the same `{ language, type, length, sharedContext, … }` reuses the warm session. Cold-start is ~1-3s; warm sessions are sub-second. Cleared on full page reload.
 
 **Result cache** (opt-in): off by default; every call hits the model. Pass `cache: "session"` for `sessionStorage`, `cache: "local"` for `localStorage`, or any `{ get, set }`-shaped object to memoize the final summary string by `cacheKey`.
+
+Built-in `"session"` / `"local"` entries expire after one hour by default. Pass `cacheTtl` (milliseconds) to change the TTL per call. Pass `cacheRefresh: true` to skip the read and replace the cached value after a successful run. Custom `{ get, set }` caches own their expiry policy.
 
 ```ts
 import { summarize } from "@web-ai-sdk/summarizer";

--- a/apps/site/src/content/docs/guides/translator.mdx
+++ b/apps/site/src/content/docs/guides/translator.mdx
@@ -34,6 +34,8 @@ interface TranslateOptions {
   monitor?: (m: TranslatorMonitor) => void;
   cache?: "session" | "local" | { get, set };
   cacheKey?: string;
+  cacheTtl?: number;      // built-in shortcut TTL in ms; default 1 hour
+  cacheRefresh?: boolean; // skip the cache read, write the fresh result
   signal?: AbortSignal;
 }
 ```
@@ -48,6 +50,8 @@ interface TranslateOptions {
 | `monitor` | `(m) => void` | Observe the first-call model download. |
 | `cache` | `"session" \| "local" \| { get, set }` | Opt-in result cache. |
 | `cacheKey` | `string` | Override the default cache key (JSON array string of normalized `[sourceLanguage, targetLanguage, input]`). |
+| `cacheTtl` | `number` | TTL in milliseconds for entries written by the built-in `"session"` / `"local"` shortcuts. Defaults to one hour. Ignored by custom `{ get, set }` caches. |
+| `cacheRefresh` | `boolean` | Skip the cache read and replace the cached value after a successful run. The refreshed run reports `cached: false`. |
 | `signal` | `AbortSignal` | Abort signal. |
 
 </div>
@@ -95,6 +99,8 @@ translate({
 ```
 
 The default cache key is `JSON.stringify([source, target, trimmedInput])`, so identical input/pair combinations hit. Pass `cacheKey` explicitly for finer-grained invalidation.
+
+Built-in `"session"` / `"local"` entries expire after one hour by default. Pass `cacheTtl` (milliseconds) to change the TTL per call. Pass `cacheRefresh: true` to skip the read and replace the cached value after a successful run. Custom `{ get, set }` caches own their expiry policy.
 
 ## Aborting
 

--- a/apps/site/src/content/docs/guides/writer.mdx
+++ b/apps/site/src/content/docs/guides/writer.mdx
@@ -40,6 +40,8 @@ interface WriteOptions {
   monitor?: (m: CreateMonitor) => void;
   cache?: "session" | "local" | { get, set };
   cacheKey?: string;
+  cacheTtl?: number;              // built-in shortcut TTL in ms; default 1 hour
+  cacheRefresh?: boolean;         // skip the cache read, write the fresh result
   onUpdate?: (text: string) => void;
   signal?: AbortSignal;
 }
@@ -60,6 +62,8 @@ interface WriteOptions {
 | `monitor` | `(m) => void` | Observe the first-call model download. |
 | `cache` | `"session" \| "local" \| { get, set }` | Opt-in result cache. |
 | `cacheKey` | `string` | Override the default cache key. |
+| `cacheTtl` | `number` | TTL in milliseconds for entries written by the built-in `"session"` / `"local"` shortcuts. Defaults to one hour. Ignored by custom `{ get, set }` caches. |
+| `cacheRefresh` | `boolean` | Skip the cache read and replace the cached value after a successful run. The refreshed run reports `cached: false`. |
 | `onUpdate` | `(text: string) => void` | Streaming update callback. Receives the cumulative buffer, not deltas. |
 | `signal` | `AbortSignal` | Abort signal. |
 
@@ -79,7 +83,7 @@ interface WriteResult {
 1. **Trim and cache check.** Whitespace-only input short-circuits to `null`. If a `cache` is configured and has the key, return immediately.
 2. **Cache `Writer.create()` sessions** by create-options. First call pays the cold start; later same-config calls reuse the warm session.
 3. **Stream `writeStreaming()`** when the instance supports it, falling back to one-shot `write()`. Chunks are merged (delta or cumulative) and pushed to `onUpdate` as the cumulative buffer.
-4. **Optionally cache the final output** when you pass a `cache`. Off by default.
+4. **Optionally cache the final output** when you pass a `cache`. Off by default. Built-in `"session"` / `"local"` entries expire after one hour by default. Pass `cacheTtl` (milliseconds) to change the TTL per call. Pass `cacheRefresh: true` to skip the read and replace the cached value after a successful run. Custom `{ get, set }` caches own their expiry policy.
 
 ## Output normalization
 

--- a/apps/site/src/content/docs/packages/detector.md
+++ b/apps/site/src/content/docs/packages/detector.md
@@ -68,6 +68,8 @@ interface DetectOptions {
   monitor?: (m: CreateMonitor) => void;
   cache?: "session" | "local" | { get, set };
   cacheKey?: string;
+  cacheTtl?: number;      // built-in shortcut TTL in ms; default 1 hour
+  cacheRefresh?: boolean; // skip the cache read, write the fresh result
   signal?: AbortSignal;
 }
 
@@ -108,6 +110,22 @@ detect({ input: "hello" });
 
 // Opt in for sessionStorage-backed caching.
 detect({ input: "hello", cache: "session" });
+```
+
+### Expiry and refresh
+
+The built-in `"session"` / `"local"` shortcuts store each entry in a versioned envelope with an expiry time. Entries expire after one hour (`DEFAULT_CACHE_TTL_MS`) by default. Pass `cacheTtl` (milliseconds) to override the TTL per call. Expired entries, legacy raw strings, and malformed envelopes count as misses and are removed.
+
+Pass `cacheRefresh: true` to force a fresh inference. The call skips the cache read, runs the model, and replaces the cached value after a successful run. Failed, aborted, or empty runs leave the cached value in place.
+
+Custom `{ get, set }` caches own their expiry policy. `cacheTtl` does not apply to them; `cacheRefresh` still bypasses their read and updates them after success.
+
+```ts
+// Cache for five minutes instead of one hour.
+detect({ input: "hello", cache: "local", cacheTtl: 5 * 60 * 1000 });
+
+// Force a fresh inference; later calls reuse the new value.
+detect({ input: "hello", cache: "local", cacheRefresh: true });
 ```
 
 ## Composing with the other packages

--- a/apps/site/src/content/docs/packages/prompt.md
+++ b/apps/site/src/content/docs/packages/prompt.md
@@ -179,6 +179,8 @@ interface AskOptions {
   omitResponseConstraintInput?: boolean;
   cache?: ResponseCache;
   cacheKey?: string;
+  cacheTtl?: number;                        // built-in shortcut TTL in ms; default 1 hour
+  cacheRefresh?: boolean;                   // skip the cache read, write the fresh result
   onUpdate?: (text: string) => void;        // CUMULATIVE buffer
   signal?: AbortSignal;
 }
@@ -435,6 +437,22 @@ ask({ input: "hi", cache: "local" });
 
 // Or roll your own.
 ask({ input: "hi", cache: myMap, cacheKey: "greeting" });
+```
+
+### Expiry and refresh
+
+The built-in `"session"` / `"local"` shortcuts store each entry in a versioned envelope with an expiry time. Entries expire after one hour (`DEFAULT_CACHE_TTL_MS`) by default. Pass `cacheTtl` (milliseconds) to override the TTL per call. Expired entries, legacy raw strings, and malformed envelopes count as misses and are removed.
+
+Pass `cacheRefresh: true` to force a fresh inference. The call skips the cache read, runs the model, and replaces the cached value after a successful run. Failed, aborted, or empty runs leave the cached value in place.
+
+Custom `{ get, set }` caches own their expiry policy. `cacheTtl` does not apply to them; `cacheRefresh` still bypasses their read and updates them after success.
+
+```ts
+// Cache for five minutes instead of one hour.
+ask({ input: "hi", cache: "local", cacheTtl: 5 * 60 * 1000 });
+
+// Force a fresh inference; later calls reuse the new value.
+ask({ input: "hi", cache: "local", cacheRefresh: true });
 ```
 
 ## Errors and unavailability

--- a/apps/site/src/content/docs/packages/proofreader.md
+++ b/apps/site/src/content/docs/packages/proofreader.md
@@ -77,6 +77,8 @@ interface ProofreadOptions {
   monitor?: (m: CreateMonitor) => void;
   cache?: "session" | "local" | { get, set };
   cacheKey?: string;
+  cacheTtl?: number;      // built-in shortcut TTL in ms; default 1 hour
+  cacheRefresh?: boolean; // skip the cache read, write the fresh result
   signal?: AbortSignal;
 }
 
@@ -114,6 +116,26 @@ Drop every cached proofreader session. Sessions live for the tab lifetime by def
 ### Session cache controls
 
 `configureProofreaderCache({ max })` bounds the internal warm `Proofreader` session cache (default `8`). `clearProofreaderSessions()` drops every warm session, and `clearProofreaderSession({ expectedInputLanguages })` drops one matching proofreader configuration.
+
+## Result caching
+
+Off by default; every call hits the model. Pass `cache: "session"` for `sessionStorage`, `cache: "local"` for `localStorage`, or any `{ get, set }`-shaped object for a custom backend. The cache stores the serialized `ProofreadOutput`.
+
+### Expiry and refresh
+
+The built-in `"session"` / `"local"` shortcuts store each entry in a versioned envelope with an expiry time. Entries expire after one hour (`DEFAULT_CACHE_TTL_MS`) by default. Pass `cacheTtl` (milliseconds) to override the TTL per call. Expired entries, legacy raw strings, and malformed envelopes count as misses and are removed.
+
+Pass `cacheRefresh: true` to force a fresh inference. The call skips the cache read, runs the model, and replaces the cached value after a successful run. Failed and aborted runs leave the cached value in place.
+
+Custom `{ get, set }` caches own their expiry policy. `cacheTtl` does not apply to them; `cacheRefresh` still bypasses their read and updates them after success.
+
+```ts
+// Cache for five minutes instead of one hour.
+proofread({ input: text, cache: "local", cacheTtl: 5 * 60 * 1000 });
+
+// Force a fresh inference; later calls reuse the new value.
+proofread({ input: text, cache: "local", cacheRefresh: true });
+```
 
 ## Rendering corrections
 

--- a/apps/site/src/content/docs/packages/rewriter.md
+++ b/apps/site/src/content/docs/packages/rewriter.md
@@ -78,6 +78,8 @@ interface RewriteOptions {
   monitor?: (m: CreateMonitor) => void;
   cache?: "session" | "local" | { get, set };
   cacheKey?: string;
+  cacheTtl?: number;      // built-in shortcut TTL in ms; default 1 hour
+  cacheRefresh?: boolean; // skip the cache read, write the fresh result
   onUpdate?: (text: string) => void; // cumulative buffer, not deltas
   signal?: AbortSignal;
 }
@@ -107,6 +109,26 @@ import {
 ```
 
 The internal session cache is LRU-bounded (default 8). Evicted sessions have their `destroy()` invoked when present.
+
+## Result caching
+
+Off by default; every call hits the model. Pass `cache: "session"` for `sessionStorage`, `cache: "local"` for `localStorage`, or any `{ get, set }`-shaped object for a custom backend.
+
+### Expiry and refresh
+
+The built-in `"session"` / `"local"` shortcuts store each entry in a versioned envelope with an expiry time. Entries expire after one hour (`DEFAULT_CACHE_TTL_MS`) by default. Pass `cacheTtl` (milliseconds) to override the TTL per call. Expired entries, legacy raw strings, and malformed envelopes count as misses and are removed.
+
+Pass `cacheRefresh: true` to force a fresh inference. The call skips the cache read, runs the model, and replaces the cached value after a successful run. Failed, aborted, or empty runs leave the cached value in place.
+
+Custom `{ get, set }` caches own their expiry policy. `cacheTtl` does not apply to them; `cacheRefresh` still bypasses their read and updates them after success.
+
+```ts
+// Cache for five minutes instead of one hour.
+rewrite({ input: text, cache: "local", cacheTtl: 5 * 60 * 1000 });
+
+// Force a fresh inference; later calls reuse the new value.
+rewrite({ input: text, cache: "local", cacheRefresh: true });
+```
 
 ## Output normalization
 

--- a/apps/site/src/content/docs/packages/summarizer.md
+++ b/apps/site/src/content/docs/packages/summarizer.md
@@ -88,6 +88,8 @@ interface SummarizeOptions {
   monitor?: (m: CreateMonitor) => void;
   cache?: "session" | "local" | { get, set };
   cacheKey?: string; // default: JSON.stringify([pathname, trimmed input, normalizedLanguage, languageHints, type, length, format, preference, sharedContext]); normalizedLanguage = language's lowercase primary subtag (pt-BR becomes pt), languageHints = boolean (normalized language is in supportedLanguages)
+  cacheTtl?: number;      // built-in shortcut TTL in ms; default 1 hour
+  cacheRefresh?: boolean; // skip the cache read, write the fresh result
   onUpdate?: (text: string) => void;
   signal?: AbortSignal;
 }
@@ -129,6 +131,22 @@ summarize({ language: "en", input: text, cache: "session" });
 
 // Persistent caching across tabs.
 summarize({ language: "en", input: text, cache: "local" });
+```
+
+### Expiry and refresh
+
+The built-in `"session"` / `"local"` shortcuts store each entry in a versioned envelope with an expiry time. Entries expire after one hour (`DEFAULT_CACHE_TTL_MS`) by default. Pass `cacheTtl` (milliseconds) to override the TTL per call. Expired entries, legacy raw strings, and malformed envelopes count as misses and are removed.
+
+Pass `cacheRefresh: true` to force a fresh inference. The call skips the cache read, runs the model, and replaces the cached value after a successful run. Failed, aborted, or empty runs leave the cached value in place.
+
+Custom `{ get, set }` caches own their expiry policy. `cacheTtl` does not apply to them; `cacheRefresh` still bypasses their read and updates them after success.
+
+```ts
+// Cache for five minutes instead of one hour.
+summarize({ language: "en", input: text, cache: "local", cacheTtl: 5 * 60 * 1000 });
+
+// Force a fresh inference; later calls reuse the new value.
+summarize({ language: "en", input: text, cache: "local", cacheRefresh: true });
 ```
 
 The internal session cache (warm `Summarizer` instances) is separate and always on, so same-config calls skip the ~1-3s cold start within a tab.

--- a/apps/site/src/content/docs/packages/translator.md
+++ b/apps/site/src/content/docs/packages/translator.md
@@ -84,6 +84,8 @@ interface TranslateOptions {
   monitor?: (m: TranslatorMonitor) => void;
   cache?: "session" | "local" | { get, set };
   cacheKey?: string;
+  cacheTtl?: number;      // built-in shortcut TTL in ms; default 1 hour
+  cacheRefresh?: boolean; // skip the cache read, write the fresh result
   signal?: AbortSignal;
 }
 
@@ -130,6 +132,34 @@ translate({
 ```
 
 The default result cache key is a JSON array string of normalized `[sourceLanguage, targetLanguage, input]`. Pass `cacheKey` explicitly for finer-grained invalidation.
+
+### Expiry and refresh
+
+The built-in `"session"` / `"local"` shortcuts store each entry in a versioned envelope with an expiry time. Entries expire after one hour (`DEFAULT_CACHE_TTL_MS`) by default. Pass `cacheTtl` (milliseconds) to override the TTL per call. Expired entries, legacy raw strings, and malformed envelopes count as misses and are removed.
+
+Pass `cacheRefresh: true` to force a fresh inference. The call skips the cache read, runs the model, and replaces the cached value after a successful run. Failed, aborted, or empty runs leave the cached value in place.
+
+Custom `{ get, set }` caches own their expiry policy. `cacheTtl` does not apply to them; `cacheRefresh` still bypasses their read and updates them after success.
+
+```ts
+// Cache for five minutes instead of one hour.
+translate({
+  input: text,
+  sourceLanguage: "en",
+  targetLanguage: "pt",
+  cache: "local",
+  cacheTtl: 5 * 60 * 1000,
+});
+
+// Force a fresh inference; later calls reuse the new value.
+translate({
+  input: text,
+  sourceLanguage: "en",
+  targetLanguage: "pt",
+  cache: "local",
+  cacheRefresh: true,
+});
+```
 
 ## DOM composition
 

--- a/apps/site/src/content/docs/packages/writer.md
+++ b/apps/site/src/content/docs/packages/writer.md
@@ -79,6 +79,8 @@ interface WriteOptions {
   monitor?: (m: CreateMonitor) => void;
   cache?: "session" | "local" | { get, set };
   cacheKey?: string;
+  cacheTtl?: number;      // built-in shortcut TTL in ms; default 1 hour
+  cacheRefresh?: boolean; // skip the cache read, write the fresh result
   onUpdate?: (text: string) => void; // cumulative buffer, not deltas
   signal?: AbortSignal;
 }
@@ -108,6 +110,26 @@ import {
 ```
 
 The internal session cache is LRU-bounded (default 8). Evicted sessions have their `destroy()` invoked when present.
+
+## Result caching
+
+Off by default; every call hits the model. Pass `cache: "session"` for `sessionStorage`, `cache: "local"` for `localStorage`, or any `{ get, set }`-shaped object for a custom backend.
+
+### Expiry and refresh
+
+The built-in `"session"` / `"local"` shortcuts store each entry in a versioned envelope with an expiry time. Entries expire after one hour (`DEFAULT_CACHE_TTL_MS`) by default. Pass `cacheTtl` (milliseconds) to override the TTL per call. Expired entries, legacy raw strings, and malformed envelopes count as misses and are removed.
+
+Pass `cacheRefresh: true` to force a fresh inference. The call skips the cache read, runs the model, and replaces the cached value after a successful run. Failed, aborted, or empty runs leave the cached value in place.
+
+Custom `{ get, set }` caches own their expiry policy. `cacheTtl` does not apply to them; `cacheRefresh` still bypasses their read and updates them after success.
+
+```ts
+// Cache for five minutes instead of one hour.
+write({ input: task, cache: "local", cacheTtl: 5 * 60 * 1000 });
+
+// Force a fresh inference; later calls reuse the new value.
+write({ input: task, cache: "local", cacheRefresh: true });
+```
 
 ## Output normalization
 

--- a/apps/site/src/content/docs/production-checklist.mdx
+++ b/apps/site/src/content/docs/production-checklist.mdx
@@ -171,36 +171,26 @@ For multi-step edits, provide version navigation or a diff.
 
 ## Expire caches and offer refresh
 
-The `"session"` and `"local"` caches do not expire entries. Use a custom cache when results need a time-to-live (TTL). Add a visible Refresh action.
+The `"session"` and `"local"` caches expire entries after one hour (`DEFAULT_CACHE_TTL_MS`). Pass `cacheTtl` (milliseconds) to change the TTL per call. Add a visible Refresh action wired to `cacheRefresh`.
 
 ```ts
-import type { ResponseCache } from "@web-ai-sdk/prompt";
 import { ask } from "@web-ai-sdk/prompt";
 
-const entries = new Map<string, { value: string; expiresAt: number }>();
-const ttlCache = {
-  get(key: string) {
-    const entry = entries.get(key);
-    if (!entry || entry.expiresAt <= Date.now()) {
-      entries.delete(key);
-      return null;
-    }
-    return entry.value;
-  },
-  set(key: string, value: string) {
-    entries.set(key, { value, expiresAt: Date.now() + 60 * 60 * 1000 });
-  },
-  delete(key: string) {
-    entries.delete(key);
-  },
-} satisfies ResponseCache & { delete(key: string): void };
-
-async function summarizeFresh(input: string, refresh = false) {
+async function summarizeArticle(input: string, refresh = false) {
   const cacheKey = JSON.stringify(["article-summary-v1", input]);
-  if (refresh) ttlCache.delete(cacheKey);
-  return ask({ input, cache: ttlCache, cacheKey });
+  return ask({
+    input,
+    cache: "local",
+    cacheKey,
+    cacheTtl: 15 * 60 * 1000, // 15 minutes for fast-moving content
+    cacheRefresh: refresh, // skip the read, replace the value on success
+  });
 }
 ```
+
+`cacheRefresh` runs the model and replaces the cached value only after a successful run. Failed, aborted, and empty runs keep the previous value.
+
+Custom `{ get, set }` caches own their expiry policy; `cacheTtl` does not apply to them. `cacheRefresh` still bypasses their read and updates them after success.
 
 Include every output-changing input and option in the key. Do not let a background refresh overwrite user edits.
 

--- a/apps/site/src/content/docs/react/use-detector.mdx
+++ b/apps/site/src/content/docs/react/use-detector.mdx
@@ -81,6 +81,8 @@ const result = useDetector({ input: text, cache: "session" });
 
 `result.fromCache` is `true` when the cache served the result. Pass `"session"` / `"local"` for the matching web-storage shortcut, or any `{ get, set }`-shaped object for a custom backend (memoize it so React doesn't restart on every render).
 
+Built-in `"session"` / `"local"` entries expire after one hour by default. Pass `cacheTtl` (milliseconds) to change the TTL per call. Pass `cacheRefresh: true` to skip the read and replace the cached value after a successful run. Custom `{ get, set }` caches own their expiry policy.
+
 ## Aborting
 
 The hook aborts any in-flight call when `input` changes or the component unmounts. You don't need to manage `AbortController` directly.
@@ -101,6 +103,8 @@ interface UseDetectorOptions extends Omit<DetectOptions, "input" | "signal"> {
   monitor?: (m: CreateMonitor) => void;
   cache?: "session" | "local" | { get, set };
   cacheKey?: string;
+  cacheTtl?: number;       // built-in shortcut TTL in ms; default 1 hour
+  cacheRefresh?: boolean;  // skip the cache read, write the fresh result
 }
 
 interface UseDetectorReturn {

--- a/apps/site/src/content/docs/react/use-prompt.mdx
+++ b/apps/site/src/content/docs/react/use-prompt.mdx
@@ -100,6 +100,8 @@ interface UsePromptOptions extends Omit<AskOptions, "input" | "onUpdate" | "sign
   monitor?: (m: CreateMonitor) => void;
   cache?: "session" | "local" | { get, set };
   cacheKey?: string;
+  cacheTtl?: number;                  // built-in shortcut TTL in ms; default 1 hour
+  cacheRefresh?: boolean;             // skip the cache read, write the fresh result
 }
 
 interface UsePromptReturn {

--- a/apps/site/src/content/docs/react/use-summarizer.mdx
+++ b/apps/site/src/content/docs/react/use-summarizer.mdx
@@ -58,6 +58,8 @@ The hook exposes the same two caches as the vanilla `summarize()`:
 - **Session cache** (in-memory, always on): warm sessions are reused across calls with the same `{ language, type, length, sharedContext, … }` shape. Plan your inputs around these dimensions to keep cold-starts rare.
 - **Result cache** (opt-in): off by default. Pass `cache: "session"` for per-tab caching, `cache: "local"` to persist across tabs, or any `{ get, set }`-shaped object for a custom backend.
 
+Built-in `"session"` / `"local"` entries expire after one hour by default. Pass `cacheTtl` (milliseconds) to change the TTL per call. Pass `cacheRefresh: true` to skip the read and replace the cached value after a successful run. Custom `{ get, set }` caches own their expiry policy.
+
 `result.fromCache` lets you render a "From cache" hint or skip a re-fetch loop entirely.
 
 ## Streaming UX
@@ -86,6 +88,8 @@ interface UseSummarizerOptions extends Omit<SummarizeOptions, "onUpdate" | "sign
   monitor?: (m: CreateMonitor) => void;
   cache?: "session" | "local" | { get, set };
   cacheKey?: string;
+  cacheTtl?: number;       // built-in shortcut TTL in ms; default 1 hour
+  cacheRefresh?: boolean;  // skip the cache read, write the fresh result
 }
 
 interface UseSummarizerReturn {

--- a/apps/site/src/content/docs/react/use-translator.mdx
+++ b/apps/site/src/content/docs/react/use-translator.mdx
@@ -62,6 +62,8 @@ const { output, fromCache } = useTranslator({
 
 `fromCache` is `true` when the cache served the result. Pass `"session"` / `"local"` for the matching web-storage shortcut, or any `{ get, set }`-shaped object for a custom backend.
 
+Built-in `"session"` / `"local"` entries expire after one hour by default. Pass `cacheTtl` (milliseconds) to change the TTL per call. Pass `cacheRefresh: true` to skip the read and replace the cached value after a successful run. Custom `{ get, set }` caches own their expiry policy.
+
 ## Aborting
 
 The hook aborts any in-flight call when inputs change or the component unmounts. You don't need to manage `AbortController` directly.
@@ -83,6 +85,8 @@ interface UseTranslatorOptions extends Omit<TranslateOptions, "signal"> {
   monitor?: (m: TranslatorMonitor) => void;
   cache?: "session" | "local" | { get, set };
   cacheKey?: string;
+  cacheTtl?: number;       // built-in shortcut TTL in ms; default 1 hour
+  cacheRefresh?: boolean;  // skip the cache read, write the fresh result
 }
 
 interface UseTranslatorReturn {

--- a/packages/detector/README.md
+++ b/packages/detector/README.md
@@ -61,6 +61,8 @@ interface DetectOptions {
   monitor?: (m: CreateMonitor) => void;
   cache?: "session" | "local" | { get, set };
   cacheKey?: string;
+  cacheTtl?: number;      // built-in shortcut TTL in ms; default 1 hour
+  cacheRefresh?: boolean; // skip the cache read, write the fresh result
   signal?: AbortSignal;
 }
 
@@ -101,6 +103,22 @@ detect({ input: "hello" });
 
 // Opt in for sessionStorage-backed caching.
 detect({ input: "hello", cache: "session" });
+```
+
+### Expiry and refresh
+
+The built-in `"session"` / `"local"` shortcuts store each entry in a versioned envelope with an expiry time. Entries expire after one hour (`DEFAULT_CACHE_TTL_MS`) by default. Pass `cacheTtl` (milliseconds) to override the TTL per call. Expired entries, legacy raw strings, and malformed envelopes count as misses and are removed.
+
+Pass `cacheRefresh: true` to force a fresh inference. The call skips the cache read, runs the model, and replaces the cached value after a successful run. Failed, aborted, or empty runs leave the cached value in place.
+
+Custom `{ get, set }` caches own their expiry policy. `cacheTtl` does not apply to them; `cacheRefresh` still bypasses their read and updates them after success.
+
+```ts
+// Cache for five minutes instead of one hour.
+detect({ input: "hello", cache: "local", cacheTtl: 5 * 60 * 1000 });
+
+// Force a fresh inference; later calls reuse the new value.
+detect({ input: "hello", cache: "local", cacheRefresh: true });
 ```
 
 ## Composing with the other packages

--- a/packages/detector/src/cache.test.ts
+++ b/packages/detector/src/cache.test.ts
@@ -1,0 +1,180 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { DEFAULT_CACHE_TTL_MS, resolveCache } from "./cache.js";
+
+const fakeStorage = (): Storage => {
+  const store = new Map<string, string>();
+  return {
+    get length() {
+      return store.size;
+    },
+    clear: () => store.clear(),
+    getItem: (k) => store.get(k) ?? null,
+    key: (i) => Array.from(store.keys())[i] ?? null,
+    removeItem: (k) => {
+      store.delete(k);
+    },
+    setItem: (k, v) => {
+      store.set(k, v);
+    },
+  };
+};
+
+const installSessionStorage = (storage: Storage | undefined): void => {
+  Object.defineProperty(globalThis, "sessionStorage", {
+    value: storage,
+    configurable: true,
+    writable: true,
+  });
+};
+
+let originalSessionStorage: PropertyDescriptor | undefined;
+
+beforeEach(() => {
+  originalSessionStorage = Object.getOwnPropertyDescriptor(
+    globalThis,
+    "sessionStorage",
+  );
+  vi.useFakeTimers();
+  vi.setSystemTime(new Date("2026-01-01T00:00:00Z"));
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  if (originalSessionStorage) {
+    Object.defineProperty(globalThis, "sessionStorage", originalSessionStorage);
+  } else {
+    delete (globalThis as { sessionStorage?: Storage }).sessionStorage;
+  }
+});
+
+describe("storage shortcut TTL envelope", () => {
+  it("round-trips a value through a versioned envelope", () => {
+    const storage = fakeStorage();
+    installSessionStorage(storage);
+    const cache = resolveCache("session");
+    cache?.set("k", "v");
+    expect(cache?.get("k")).toBe("v");
+    const raw = storage.getItem("detector:k");
+    expect(raw).not.toBe("v");
+    expect(JSON.parse(raw ?? "")).toEqual({
+      v: 1,
+      value: "v",
+      expiresAt: Date.now() + DEFAULT_CACHE_TTL_MS,
+    });
+  });
+
+  it("expires entries after the default TTL and removes them", () => {
+    const storage = fakeStorage();
+    installSessionStorage(storage);
+    const cache = resolveCache("session");
+    cache?.set("k", "v");
+    vi.advanceTimersByTime(DEFAULT_CACHE_TTL_MS - 1);
+    expect(cache?.get("k")).toBe("v");
+    vi.advanceTimersByTime(1);
+    expect(cache?.get("k")).toBeNull();
+    expect(storage.getItem("detector:k")).toBeNull();
+  });
+
+  it("honors a caller-provided TTL override", () => {
+    installSessionStorage(fakeStorage());
+    const cache = resolveCache("session", 5_000);
+    cache?.set("k", "v");
+    vi.advanceTimersByTime(4_999);
+    expect(cache?.get("k")).toBe("v");
+    vi.advanceTimersByTime(1);
+    expect(cache?.get("k")).toBeNull();
+  });
+
+  it("falls back to the default TTL for invalid overrides", () => {
+    installSessionStorage(fakeStorage());
+    for (const ttl of [0, -1, Number.NaN, Number.POSITIVE_INFINITY]) {
+      const cache = resolveCache("session", ttl);
+      cache?.set("k", "v");
+      expect(cache?.get("k")).toBe("v");
+      vi.advanceTimersByTime(DEFAULT_CACHE_TTL_MS);
+      expect(cache?.get("k")).toBeNull();
+    }
+  });
+
+  it("treats legacy raw strings as misses and removes them", () => {
+    const storage = fakeStorage();
+    installSessionStorage(storage);
+    storage.setItem("detector:k", "legacy value");
+    const cache = resolveCache("session");
+    expect(cache?.get("k")).toBeNull();
+    expect(storage.getItem("detector:k")).toBeNull();
+  });
+
+  it("treats malformed envelopes as misses", () => {
+    const storage = fakeStorage();
+    installSessionStorage(storage);
+    const cache = resolveCache("session");
+    const badEntries = [
+      "{not json",
+      "null",
+      '"just a string"',
+      JSON.stringify({ v: 2, value: "v", expiresAt: Date.now() + 1000 }),
+      JSON.stringify({ v: 1, expiresAt: Date.now() + 1000 }),
+      JSON.stringify({ v: 1, value: 42, expiresAt: Date.now() + 1000 }),
+      JSON.stringify({ v: 1, value: "v" }),
+      JSON.stringify({ v: 1, value: "v", expiresAt: "soon" }),
+      JSON.stringify({ v: 1, value: "v", expiresAt: Number.NaN }),
+    ];
+    for (const entry of badEntries) {
+      storage.setItem("detector:k", entry);
+      expect(cache?.get("k")).toBeNull();
+      expect(storage.getItem("detector:k")).toBeNull();
+    }
+  });
+
+  it("replaces an invalid entry on the next set", () => {
+    const storage = fakeStorage();
+    installSessionStorage(storage);
+    storage.setItem("detector:k", "legacy value");
+    const cache = resolveCache("session");
+    expect(cache?.get("k")).toBeNull();
+    cache?.set("k", "fresh");
+    expect(cache?.get("k")).toBe("fresh");
+  });
+
+  it("returns null when storage is missing", () => {
+    installSessionStorage(undefined);
+    const cache = resolveCache("session");
+    expect(cache?.get("k")).toBeNull();
+    expect(() => cache?.set("k", "v")).not.toThrow();
+  });
+
+  it("swallows storage failures on get, set, and cleanup", () => {
+    const storage = fakeStorage();
+    storage.setItem("detector:k", "legacy value");
+    const throwing = {
+      ...storage,
+      getItem: () => {
+        throw new Error("denied");
+      },
+      setItem: () => {
+        throw new Error("quota");
+      },
+    } as Storage;
+    installSessionStorage(throwing);
+    const cache = resolveCache("session");
+    expect(cache?.get("k")).toBeNull();
+    expect(() => cache?.set("k", "v")).not.toThrow();
+
+    const removeThrows = {
+      ...storage,
+      getItem: (k: string) => storage.getItem(k),
+      removeItem: () => {
+        throw new Error("denied");
+      },
+    } as Storage;
+    installSessionStorage(removeThrows);
+    const cleanupCache = resolveCache("session");
+    expect(cleanupCache?.get("k")).toBeNull();
+  });
+
+  it("passes custom cache objects through untouched", () => {
+    const custom = { get: () => "v", set: () => {} };
+    expect(resolveCache(custom, 5_000)).toBe(custom);
+  });
+});

--- a/packages/detector/src/cache.ts
+++ b/packages/detector/src/cache.ts
@@ -20,28 +20,96 @@ export interface DetectionCache {
  */
 export type CacheOption = "session" | "local" | DetectionCache;
 
+/**
+ * Default time-to-live for entries written by the built-in `"session"` /
+ * `"local"` storage shortcuts: one hour. On-device model output changes as
+ * the browser updates the model, so built-in entries expire instead of
+ * persisting indefinitely. Override per call with `cacheTtl`. Custom
+ * `{ get, set }` caches own their expiry policy.
+ */
+export const DEFAULT_CACHE_TTL_MS = 60 * 60 * 1000;
+
+/** Version tag for the storage envelope written by the built-in shortcuts. */
+const ENVELOPE_VERSION = 1;
+
+interface CacheEnvelope {
+  v: number;
+  value: string;
+  expiresAt: number;
+}
+
+/**
+ * Parse a stored entry into a versioned envelope. Legacy raw strings,
+ * malformed JSON, unsupported versions, and invalid timestamps all return
+ * `null` so the caller treats them as misses.
+ */
+const parseEnvelope = (raw: string): CacheEnvelope | null => {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return null;
+  }
+  if (typeof parsed !== "object" || parsed === null) return null;
+  const envelope = parsed as Partial<CacheEnvelope>;
+  if (envelope.v !== ENVELOPE_VERSION) return null;
+  if (typeof envelope.value !== "string") return null;
+  if (
+    typeof envelope.expiresAt !== "number" ||
+    !Number.isFinite(envelope.expiresAt)
+  )
+    return null;
+  return envelope as CacheEnvelope;
+};
+
+const normalizeTtl = (ttlMs: number | undefined): number =>
+  typeof ttlMs === "number" && Number.isFinite(ttlMs) && ttlMs > 0
+    ? ttlMs
+    : DEFAULT_CACHE_TTL_MS;
+
 interface DefaultCacheOptions {
   storage?: Storage;
   prefix?: string;
+  ttlMs?: number;
 }
 
 const createStorageCache = (options: DefaultCacheOptions): DetectionCache => {
   const prefix = options.prefix ?? "detector:";
   const storage = options.storage;
+  const ttlMs = normalizeTtl(options.ttlMs);
 
   return {
     get(key) {
       if (!storage) return null;
+      let raw: string | null;
       try {
-        return storage.getItem(prefix + key);
+        raw = storage.getItem(prefix + key);
       } catch {
         return null;
       }
+      if (raw === null) return null;
+      const envelope = parseEnvelope(raw);
+      if (envelope && Date.now() < envelope.expiresAt) return envelope.value;
+      // Legacy raw strings, malformed envelopes, and expired entries are
+      // misses; drop them so the next successful run replaces the slot.
+      try {
+        storage.removeItem(prefix + key);
+      } catch {
+        // best-effort cleanup only.
+      }
+      return null;
     },
     set(key, value) {
       if (!storage) return;
       try {
-        storage.setItem(prefix + key, value);
+        storage.setItem(
+          prefix + key,
+          JSON.stringify({
+            v: ENVELOPE_VERSION,
+            value,
+            expiresAt: Date.now() + ttlMs,
+          }),
+        );
       } catch {
         // quota / disabled storage; best-effort only.
       }
@@ -52,10 +120,12 @@ const createStorageCache = (options: DefaultCacheOptions): DetectionCache => {
 /**
  * Resolve the public `cache` option into a concrete `{ get, set }` backend.
  * `undefined` → no caching. `"session"` / `"local"` → wrap the matching
- * web-storage backend (no-op fallback if unavailable). Object → passthrough.
+ * web-storage backend (no-op fallback if unavailable) with a TTL envelope.
+ * Object → passthrough; `ttlMs` does not apply to custom backends.
  */
 export const resolveCache = (
   value: CacheOption | undefined,
+  ttlMs?: number,
 ): DetectionCache | undefined => {
   if (value === undefined) return undefined;
   if (value === "session") {
@@ -63,14 +133,14 @@ export const resolveCache = (
       typeof globalThis !== "undefined"
         ? (globalThis as { sessionStorage?: Storage }).sessionStorage
         : undefined;
-    return createStorageCache({ storage });
+    return createStorageCache({ storage, ttlMs });
   }
   if (value === "local") {
     const storage =
       typeof globalThis !== "undefined"
         ? (globalThis as { localStorage?: Storage }).localStorage
         : undefined;
-    return createStorageCache({ storage });
+    return createStorageCache({ storage, ttlMs });
   }
   return value;
 };

--- a/packages/detector/src/index.test.ts
+++ b/packages/detector/src/index.test.ts
@@ -165,6 +165,55 @@ describe("detect", () => {
     expect(cache.get("k")).toContain("ja");
   });
 
+  it("bypasses the cache read and replaces the value on cacheRefresh", async () => {
+    const api = installFakeDetector();
+    const cache = inMemoryCache();
+    cache.set(
+      '["hello",[]]',
+      JSON.stringify([{ detectedLanguage: "fr", confidence: 0.99 }]),
+    );
+    const result = await detect({ input: "hello", cache, cacheRefresh: true });
+    expect(result.output?.language).toBe("en");
+    expect(result.cached).toBe(false);
+    expect(api.create).toHaveBeenCalled();
+    expect(JSON.parse(cache.get('["hello",[]]') ?? "")).toEqual([
+      { detectedLanguage: "en", confidence: 0.95 },
+      { detectedLanguage: "es", confidence: 0.04 },
+    ]);
+  });
+
+  it("does not overwrite a cached value when the run is aborted", async () => {
+    installFakeDetector();
+    const cache = inMemoryCache();
+    const seeded = JSON.stringify([
+      { detectedLanguage: "fr", confidence: 0.99 },
+    ]);
+    cache.set('["hello",[]]', seeded);
+    const controller = new AbortController();
+    controller.abort();
+    await expect(
+      detect({
+        input: "hello",
+        cache,
+        cacheRefresh: true,
+        signal: controller.signal,
+      }),
+    ).rejects.toMatchObject({ name: "AbortError" });
+    expect(cache.get('["hello",[]]')).toBe(seeded);
+  });
+
+  it("does not overwrite a cached value when the run yields no results", async () => {
+    installFakeDetector({ results: [] });
+    const cache = inMemoryCache();
+    const seeded = JSON.stringify([
+      { detectedLanguage: "fr", confidence: 0.99 },
+    ]);
+    cache.set('["hello",[]]', seeded);
+    const result = await detect({ input: "hello", cache, cacheRefresh: true });
+    expect(result).toEqual({ output: null, cached: false });
+    expect(cache.get('["hello",[]]')).toBe(seeded);
+  });
+
   it("forwards expectedInputLanguages to create()", async () => {
     const api = installFakeDetector();
     await detect({ input: "hi", expectedInputLanguages: ["en", "es"] });
@@ -328,10 +377,10 @@ describe("detect", () => {
       });
       expect(first.cached).toBe(false);
       expect(first.output?.language).toBe("en");
-      expect(storage.setItem).toHaveBeenCalledWith(
-        "detector:k",
-        expect.any(String),
-      );
+      const stored = JSON.parse(store.get("detector:k") ?? "");
+      expect(stored.v).toBe(1);
+      expect(JSON.parse(stored.value)[0]?.detectedLanguage).toBe("en");
+      expect(stored.expiresAt).toBeGreaterThan(Date.now());
 
       const createsAfterFirst = api.create.mock.calls.length;
       const second = await detect({
@@ -365,10 +414,10 @@ describe("detect", () => {
       });
       expect(first.cached).toBe(false);
       expect(first.output?.language).toBe("en");
-      expect(storage.setItem).toHaveBeenCalledWith(
-        "detector:k",
-        expect.any(String),
-      );
+      const stored = JSON.parse(store.get("detector:k") ?? "");
+      expect(stored.v).toBe(1);
+      expect(JSON.parse(stored.value)[0]?.detectedLanguage).toBe("en");
+      expect(stored.expiresAt).toBeGreaterThan(Date.now());
 
       const createsAfterFirst = api.create.mock.calls.length;
       const second = await detect({

--- a/packages/detector/src/index.ts
+++ b/packages/detector/src/index.ts
@@ -27,6 +27,7 @@ import {
 } from "./api.js";
 import {
   type CacheOption,
+  DEFAULT_CACHE_TTL_MS,
   type DetectionCache,
   defaultCacheKey,
   resolveCache,
@@ -49,6 +50,7 @@ export {
   clearLanguageDetectorSession,
   clearLanguageDetectorSessions,
   configureLanguageDetectorCache,
+  DEFAULT_CACHE_TTL_MS,
   isAvailable,
 };
 
@@ -72,6 +74,19 @@ export interface DetectOptions {
   cache?: CacheOption;
   /** Cache key. Default: JSON array string of `[input, sortedExpectedInputLanguages]`. */
   cacheKey?: string;
+  /**
+   * Time-to-live in milliseconds for entries written by the built-in
+   * `"session"` / `"local"` storage shortcuts. Default: one hour
+   * (`DEFAULT_CACHE_TTL_MS`). Ignored for custom `{ get, set }` caches, which
+   * own their expiry policy.
+   */
+  cacheTtl?: number;
+  /**
+   * Force a fresh detection. Skips the cache read, runs the model, and
+   * replaces the cached value after a successful run. Applies to built-in
+   * and custom caches.
+   */
+  cacheRefresh?: boolean;
   /** Abort signal. */
   signal?: AbortSignal;
 }
@@ -128,10 +143,10 @@ export const detect = async (options: DetectOptions): Promise<DetectResult> => {
     ? [...options.expectedInputLanguages]
     : undefined;
 
-  const cache = resolveCache(options.cache);
+  const cache = resolveCache(options.cache, options.cacheTtl);
   const cacheKey =
     options.cacheKey ?? defaultCacheKey({ text, expectedInputLanguages });
-  if (cache) {
+  if (cache && !options.cacheRefresh) {
     const cached = cache.get(cacheKey);
     if (cached) {
       try {

--- a/packages/detector/src/react/index.ts
+++ b/packages/detector/src/react/index.ts
@@ -49,6 +49,8 @@ export const useDetector = (options: UseDetectorOptions): UseDetectorReturn => {
     monitor,
     cache,
     cacheKey,
+    cacheTtl,
+    cacheRefresh,
     enabled = true,
   } = options;
 
@@ -80,6 +82,8 @@ export const useDetector = (options: UseDetectorOptions): UseDetectorReturn => {
       monitor,
       cache,
       cacheKey,
+      cacheTtl,
+      cacheRefresh,
       signal: controller.signal,
     })
       .then((result: DetectResult) => {
@@ -110,6 +114,8 @@ export const useDetector = (options: UseDetectorOptions): UseDetectorReturn => {
     monitor,
     cache,
     cacheKey,
+    cacheTtl,
+    cacheRefresh,
   ]);
 
   return { status, output, error, fromCache };

--- a/packages/prompt/README.md
+++ b/packages/prompt/README.md
@@ -172,6 +172,8 @@ interface AskOptions {
   omitResponseConstraintInput?: boolean;
   cache?: ResponseCache;
   cacheKey?: string;
+  cacheTtl?: number;                        // built-in shortcut TTL in ms; default 1 hour
+  cacheRefresh?: boolean;                   // skip the cache read, write the fresh result
   onUpdate?: (text: string) => void;        // CUMULATIVE buffer
   signal?: AbortSignal;
 }
@@ -428,6 +430,22 @@ ask({ input: "hi", cache: "local" });
 
 // Or roll your own.
 ask({ input: "hi", cache: myMap, cacheKey: "greeting" });
+```
+
+### Expiry and refresh
+
+The built-in `"session"` / `"local"` shortcuts store each entry in a versioned envelope with an expiry time. Entries expire after one hour (`DEFAULT_CACHE_TTL_MS`) by default. Pass `cacheTtl` (milliseconds) to override the TTL per call. Expired entries, legacy raw strings, and malformed envelopes count as misses and are removed.
+
+Pass `cacheRefresh: true` to force a fresh inference. The call skips the cache read, runs the model, and replaces the cached value after a successful run. Failed, aborted, or empty runs leave the cached value in place.
+
+Custom `{ get, set }` caches own their expiry policy. `cacheTtl` does not apply to them; `cacheRefresh` still bypasses their read and updates them after success.
+
+```ts
+// Cache for five minutes instead of one hour.
+ask({ input: "hi", cache: "local", cacheTtl: 5 * 60 * 1000 });
+
+// Force a fresh inference; later calls reuse the new value.
+ask({ input: "hi", cache: "local", cacheRefresh: true });
 ```
 
 ## Errors and unavailability

--- a/packages/prompt/src/cache.test.ts
+++ b/packages/prompt/src/cache.test.ts
@@ -1,0 +1,180 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { DEFAULT_CACHE_TTL_MS, resolveCache } from "./cache.js";
+
+const fakeStorage = (): Storage => {
+  const store = new Map<string, string>();
+  return {
+    get length() {
+      return store.size;
+    },
+    clear: () => store.clear(),
+    getItem: (k) => store.get(k) ?? null,
+    key: (i) => Array.from(store.keys())[i] ?? null,
+    removeItem: (k) => {
+      store.delete(k);
+    },
+    setItem: (k, v) => {
+      store.set(k, v);
+    },
+  };
+};
+
+const installSessionStorage = (storage: Storage | undefined): void => {
+  Object.defineProperty(globalThis, "sessionStorage", {
+    value: storage,
+    configurable: true,
+    writable: true,
+  });
+};
+
+let originalSessionStorage: PropertyDescriptor | undefined;
+
+beforeEach(() => {
+  originalSessionStorage = Object.getOwnPropertyDescriptor(
+    globalThis,
+    "sessionStorage",
+  );
+  vi.useFakeTimers();
+  vi.setSystemTime(new Date("2026-01-01T00:00:00Z"));
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  if (originalSessionStorage) {
+    Object.defineProperty(globalThis, "sessionStorage", originalSessionStorage);
+  } else {
+    delete (globalThis as { sessionStorage?: Storage }).sessionStorage;
+  }
+});
+
+describe("storage shortcut TTL envelope", () => {
+  it("round-trips a value through a versioned envelope", () => {
+    const storage = fakeStorage();
+    installSessionStorage(storage);
+    const cache = resolveCache("session");
+    cache?.set("k", "v");
+    expect(cache?.get("k")).toBe("v");
+    const raw = storage.getItem("prompt:k");
+    expect(raw).not.toBe("v");
+    expect(JSON.parse(raw ?? "")).toEqual({
+      v: 1,
+      value: "v",
+      expiresAt: Date.now() + DEFAULT_CACHE_TTL_MS,
+    });
+  });
+
+  it("expires entries after the default TTL and removes them", () => {
+    const storage = fakeStorage();
+    installSessionStorage(storage);
+    const cache = resolveCache("session");
+    cache?.set("k", "v");
+    vi.advanceTimersByTime(DEFAULT_CACHE_TTL_MS - 1);
+    expect(cache?.get("k")).toBe("v");
+    vi.advanceTimersByTime(1);
+    expect(cache?.get("k")).toBeNull();
+    expect(storage.getItem("prompt:k")).toBeNull();
+  });
+
+  it("honors a caller-provided TTL override", () => {
+    installSessionStorage(fakeStorage());
+    const cache = resolveCache("session", 5_000);
+    cache?.set("k", "v");
+    vi.advanceTimersByTime(4_999);
+    expect(cache?.get("k")).toBe("v");
+    vi.advanceTimersByTime(1);
+    expect(cache?.get("k")).toBeNull();
+  });
+
+  it("falls back to the default TTL for invalid overrides", () => {
+    installSessionStorage(fakeStorage());
+    for (const ttl of [0, -1, Number.NaN, Number.POSITIVE_INFINITY]) {
+      const cache = resolveCache("session", ttl);
+      cache?.set("k", "v");
+      expect(cache?.get("k")).toBe("v");
+      vi.advanceTimersByTime(DEFAULT_CACHE_TTL_MS);
+      expect(cache?.get("k")).toBeNull();
+    }
+  });
+
+  it("treats legacy raw strings as misses and removes them", () => {
+    const storage = fakeStorage();
+    installSessionStorage(storage);
+    storage.setItem("prompt:k", "legacy value");
+    const cache = resolveCache("session");
+    expect(cache?.get("k")).toBeNull();
+    expect(storage.getItem("prompt:k")).toBeNull();
+  });
+
+  it("treats malformed envelopes as misses", () => {
+    const storage = fakeStorage();
+    installSessionStorage(storage);
+    const cache = resolveCache("session");
+    const badEntries = [
+      "{not json",
+      "null",
+      '"just a string"',
+      JSON.stringify({ v: 2, value: "v", expiresAt: Date.now() + 1000 }),
+      JSON.stringify({ v: 1, expiresAt: Date.now() + 1000 }),
+      JSON.stringify({ v: 1, value: 42, expiresAt: Date.now() + 1000 }),
+      JSON.stringify({ v: 1, value: "v" }),
+      JSON.stringify({ v: 1, value: "v", expiresAt: "soon" }),
+      JSON.stringify({ v: 1, value: "v", expiresAt: Number.NaN }),
+    ];
+    for (const entry of badEntries) {
+      storage.setItem("prompt:k", entry);
+      expect(cache?.get("k")).toBeNull();
+      expect(storage.getItem("prompt:k")).toBeNull();
+    }
+  });
+
+  it("replaces an invalid entry on the next set", () => {
+    const storage = fakeStorage();
+    installSessionStorage(storage);
+    storage.setItem("prompt:k", "legacy value");
+    const cache = resolveCache("session");
+    expect(cache?.get("k")).toBeNull();
+    cache?.set("k", "fresh");
+    expect(cache?.get("k")).toBe("fresh");
+  });
+
+  it("returns null when storage is missing", () => {
+    installSessionStorage(undefined);
+    const cache = resolveCache("session");
+    expect(cache?.get("k")).toBeNull();
+    expect(() => cache?.set("k", "v")).not.toThrow();
+  });
+
+  it("swallows storage failures on get, set, and cleanup", () => {
+    const storage = fakeStorage();
+    storage.setItem("prompt:k", "legacy value");
+    const throwing = {
+      ...storage,
+      getItem: () => {
+        throw new Error("denied");
+      },
+      setItem: () => {
+        throw new Error("quota");
+      },
+    } as Storage;
+    installSessionStorage(throwing);
+    const cache = resolveCache("session");
+    expect(cache?.get("k")).toBeNull();
+    expect(() => cache?.set("k", "v")).not.toThrow();
+
+    const removeThrows = {
+      ...storage,
+      getItem: (k: string) => storage.getItem(k),
+      removeItem: () => {
+        throw new Error("denied");
+      },
+    } as Storage;
+    installSessionStorage(removeThrows);
+    const cleanupCache = resolveCache("session");
+    expect(cleanupCache?.get("k")).toBeNull();
+  });
+
+  it("passes custom cache objects through untouched", () => {
+    const custom = { get: () => "v", set: () => {} };
+    expect(resolveCache(custom, 5_000)).toBe(custom);
+  });
+});

--- a/packages/prompt/src/cache.ts
+++ b/packages/prompt/src/cache.ts
@@ -27,28 +27,96 @@ export interface ResponseCache {
  */
 export type CacheOption = "session" | "local" | ResponseCache;
 
+/**
+ * Default time-to-live for entries written by the built-in `"session"` /
+ * `"local"` storage shortcuts: one hour. On-device model output changes as
+ * the browser updates the model, so built-in entries expire instead of
+ * persisting indefinitely. Override per call with `cacheTtl`. Custom
+ * `{ get, set }` caches own their expiry policy.
+ */
+export const DEFAULT_CACHE_TTL_MS = 60 * 60 * 1000;
+
+/** Version tag for the storage envelope written by the built-in shortcuts. */
+const ENVELOPE_VERSION = 1;
+
+interface CacheEnvelope {
+  v: number;
+  value: string;
+  expiresAt: number;
+}
+
+/**
+ * Parse a stored entry into a versioned envelope. Legacy raw strings,
+ * malformed JSON, unsupported versions, and invalid timestamps all return
+ * `null` so the caller treats them as misses.
+ */
+const parseEnvelope = (raw: string): CacheEnvelope | null => {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return null;
+  }
+  if (typeof parsed !== "object" || parsed === null) return null;
+  const envelope = parsed as Partial<CacheEnvelope>;
+  if (envelope.v !== ENVELOPE_VERSION) return null;
+  if (typeof envelope.value !== "string") return null;
+  if (
+    typeof envelope.expiresAt !== "number" ||
+    !Number.isFinite(envelope.expiresAt)
+  )
+    return null;
+  return envelope as CacheEnvelope;
+};
+
+const normalizeTtl = (ttlMs: number | undefined): number =>
+  typeof ttlMs === "number" && Number.isFinite(ttlMs) && ttlMs > 0
+    ? ttlMs
+    : DEFAULT_CACHE_TTL_MS;
+
 interface DefaultCacheOptions {
   storage?: Storage;
   prefix?: string;
+  ttlMs?: number;
 }
 
 const createStorageCache = (options: DefaultCacheOptions): ResponseCache => {
   const prefix = options.prefix ?? "prompt:";
   const storage = options.storage;
+  const ttlMs = normalizeTtl(options.ttlMs);
 
   return {
     get(key) {
       if (!storage) return null;
+      let raw: string | null;
       try {
-        return storage.getItem(prefix + key);
+        raw = storage.getItem(prefix + key);
       } catch {
         return null;
       }
+      if (raw === null) return null;
+      const envelope = parseEnvelope(raw);
+      if (envelope && Date.now() < envelope.expiresAt) return envelope.value;
+      // Legacy raw strings, malformed envelopes, and expired entries are
+      // misses; drop them so the next successful run replaces the slot.
+      try {
+        storage.removeItem(prefix + key);
+      } catch {
+        // best-effort cleanup only.
+      }
+      return null;
     },
     set(key, value) {
       if (!storage) return;
       try {
-        storage.setItem(prefix + key, value);
+        storage.setItem(
+          prefix + key,
+          JSON.stringify({
+            v: ENVELOPE_VERSION,
+            value,
+            expiresAt: Date.now() + ttlMs,
+          }),
+        );
       } catch {
         // quota / disabled storage; best-effort only.
       }
@@ -59,10 +127,12 @@ const createStorageCache = (options: DefaultCacheOptions): ResponseCache => {
 /**
  * Resolve the public `cache` option into a concrete `{ get, set }` backend.
  * `undefined` → no caching. `"session"` / `"local"` → wrap the matching
- * web-storage backend (no-op fallback if unavailable). Object → passthrough.
+ * web-storage backend (no-op fallback if unavailable) with a TTL envelope.
+ * Object → passthrough; `ttlMs` does not apply to custom backends.
  */
 export const resolveCache = (
   value: CacheOption | undefined,
+  ttlMs?: number,
 ): ResponseCache | undefined => {
   if (value === undefined) return undefined;
   if (value === "session") {
@@ -70,14 +140,14 @@ export const resolveCache = (
       typeof globalThis !== "undefined"
         ? (globalThis as { sessionStorage?: Storage }).sessionStorage
         : undefined;
-    return createStorageCache({ storage });
+    return createStorageCache({ storage, ttlMs });
   }
   if (value === "local") {
     const storage =
       typeof globalThis !== "undefined"
         ? (globalThis as { localStorage?: Storage }).localStorage
         : undefined;
-    return createStorageCache({ storage });
+    return createStorageCache({ storage, ttlMs });
   }
   return value;
 };

--- a/packages/prompt/src/index.test.ts
+++ b/packages/prompt/src/index.test.ts
@@ -125,6 +125,42 @@ describe("ask", () => {
     expect(fake.create).not.toHaveBeenCalled();
   });
 
+  it("bypasses the cache read and replaces the value on cacheRefresh", async () => {
+    const fake = installFakeLanguageModel({ response: "fresh answer" });
+    const cache = inMemoryCache();
+    cache.set('["hello","",null,null]', "cached answer");
+    const result = await ask({ input: "hello", cache, cacheRefresh: true });
+    expect(result).toEqual({ output: "fresh answer", cached: false });
+    expect(fake.create).toHaveBeenCalled();
+    expect(cache.get('["hello","",null,null]')).toBe("fresh answer");
+  });
+
+  it("does not overwrite a cached value when the run is aborted", async () => {
+    installFakeLanguageModel();
+    const cache = inMemoryCache();
+    cache.set('["hello","",null,null]', "cached answer");
+    const controller = new AbortController();
+    controller.abort();
+    await expect(
+      ask({
+        input: "hello",
+        cache,
+        cacheRefresh: true,
+        signal: controller.signal,
+      }),
+    ).rejects.toBeInstanceOf(PromptAbortError);
+    expect(cache.get('["hello","",null,null]')).toBe("cached answer");
+  });
+
+  it("does not overwrite a cached value when the response is empty", async () => {
+    installFakeLanguageModel({ response: "   " });
+    const cache = inMemoryCache();
+    cache.set('["hello","",null,null]', "cached answer");
+    const result = await ask({ input: "hello", cache, cacheRefresh: true });
+    expect(result).toEqual({ output: null, cached: false });
+    expect(cache.get('["hello","",null,null]')).toBe("cached answer");
+  });
+
   it("does not collide cache entries when language hints differ", async () => {
     let calls = 0;
     installFakeLanguageModel({
@@ -698,7 +734,10 @@ describe("ask", () => {
         cacheKey: "k",
       });
       expect(first).toEqual({ output: "Hello, world.", cached: false });
-      expect(storage.setItem).toHaveBeenCalledWith("prompt:k", "Hello, world.");
+      const stored = JSON.parse(store.get("prompt:k") ?? "");
+      expect(stored.v).toBe(1);
+      expect(stored.value).toBe("Hello, world.");
+      expect(stored.expiresAt).toBeGreaterThan(Date.now());
 
       const createsAfterFirst = fake.create.mock.calls.length;
       const second = await ask({
@@ -730,7 +769,10 @@ describe("ask", () => {
         cacheKey: "k",
       });
       expect(first).toEqual({ output: "Hello, world.", cached: false });
-      expect(storage.setItem).toHaveBeenCalledWith("prompt:k", "Hello, world.");
+      const stored = JSON.parse(store.get("prompt:k") ?? "");
+      expect(stored.v).toBe(1);
+      expect(stored.value).toBe("Hello, world.");
+      expect(stored.expiresAt).toBeGreaterThan(Date.now());
 
       const createsAfterFirst = fake.create.mock.calls.length;
       const second = await ask({

--- a/packages/prompt/src/index.ts
+++ b/packages/prompt/src/index.ts
@@ -31,6 +31,7 @@ import {
 } from "./api.js";
 import {
   type CacheOption,
+  DEFAULT_CACHE_TTL_MS,
   type DefaultCacheKeyInput,
   defaultCacheKey,
   type ResponseCache,
@@ -72,6 +73,7 @@ export type {
 export {
   checkAvailability,
   createSession,
+  DEFAULT_CACHE_TTL_MS,
   isAvailable,
   PromptAbortError,
   PromptUnavailableError,
@@ -123,6 +125,19 @@ export interface AskOptions {
   cache?: CacheOption;
   /** Cache key. Default: JSON string of the prompt and output-shaping options. */
   cacheKey?: string;
+  /**
+   * Time-to-live in milliseconds for entries written by the built-in
+   * `"session"` / `"local"` storage shortcuts. Default: one hour
+   * (`DEFAULT_CACHE_TTL_MS`). Ignored for custom `{ get, set }` caches, which
+   * own their expiry policy.
+   */
+  cacheTtl?: number;
+  /**
+   * Force a fresh inference. Skips the cache read, runs the model, and
+   * replaces the cached value after a successful run. Applies to built-in
+   * and custom caches.
+   */
+  cacheRefresh?: boolean;
   /**
    * Streaming update callback. Receives the **cumulative** buffer (full text so
    * far), not deltas. For delta-shaped streaming, use `createSession()` and
@@ -209,7 +224,7 @@ export const ask = async (options: AskOptions): Promise<AskResult> => {
   // Mirror buildLangHints() exactly: supportedLanguages are intentionally not
   // normalized in the cache key unless they produce runtime language hints.
   const effectiveLanguageHint = languageHintedInput ?? languageHintedOutput;
-  const cache = resolveCache(options.cache);
+  const cache = resolveCache(options.cache, options.cacheTtl);
   const cacheKey =
     options.cacheKey ??
     defaultCacheKey({
@@ -226,7 +241,7 @@ export const ask = async (options: AskOptions): Promise<AskResult> => {
       responseConstraint: options.responseConstraint,
       omitResponseConstraintInput: options.omitResponseConstraintInput,
     });
-  if (cache) {
+  if (cache && !options.cacheRefresh) {
     const cached = cache.get(cacheKey);
     if (cached) return { output: cached, cached: true };
   }

--- a/packages/proofreader/README.md
+++ b/packages/proofreader/README.md
@@ -70,6 +70,8 @@ interface ProofreadOptions {
   monitor?: (m: CreateMonitor) => void;
   cache?: "session" | "local" | { get, set };
   cacheKey?: string;
+  cacheTtl?: number;      // built-in shortcut TTL in ms; default 1 hour
+  cacheRefresh?: boolean; // skip the cache read, write the fresh result
   signal?: AbortSignal;
 }
 
@@ -107,6 +109,26 @@ Drop every cached proofreader session. Sessions live for the tab lifetime by def
 ### Session cache controls
 
 `configureProofreaderCache({ max })` bounds the internal warm `Proofreader` session cache (default `8`). `clearProofreaderSessions()` drops every warm session, and `clearProofreaderSession({ expectedInputLanguages })` drops one matching proofreader configuration.
+
+## Result caching
+
+Off by default; every call hits the model. Pass `cache: "session"` for `sessionStorage`, `cache: "local"` for `localStorage`, or any `{ get, set }`-shaped object for a custom backend. The cache stores the serialized `ProofreadOutput`.
+
+### Expiry and refresh
+
+The built-in `"session"` / `"local"` shortcuts store each entry in a versioned envelope with an expiry time. Entries expire after one hour (`DEFAULT_CACHE_TTL_MS`) by default. Pass `cacheTtl` (milliseconds) to override the TTL per call. Expired entries, legacy raw strings, and malformed envelopes count as misses and are removed.
+
+Pass `cacheRefresh: true` to force a fresh inference. The call skips the cache read, runs the model, and replaces the cached value after a successful run. Failed and aborted runs leave the cached value in place.
+
+Custom `{ get, set }` caches own their expiry policy. `cacheTtl` does not apply to them; `cacheRefresh` still bypasses their read and updates them after success.
+
+```ts
+// Cache for five minutes instead of one hour.
+proofread({ input: text, cache: "local", cacheTtl: 5 * 60 * 1000 });
+
+// Force a fresh inference; later calls reuse the new value.
+proofread({ input: text, cache: "local", cacheRefresh: true });
+```
 
 ## Rendering corrections
 

--- a/packages/proofreader/src/cache.test.ts
+++ b/packages/proofreader/src/cache.test.ts
@@ -1,0 +1,180 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { DEFAULT_CACHE_TTL_MS, resolveCache } from "./cache.js";
+
+const fakeStorage = (): Storage => {
+  const store = new Map<string, string>();
+  return {
+    get length() {
+      return store.size;
+    },
+    clear: () => store.clear(),
+    getItem: (k) => store.get(k) ?? null,
+    key: (i) => Array.from(store.keys())[i] ?? null,
+    removeItem: (k) => {
+      store.delete(k);
+    },
+    setItem: (k, v) => {
+      store.set(k, v);
+    },
+  };
+};
+
+const installSessionStorage = (storage: Storage | undefined): void => {
+  Object.defineProperty(globalThis, "sessionStorage", {
+    value: storage,
+    configurable: true,
+    writable: true,
+  });
+};
+
+let originalSessionStorage: PropertyDescriptor | undefined;
+
+beforeEach(() => {
+  originalSessionStorage = Object.getOwnPropertyDescriptor(
+    globalThis,
+    "sessionStorage",
+  );
+  vi.useFakeTimers();
+  vi.setSystemTime(new Date("2026-01-01T00:00:00Z"));
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  if (originalSessionStorage) {
+    Object.defineProperty(globalThis, "sessionStorage", originalSessionStorage);
+  } else {
+    delete (globalThis as { sessionStorage?: Storage }).sessionStorage;
+  }
+});
+
+describe("storage shortcut TTL envelope", () => {
+  it("round-trips a value through a versioned envelope", () => {
+    const storage = fakeStorage();
+    installSessionStorage(storage);
+    const cache = resolveCache("session");
+    cache?.set("k", "v");
+    expect(cache?.get("k")).toBe("v");
+    const raw = storage.getItem("proofreader:k");
+    expect(raw).not.toBe("v");
+    expect(JSON.parse(raw ?? "")).toEqual({
+      v: 1,
+      value: "v",
+      expiresAt: Date.now() + DEFAULT_CACHE_TTL_MS,
+    });
+  });
+
+  it("expires entries after the default TTL and removes them", () => {
+    const storage = fakeStorage();
+    installSessionStorage(storage);
+    const cache = resolveCache("session");
+    cache?.set("k", "v");
+    vi.advanceTimersByTime(DEFAULT_CACHE_TTL_MS - 1);
+    expect(cache?.get("k")).toBe("v");
+    vi.advanceTimersByTime(1);
+    expect(cache?.get("k")).toBeNull();
+    expect(storage.getItem("proofreader:k")).toBeNull();
+  });
+
+  it("honors a caller-provided TTL override", () => {
+    installSessionStorage(fakeStorage());
+    const cache = resolveCache("session", 5_000);
+    cache?.set("k", "v");
+    vi.advanceTimersByTime(4_999);
+    expect(cache?.get("k")).toBe("v");
+    vi.advanceTimersByTime(1);
+    expect(cache?.get("k")).toBeNull();
+  });
+
+  it("falls back to the default TTL for invalid overrides", () => {
+    installSessionStorage(fakeStorage());
+    for (const ttl of [0, -1, Number.NaN, Number.POSITIVE_INFINITY]) {
+      const cache = resolveCache("session", ttl);
+      cache?.set("k", "v");
+      expect(cache?.get("k")).toBe("v");
+      vi.advanceTimersByTime(DEFAULT_CACHE_TTL_MS);
+      expect(cache?.get("k")).toBeNull();
+    }
+  });
+
+  it("treats legacy raw strings as misses and removes them", () => {
+    const storage = fakeStorage();
+    installSessionStorage(storage);
+    storage.setItem("proofreader:k", "legacy value");
+    const cache = resolveCache("session");
+    expect(cache?.get("k")).toBeNull();
+    expect(storage.getItem("proofreader:k")).toBeNull();
+  });
+
+  it("treats malformed envelopes as misses", () => {
+    const storage = fakeStorage();
+    installSessionStorage(storage);
+    const cache = resolveCache("session");
+    const badEntries = [
+      "{not json",
+      "null",
+      '"just a string"',
+      JSON.stringify({ v: 2, value: "v", expiresAt: Date.now() + 1000 }),
+      JSON.stringify({ v: 1, expiresAt: Date.now() + 1000 }),
+      JSON.stringify({ v: 1, value: 42, expiresAt: Date.now() + 1000 }),
+      JSON.stringify({ v: 1, value: "v" }),
+      JSON.stringify({ v: 1, value: "v", expiresAt: "soon" }),
+      JSON.stringify({ v: 1, value: "v", expiresAt: Number.NaN }),
+    ];
+    for (const entry of badEntries) {
+      storage.setItem("proofreader:k", entry);
+      expect(cache?.get("k")).toBeNull();
+      expect(storage.getItem("proofreader:k")).toBeNull();
+    }
+  });
+
+  it("replaces an invalid entry on the next set", () => {
+    const storage = fakeStorage();
+    installSessionStorage(storage);
+    storage.setItem("proofreader:k", "legacy value");
+    const cache = resolveCache("session");
+    expect(cache?.get("k")).toBeNull();
+    cache?.set("k", "fresh");
+    expect(cache?.get("k")).toBe("fresh");
+  });
+
+  it("returns null when storage is missing", () => {
+    installSessionStorage(undefined);
+    const cache = resolveCache("session");
+    expect(cache?.get("k")).toBeNull();
+    expect(() => cache?.set("k", "v")).not.toThrow();
+  });
+
+  it("swallows storage failures on get, set, and cleanup", () => {
+    const storage = fakeStorage();
+    storage.setItem("proofreader:k", "legacy value");
+    const throwing = {
+      ...storage,
+      getItem: () => {
+        throw new Error("denied");
+      },
+      setItem: () => {
+        throw new Error("quota");
+      },
+    } as Storage;
+    installSessionStorage(throwing);
+    const cache = resolveCache("session");
+    expect(cache?.get("k")).toBeNull();
+    expect(() => cache?.set("k", "v")).not.toThrow();
+
+    const removeThrows = {
+      ...storage,
+      getItem: (k: string) => storage.getItem(k),
+      removeItem: () => {
+        throw new Error("denied");
+      },
+    } as Storage;
+    installSessionStorage(removeThrows);
+    const cleanupCache = resolveCache("session");
+    expect(cleanupCache?.get("k")).toBeNull();
+  });
+
+  it("passes custom cache objects through untouched", () => {
+    const custom = { get: () => "v", set: () => {} };
+    expect(resolveCache(custom, 5_000)).toBe(custom);
+  });
+});

--- a/packages/proofreader/src/cache.ts
+++ b/packages/proofreader/src/cache.ts
@@ -16,28 +16,96 @@ export interface ProofreadCache {
  */
 export type CacheOption = "session" | "local" | ProofreadCache;
 
+/**
+ * Default time-to-live for entries written by the built-in `"session"` /
+ * `"local"` storage shortcuts: one hour. On-device model output changes as
+ * the browser updates the model, so built-in entries expire instead of
+ * persisting indefinitely. Override per call with `cacheTtl`. Custom
+ * `{ get, set }` caches own their expiry policy.
+ */
+export const DEFAULT_CACHE_TTL_MS = 60 * 60 * 1000;
+
+/** Version tag for the storage envelope written by the built-in shortcuts. */
+const ENVELOPE_VERSION = 1;
+
+interface CacheEnvelope {
+  v: number;
+  value: string;
+  expiresAt: number;
+}
+
+/**
+ * Parse a stored entry into a versioned envelope. Legacy raw strings,
+ * malformed JSON, unsupported versions, and invalid timestamps all return
+ * `null` so the caller treats them as misses.
+ */
+const parseEnvelope = (raw: string): CacheEnvelope | null => {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return null;
+  }
+  if (typeof parsed !== "object" || parsed === null) return null;
+  const envelope = parsed as Partial<CacheEnvelope>;
+  if (envelope.v !== ENVELOPE_VERSION) return null;
+  if (typeof envelope.value !== "string") return null;
+  if (
+    typeof envelope.expiresAt !== "number" ||
+    !Number.isFinite(envelope.expiresAt)
+  )
+    return null;
+  return envelope as CacheEnvelope;
+};
+
+const normalizeTtl = (ttlMs: number | undefined): number =>
+  typeof ttlMs === "number" && Number.isFinite(ttlMs) && ttlMs > 0
+    ? ttlMs
+    : DEFAULT_CACHE_TTL_MS;
+
 interface DefaultCacheOptions {
   storage?: Storage;
   prefix?: string;
+  ttlMs?: number;
 }
 
 const createStorageCache = (options: DefaultCacheOptions): ProofreadCache => {
   const prefix = options.prefix ?? "proofreader:";
   const storage = options.storage;
+  const ttlMs = normalizeTtl(options.ttlMs);
 
   return {
     get(key) {
       if (!storage) return null;
+      let raw: string | null;
       try {
-        return storage.getItem(prefix + key);
+        raw = storage.getItem(prefix + key);
       } catch {
         return null;
       }
+      if (raw === null) return null;
+      const envelope = parseEnvelope(raw);
+      if (envelope && Date.now() < envelope.expiresAt) return envelope.value;
+      // Legacy raw strings, malformed envelopes, and expired entries are
+      // misses; drop them so the next successful run replaces the slot.
+      try {
+        storage.removeItem(prefix + key);
+      } catch {
+        // best-effort cleanup only.
+      }
+      return null;
     },
     set(key, value) {
       if (!storage) return;
       try {
-        storage.setItem(prefix + key, value);
+        storage.setItem(
+          prefix + key,
+          JSON.stringify({
+            v: ENVELOPE_VERSION,
+            value,
+            expiresAt: Date.now() + ttlMs,
+          }),
+        );
       } catch {
         // quota / disabled storage; best-effort only.
       }
@@ -48,10 +116,12 @@ const createStorageCache = (options: DefaultCacheOptions): ProofreadCache => {
 /**
  * Resolve the public `cache` option into a concrete `{ get, set }` backend.
  * `undefined` → no caching. `"session"` / `"local"` → wrap the matching
- * web-storage backend (no-op fallback if unavailable). Object → passthrough.
+ * web-storage backend (no-op fallback if unavailable) with a TTL envelope.
+ * Object → passthrough; `ttlMs` does not apply to custom backends.
  */
 export const resolveCache = (
   value: CacheOption | undefined,
+  ttlMs?: number,
 ): ProofreadCache | undefined => {
   if (value === undefined) return undefined;
   if (value === "session") {
@@ -59,14 +129,14 @@ export const resolveCache = (
       typeof globalThis !== "undefined"
         ? (globalThis as { sessionStorage?: Storage }).sessionStorage
         : undefined;
-    return createStorageCache({ storage });
+    return createStorageCache({ storage, ttlMs });
   }
   if (value === "local") {
     const storage =
       typeof globalThis !== "undefined"
         ? (globalThis as { localStorage?: Storage }).localStorage
         : undefined;
-    return createStorageCache({ storage });
+    return createStorageCache({ storage, ttlMs });
   }
   return value;
 };

--- a/packages/proofreader/src/index.test.ts
+++ b/packages/proofreader/src/index.test.ts
@@ -128,6 +128,64 @@ describe("proofread", () => {
     expect(api.create).not.toHaveBeenCalled();
   });
 
+  it("bypasses the cache read and replaces the value on cacheRefresh", async () => {
+    const api = installFakeProofreader({ correctedInput: "Fresh." });
+    const cache = inMemoryCache();
+    cache.set(
+      '["hello",[]]',
+      JSON.stringify({ correctedInput: "Cached.", corrections: [] }),
+    );
+    const result = await proofread({
+      input: "hello",
+      cache,
+      cacheRefresh: true,
+    });
+    expect(result.cached).toBe(false);
+    expect(result.output?.correctedInput).toBe("Fresh.");
+    expect(api.create).toHaveBeenCalled();
+    expect(JSON.parse(cache.get('["hello",[]]') as string).correctedInput).toBe(
+      "Fresh.",
+    );
+  });
+
+  it("does not overwrite a cached value when the run is aborted", async () => {
+    installFakeProofreader();
+    const cache = inMemoryCache();
+    const seeded = JSON.stringify({
+      correctedInput: "Cached.",
+      corrections: [],
+    });
+    cache.set('["hello",[]]', seeded);
+    const controller = new AbortController();
+    controller.abort();
+    await expect(
+      proofread({
+        input: "hello",
+        cache,
+        cacheRefresh: true,
+        signal: controller.signal,
+      }),
+    ).rejects.toMatchObject({ name: "AbortError" });
+    expect(cache.get('["hello",[]]')).toBe(seeded);
+  });
+
+  it("does not touch the cache when the input is empty", async () => {
+    installFakeProofreader();
+    const cache = inMemoryCache();
+    const seeded = JSON.stringify({
+      correctedInput: "Cached.",
+      corrections: [],
+    });
+    cache.set('["hello",[]]', seeded);
+    const result = await proofread({
+      input: "   ",
+      cache,
+      cacheRefresh: true,
+    });
+    expect(result).toEqual({ output: null, cached: false });
+    expect(cache.get('["hello",[]]')).toBe(seeded);
+  });
+
   it("writes results to the cache", async () => {
     installFakeProofreader({ correctedInput: "Fixed." });
     const cache = inMemoryCache();
@@ -313,10 +371,10 @@ describe("proofread", () => {
       });
       expect(first.cached).toBe(false);
       expect(first.output?.correctedInput).toBe("Fixed.");
-      expect(storage.setItem).toHaveBeenCalledWith(
-        "proofreader:k",
-        '{"correctedInput":"Fixed.","corrections":[]}',
-      );
+      const stored = JSON.parse(store.get("proofreader:k") ?? "");
+      expect(stored.v).toBe(1);
+      expect(stored.value).toBe('{"correctedInput":"Fixed.","corrections":[]}');
+      expect(stored.expiresAt).toBeGreaterThan(Date.now());
 
       const createsAfterFirst = api.create.mock.calls.length;
       const second = await proofread({
@@ -350,10 +408,10 @@ describe("proofread", () => {
       });
       expect(first.cached).toBe(false);
       expect(first.output?.correctedInput).toBe("Fixed.");
-      expect(storage.setItem).toHaveBeenCalledWith(
-        "proofreader:k",
-        '{"correctedInput":"Fixed.","corrections":[]}',
-      );
+      const stored = JSON.parse(store.get("proofreader:k") ?? "");
+      expect(stored.v).toBe(1);
+      expect(stored.value).toBe('{"correctedInput":"Fixed.","corrections":[]}');
+      expect(stored.expiresAt).toBeGreaterThan(Date.now());
 
       const createsAfterFirst = api.create.mock.calls.length;
       const second = await proofread({

--- a/packages/proofreader/src/index.ts
+++ b/packages/proofreader/src/index.ts
@@ -38,7 +38,11 @@ export {
   isAvailable,
 } from "./api.js";
 
-export { defaultCacheKey, resolveCache } from "./cache.js";
+export {
+  DEFAULT_CACHE_TTL_MS,
+  defaultCacheKey,
+  resolveCache,
+} from "./cache.js";
 
 export type {
   CacheOption,
@@ -69,6 +73,19 @@ export interface ProofreadOptions {
   cache?: CacheOption;
   /** Cache key. Default: JSON array string of `[input, sortedExpectedInputLanguages]`. */
   cacheKey?: string;
+  /**
+   * Time-to-live in milliseconds for entries written by the built-in
+   * `"session"` / `"local"` storage shortcuts. Default: one hour
+   * (`DEFAULT_CACHE_TTL_MS`). Ignored for custom `{ get, set }` caches, which
+   * own their expiry policy.
+   */
+  cacheTtl?: number;
+  /**
+   * Force a fresh proofread. Skips the cache read, runs the model, and
+   * replaces the cached value after a successful run. Applies to built-in
+   * and custom caches.
+   */
+  cacheRefresh?: boolean;
   /** Abort signal. */
   signal?: AbortSignal;
 }
@@ -119,10 +136,10 @@ export const proofread = async (
     ? [...options.expectedInputLanguages]
     : undefined;
 
-  const cache = resolveCache(options.cache);
+  const cache = resolveCache(options.cache, options.cacheTtl);
   const cacheKey =
     options.cacheKey ?? defaultCacheKey({ text, expectedInputLanguages });
-  if (cache) {
+  if (cache && !options.cacheRefresh) {
     const cached = cache.get(cacheKey);
     if (cached) {
       try {

--- a/packages/proofreader/src/react/index.ts
+++ b/packages/proofreader/src/react/index.ts
@@ -47,6 +47,8 @@ export const useProofreader = (
     monitor,
     cache,
     cacheKey,
+    cacheTtl,
+    cacheRefresh,
     enabled = true,
   } = options;
 
@@ -72,6 +74,8 @@ export const useProofreader = (
       monitor,
       cache,
       cacheKey,
+      cacheTtl,
+      cacheRefresh,
       signal: controller.signal,
     })
       .then((result) => {
@@ -94,7 +98,16 @@ export const useProofreader = (
     return () => {
       controller.abort();
     };
-  }, [enabled, input, expectedInputLanguages, monitor, cache, cacheKey]);
+  }, [
+    enabled,
+    input,
+    expectedInputLanguages,
+    monitor,
+    cache,
+    cacheKey,
+    cacheTtl,
+    cacheRefresh,
+  ]);
 
   return { status, output, error, fromCache };
 };

--- a/packages/rewriter/README.md
+++ b/packages/rewriter/README.md
@@ -71,6 +71,8 @@ interface RewriteOptions {
   monitor?: (m: CreateMonitor) => void;
   cache?: "session" | "local" | { get, set };
   cacheKey?: string;
+  cacheTtl?: number;      // built-in shortcut TTL in ms; default 1 hour
+  cacheRefresh?: boolean; // skip the cache read, write the fresh result
   onUpdate?: (text: string) => void; // cumulative buffer, not deltas
   signal?: AbortSignal;
 }
@@ -100,6 +102,26 @@ import {
 ```
 
 The internal session cache is LRU-bounded (default 8). Evicted sessions have their `destroy()` invoked when present.
+
+## Result caching
+
+Off by default; every call hits the model. Pass `cache: "session"` for `sessionStorage`, `cache: "local"` for `localStorage`, or any `{ get, set }`-shaped object for a custom backend.
+
+### Expiry and refresh
+
+The built-in `"session"` / `"local"` shortcuts store each entry in a versioned envelope with an expiry time. Entries expire after one hour (`DEFAULT_CACHE_TTL_MS`) by default. Pass `cacheTtl` (milliseconds) to override the TTL per call. Expired entries, legacy raw strings, and malformed envelopes count as misses and are removed.
+
+Pass `cacheRefresh: true` to force a fresh inference. The call skips the cache read, runs the model, and replaces the cached value after a successful run. Failed, aborted, or empty runs leave the cached value in place.
+
+Custom `{ get, set }` caches own their expiry policy. `cacheTtl` does not apply to them; `cacheRefresh` still bypasses their read and updates them after success.
+
+```ts
+// Cache for five minutes instead of one hour.
+rewrite({ input: text, cache: "local", cacheTtl: 5 * 60 * 1000 });
+
+// Force a fresh inference; later calls reuse the new value.
+rewrite({ input: text, cache: "local", cacheRefresh: true });
+```
 
 ## Output normalization
 

--- a/packages/rewriter/src/cache.test.ts
+++ b/packages/rewriter/src/cache.test.ts
@@ -1,0 +1,180 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { DEFAULT_CACHE_TTL_MS, resolveCache } from "./cache.js";
+
+const fakeStorage = (): Storage => {
+  const store = new Map<string, string>();
+  return {
+    get length() {
+      return store.size;
+    },
+    clear: () => store.clear(),
+    getItem: (k) => store.get(k) ?? null,
+    key: (i) => Array.from(store.keys())[i] ?? null,
+    removeItem: (k) => {
+      store.delete(k);
+    },
+    setItem: (k, v) => {
+      store.set(k, v);
+    },
+  };
+};
+
+const installSessionStorage = (storage: Storage | undefined): void => {
+  Object.defineProperty(globalThis, "sessionStorage", {
+    value: storage,
+    configurable: true,
+    writable: true,
+  });
+};
+
+let originalSessionStorage: PropertyDescriptor | undefined;
+
+beforeEach(() => {
+  originalSessionStorage = Object.getOwnPropertyDescriptor(
+    globalThis,
+    "sessionStorage",
+  );
+  vi.useFakeTimers();
+  vi.setSystemTime(new Date("2026-01-01T00:00:00Z"));
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  if (originalSessionStorage) {
+    Object.defineProperty(globalThis, "sessionStorage", originalSessionStorage);
+  } else {
+    delete (globalThis as { sessionStorage?: Storage }).sessionStorage;
+  }
+});
+
+describe("storage shortcut TTL envelope", () => {
+  it("round-trips a value through a versioned envelope", () => {
+    const storage = fakeStorage();
+    installSessionStorage(storage);
+    const cache = resolveCache("session");
+    cache?.set("k", "v");
+    expect(cache?.get("k")).toBe("v");
+    const raw = storage.getItem("rewriter:k");
+    expect(raw).not.toBe("v");
+    expect(JSON.parse(raw ?? "")).toEqual({
+      v: 1,
+      value: "v",
+      expiresAt: Date.now() + DEFAULT_CACHE_TTL_MS,
+    });
+  });
+
+  it("expires entries after the default TTL and removes them", () => {
+    const storage = fakeStorage();
+    installSessionStorage(storage);
+    const cache = resolveCache("session");
+    cache?.set("k", "v");
+    vi.advanceTimersByTime(DEFAULT_CACHE_TTL_MS - 1);
+    expect(cache?.get("k")).toBe("v");
+    vi.advanceTimersByTime(1);
+    expect(cache?.get("k")).toBeNull();
+    expect(storage.getItem("rewriter:k")).toBeNull();
+  });
+
+  it("honors a caller-provided TTL override", () => {
+    installSessionStorage(fakeStorage());
+    const cache = resolveCache("session", 5_000);
+    cache?.set("k", "v");
+    vi.advanceTimersByTime(4_999);
+    expect(cache?.get("k")).toBe("v");
+    vi.advanceTimersByTime(1);
+    expect(cache?.get("k")).toBeNull();
+  });
+
+  it("falls back to the default TTL for invalid overrides", () => {
+    installSessionStorage(fakeStorage());
+    for (const ttl of [0, -1, Number.NaN, Number.POSITIVE_INFINITY]) {
+      const cache = resolveCache("session", ttl);
+      cache?.set("k", "v");
+      expect(cache?.get("k")).toBe("v");
+      vi.advanceTimersByTime(DEFAULT_CACHE_TTL_MS);
+      expect(cache?.get("k")).toBeNull();
+    }
+  });
+
+  it("treats legacy raw strings as misses and removes them", () => {
+    const storage = fakeStorage();
+    installSessionStorage(storage);
+    storage.setItem("rewriter:k", "legacy value");
+    const cache = resolveCache("session");
+    expect(cache?.get("k")).toBeNull();
+    expect(storage.getItem("rewriter:k")).toBeNull();
+  });
+
+  it("treats malformed envelopes as misses", () => {
+    const storage = fakeStorage();
+    installSessionStorage(storage);
+    const cache = resolveCache("session");
+    const badEntries = [
+      "{not json",
+      "null",
+      '"just a string"',
+      JSON.stringify({ v: 2, value: "v", expiresAt: Date.now() + 1000 }),
+      JSON.stringify({ v: 1, expiresAt: Date.now() + 1000 }),
+      JSON.stringify({ v: 1, value: 42, expiresAt: Date.now() + 1000 }),
+      JSON.stringify({ v: 1, value: "v" }),
+      JSON.stringify({ v: 1, value: "v", expiresAt: "soon" }),
+      JSON.stringify({ v: 1, value: "v", expiresAt: Number.NaN }),
+    ];
+    for (const entry of badEntries) {
+      storage.setItem("rewriter:k", entry);
+      expect(cache?.get("k")).toBeNull();
+      expect(storage.getItem("rewriter:k")).toBeNull();
+    }
+  });
+
+  it("replaces an invalid entry on the next set", () => {
+    const storage = fakeStorage();
+    installSessionStorage(storage);
+    storage.setItem("rewriter:k", "legacy value");
+    const cache = resolveCache("session");
+    expect(cache?.get("k")).toBeNull();
+    cache?.set("k", "fresh");
+    expect(cache?.get("k")).toBe("fresh");
+  });
+
+  it("returns null when storage is missing", () => {
+    installSessionStorage(undefined);
+    const cache = resolveCache("session");
+    expect(cache?.get("k")).toBeNull();
+    expect(() => cache?.set("k", "v")).not.toThrow();
+  });
+
+  it("swallows storage failures on get, set, and cleanup", () => {
+    const storage = fakeStorage();
+    storage.setItem("rewriter:k", "legacy value");
+    const throwing = {
+      ...storage,
+      getItem: () => {
+        throw new Error("denied");
+      },
+      setItem: () => {
+        throw new Error("quota");
+      },
+    } as Storage;
+    installSessionStorage(throwing);
+    const cache = resolveCache("session");
+    expect(cache?.get("k")).toBeNull();
+    expect(() => cache?.set("k", "v")).not.toThrow();
+
+    const removeThrows = {
+      ...storage,
+      getItem: (k: string) => storage.getItem(k),
+      removeItem: () => {
+        throw new Error("denied");
+      },
+    } as Storage;
+    installSessionStorage(removeThrows);
+    const cleanupCache = resolveCache("session");
+    expect(cleanupCache?.get("k")).toBeNull();
+  });
+
+  it("passes custom cache objects through untouched", () => {
+    const custom = { get: () => "v", set: () => {} };
+    expect(resolveCache(custom, 5_000)).toBe(custom);
+  });
+});

--- a/packages/rewriter/src/cache.ts
+++ b/packages/rewriter/src/cache.ts
@@ -15,28 +15,96 @@ export interface RewriteCache {
  */
 export type CacheOption = "session" | "local" | RewriteCache;
 
+/**
+ * Default time-to-live for entries written by the built-in `"session"` /
+ * `"local"` storage shortcuts: one hour. On-device model output changes as
+ * the browser updates the model, so built-in entries expire instead of
+ * persisting indefinitely. Override per call with `cacheTtl`. Custom
+ * `{ get, set }` caches own their expiry policy.
+ */
+export const DEFAULT_CACHE_TTL_MS = 60 * 60 * 1000;
+
+/** Version tag for the storage envelope written by the built-in shortcuts. */
+const ENVELOPE_VERSION = 1;
+
+interface CacheEnvelope {
+  v: number;
+  value: string;
+  expiresAt: number;
+}
+
+/**
+ * Parse a stored entry into a versioned envelope. Legacy raw strings,
+ * malformed JSON, unsupported versions, and invalid timestamps all return
+ * `null` so the caller treats them as misses.
+ */
+const parseEnvelope = (raw: string): CacheEnvelope | null => {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return null;
+  }
+  if (typeof parsed !== "object" || parsed === null) return null;
+  const envelope = parsed as Partial<CacheEnvelope>;
+  if (envelope.v !== ENVELOPE_VERSION) return null;
+  if (typeof envelope.value !== "string") return null;
+  if (
+    typeof envelope.expiresAt !== "number" ||
+    !Number.isFinite(envelope.expiresAt)
+  )
+    return null;
+  return envelope as CacheEnvelope;
+};
+
+const normalizeTtl = (ttlMs: number | undefined): number =>
+  typeof ttlMs === "number" && Number.isFinite(ttlMs) && ttlMs > 0
+    ? ttlMs
+    : DEFAULT_CACHE_TTL_MS;
+
 interface DefaultCacheOptions {
   storage?: Storage;
   prefix?: string;
+  ttlMs?: number;
 }
 
 const createStorageCache = (options: DefaultCacheOptions): RewriteCache => {
   const prefix = options.prefix ?? "rewriter:";
   const storage = options.storage;
+  const ttlMs = normalizeTtl(options.ttlMs);
 
   return {
     get(key) {
       if (!storage) return null;
+      let raw: string | null;
       try {
-        return storage.getItem(prefix + key);
+        raw = storage.getItem(prefix + key);
       } catch {
         return null;
       }
+      if (raw === null) return null;
+      const envelope = parseEnvelope(raw);
+      if (envelope && Date.now() < envelope.expiresAt) return envelope.value;
+      // Legacy raw strings, malformed envelopes, and expired entries are
+      // misses; drop them so the next successful run replaces the slot.
+      try {
+        storage.removeItem(prefix + key);
+      } catch {
+        // best-effort cleanup only.
+      }
+      return null;
     },
     set(key, value) {
       if (!storage) return;
       try {
-        storage.setItem(prefix + key, value);
+        storage.setItem(
+          prefix + key,
+          JSON.stringify({
+            v: ENVELOPE_VERSION,
+            value,
+            expiresAt: Date.now() + ttlMs,
+          }),
+        );
       } catch {
         // quota / disabled storage; best-effort only.
       }
@@ -47,10 +115,12 @@ const createStorageCache = (options: DefaultCacheOptions): RewriteCache => {
 /**
  * Resolve the public `cache` option into a concrete `{ get, set }` backend.
  * `undefined` → no caching. `"session"` / `"local"` → wrap the matching
- * web-storage backend (no-op fallback if unavailable). Object → passthrough.
+ * web-storage backend (no-op fallback if unavailable) with a TTL envelope.
+ * Object → passthrough; `ttlMs` does not apply to custom backends.
  */
 export const resolveCache = (
   value: CacheOption | undefined,
+  ttlMs?: number,
 ): RewriteCache | undefined => {
   if (value === undefined) return undefined;
   if (value === "session") {
@@ -58,14 +128,14 @@ export const resolveCache = (
       typeof globalThis !== "undefined"
         ? (globalThis as { sessionStorage?: Storage }).sessionStorage
         : undefined;
-    return createStorageCache({ storage });
+    return createStorageCache({ storage, ttlMs });
   }
   if (value === "local") {
     const storage =
       typeof globalThis !== "undefined"
         ? (globalThis as { localStorage?: Storage }).localStorage
         : undefined;
-    return createStorageCache({ storage });
+    return createStorageCache({ storage, ttlMs });
   }
   return value;
 };

--- a/packages/rewriter/src/index.test.ts
+++ b/packages/rewriter/src/index.test.ts
@@ -134,6 +134,53 @@ describe("rewrite", () => {
     expect(api.create).not.toHaveBeenCalled();
   });
 
+  it("bypasses the cache read and replaces the value on cacheRefresh", async () => {
+    const api = installFakeRewriter({ output: "Fresh rewrite." });
+    const cache = inMemoryCache();
+    cache.set("k", "Cached rewrite.");
+    const result = await rewrite({
+      input: "irrelevant",
+      cache,
+      cacheKey: "k",
+      cacheRefresh: true,
+    });
+    expect(result).toEqual({ output: "Fresh rewrite.", cached: false });
+    expect(api.create).toHaveBeenCalled();
+    expect(cache.get("k")).toBe("Fresh rewrite.");
+  });
+
+  it("does not overwrite a cached value when the run is aborted", async () => {
+    installFakeRewriter();
+    const cache = inMemoryCache();
+    cache.set("k", "Cached rewrite.");
+    const controller = new AbortController();
+    controller.abort();
+    await expect(
+      rewrite({
+        input: "irrelevant",
+        cache,
+        cacheKey: "k",
+        cacheRefresh: true,
+        signal: controller.signal,
+      }),
+    ).rejects.toMatchObject({ name: "AbortError" });
+    expect(cache.get("k")).toBe("Cached rewrite.");
+  });
+
+  it("does not overwrite a cached value when the response is empty", async () => {
+    installFakeRewriter({ output: "   " });
+    const cache = inMemoryCache();
+    cache.set("k", "Cached rewrite.");
+    const result = await rewrite({
+      input: "irrelevant",
+      cache,
+      cacheKey: "k",
+      cacheRefresh: true,
+    });
+    expect(result).toEqual({ output: null, cached: false });
+    expect(cache.get("k")).toBe("Cached rewrite.");
+  });
+
   it("does not collide cache entries when sharedContext differs", async () => {
     let calls = 0;
     const api = installFakeRewriter();
@@ -287,7 +334,10 @@ describe("rewrite", () => {
         cacheKey: "k",
       });
       expect(first).toEqual({ output: "Stored.", cached: false });
-      expect(storage.setItem).toHaveBeenCalledWith("rewriter:k", "Stored.");
+      const stored = JSON.parse(store.get("rewriter:k") ?? "");
+      expect(stored.v).toBe(1);
+      expect(stored.value).toBe("Stored.");
+      expect(stored.expiresAt).toBeGreaterThan(Date.now());
 
       const createsAfterFirst = api.create.mock.calls.length;
       const second = await rewrite({
@@ -319,7 +369,10 @@ describe("rewrite", () => {
         cacheKey: "k",
       });
       expect(first).toEqual({ output: "Stored.", cached: false });
-      expect(storage.setItem).toHaveBeenCalledWith("rewriter:k", "Stored.");
+      const stored = JSON.parse(store.get("rewriter:k") ?? "");
+      expect(stored.v).toBe(1);
+      expect(stored.value).toBe("Stored.");
+      expect(stored.expiresAt).toBeGreaterThan(Date.now());
 
       const createsAfterFirst = api.create.mock.calls.length;
       const second = await rewrite({

--- a/packages/rewriter/src/index.ts
+++ b/packages/rewriter/src/index.ts
@@ -34,7 +34,11 @@ export {
   isAvailable,
 } from "./api.js";
 
-export { defaultCacheKey, resolveCache } from "./cache.js";
+export {
+  DEFAULT_CACHE_TTL_MS,
+  defaultCacheKey,
+  resolveCache,
+} from "./cache.js";
 
 export type {
   CacheOption,
@@ -74,6 +78,19 @@ export interface RewriteOptions {
   cache?: CacheOption;
   /** Cache key. Default: JSON string of input, context, language hints, shared context, and output shape. */
   cacheKey?: string;
+  /**
+   * Time-to-live in milliseconds for entries written by the built-in
+   * `"session"` / `"local"` storage shortcuts. Default: one hour
+   * (`DEFAULT_CACHE_TTL_MS`). Ignored for custom `{ get, set }` caches, which
+   * own their expiry policy.
+   */
+  cacheTtl?: number;
+  /**
+   * Force a fresh rewrite. Skips the cache read, runs the model, and
+   * replaces the cached value after a successful run. Applies to built-in
+   * and custom caches.
+   */
+  cacheRefresh?: boolean;
   /**
    * Streaming update callback (cumulative buffer, monotonically growing).
    * Receives the **cumulative** text, not deltas.
@@ -134,7 +151,7 @@ export const rewrite = async (
   ).map(NORMALIZE_LANG);
   const supported = new Set(supportedLanguages);
   const languageHints = lang ? supported.has(lang) : false;
-  const cache = resolveCache(options.cache);
+  const cache = resolveCache(options.cache, options.cacheTtl);
   const cacheKey =
     options.cacheKey ??
     defaultCacheKey({
@@ -147,7 +164,7 @@ export const rewrite = async (
       language: lang,
       languageHints,
     });
-  if (cache) {
+  if (cache && !options.cacheRefresh) {
     const cached = cache.get(cacheKey);
     if (cached) return { output: cached, cached: true };
   }

--- a/packages/rewriter/src/react/index.ts
+++ b/packages/rewriter/src/react/index.ts
@@ -55,6 +55,8 @@ export const useRewriter = (options: UseRewriterOptions): UseRewriterReturn => {
     monitor,
     cache,
     cacheKey,
+    cacheTtl,
+    cacheRefresh,
     enabled = true,
   } = options;
 
@@ -86,6 +88,8 @@ export const useRewriter = (options: UseRewriterOptions): UseRewriterReturn => {
       monitor,
       cache,
       cacheKey,
+      cacheTtl,
+      cacheRefresh,
       signal: controller.signal,
       onUpdate: (chunk) => {
         if (controller.signal.aborted) return;
@@ -126,6 +130,8 @@ export const useRewriter = (options: UseRewriterOptions): UseRewriterReturn => {
     monitor,
     cache,
     cacheKey,
+    cacheTtl,
+    cacheRefresh,
   ]);
 
   const dismiss = () => {

--- a/packages/sdk/src/index.test.ts
+++ b/packages/sdk/src/index.test.ts
@@ -16,6 +16,30 @@ import * as writerSubpath from "./writer.js";
 // We check a single representative export from each package as a tripwire;
 // the full APIs are covered by each scoped package's own tests.
 
+// Compile-time tripwire: the shared result-cache options exist with the same
+// names on every result-producing package.
+type SharedCacheOptions = { cacheTtl?: number; cacheRefresh?: boolean };
+const _cacheOptionTripwire: [
+  Pick<sdk.prompt.AskOptions, "cacheTtl" | "cacheRefresh">,
+  Pick<sdk.summarizer.SummarizeOptions, "cacheTtl" | "cacheRefresh">,
+  Pick<sdk.translator.TranslateOptions, "cacheTtl" | "cacheRefresh">,
+  Pick<sdk.detector.DetectOptions, "cacheTtl" | "cacheRefresh">,
+  Pick<sdk.writer.WriteOptions, "cacheTtl" | "cacheRefresh">,
+  Pick<sdk.rewriter.RewriteOptions, "cacheTtl" | "cacheRefresh">,
+  Pick<sdk.proofreader.ProofreadOptions, "cacheTtl" | "cacheRefresh">,
+] extends [
+  SharedCacheOptions,
+  SharedCacheOptions,
+  SharedCacheOptions,
+  SharedCacheOptions,
+  SharedCacheOptions,
+  SharedCacheOptions,
+  SharedCacheOptions,
+]
+  ? true
+  : never = true;
+void _cacheOptionTripwire;
+
 describe("web-ai-sdk root namespace", () => {
   it("exposes every scoped package", () => {
     expect(typeof sdk.prompt.ask).toBe("function");
@@ -30,6 +54,17 @@ describe("web-ai-sdk root namespace", () => {
     expect(typeof sdk.writer.write).toBe("function");
     expect(typeof sdk.rewriter.rewrite).toBe("function");
     expect(typeof sdk.proofreader.proofread).toBe("function");
+  });
+
+  it("exposes the shared cache TTL default on result-producing packages", () => {
+    const oneHour = 60 * 60 * 1000;
+    expect(sdk.prompt.DEFAULT_CACHE_TTL_MS).toBe(oneHour);
+    expect(sdk.summarizer.DEFAULT_CACHE_TTL_MS).toBe(oneHour);
+    expect(sdk.translator.DEFAULT_CACHE_TTL_MS).toBe(oneHour);
+    expect(sdk.detector.DEFAULT_CACHE_TTL_MS).toBe(oneHour);
+    expect(sdk.writer.DEFAULT_CACHE_TTL_MS).toBe(oneHour);
+    expect(sdk.rewriter.DEFAULT_CACHE_TTL_MS).toBe(oneHour);
+    expect(sdk.proofreader.DEFAULT_CACHE_TTL_MS).toBe(oneHour);
   });
 });
 

--- a/packages/summarizer/README.md
+++ b/packages/summarizer/README.md
@@ -81,6 +81,8 @@ interface SummarizeOptions {
   monitor?: (m: CreateMonitor) => void;
   cache?: "session" | "local" | { get, set };
   cacheKey?: string; // default: JSON.stringify([pathname, trimmed input, normalizedLanguage, languageHints, type, length, format, preference, sharedContext]); normalizedLanguage = language's lowercase primary subtag (pt-BR becomes pt), languageHints = boolean (normalized language is in supportedLanguages)
+  cacheTtl?: number;      // built-in shortcut TTL in ms; default 1 hour
+  cacheRefresh?: boolean; // skip the cache read, write the fresh result
   onUpdate?: (text: string) => void;
   signal?: AbortSignal;
 }
@@ -122,6 +124,22 @@ summarize({ language: "en", input: text, cache: "session" });
 
 // Persistent caching across tabs.
 summarize({ language: "en", input: text, cache: "local" });
+```
+
+### Expiry and refresh
+
+The built-in `"session"` / `"local"` shortcuts store each entry in a versioned envelope with an expiry time. Entries expire after one hour (`DEFAULT_CACHE_TTL_MS`) by default. Pass `cacheTtl` (milliseconds) to override the TTL per call. Expired entries, legacy raw strings, and malformed envelopes count as misses and are removed.
+
+Pass `cacheRefresh: true` to force a fresh inference. The call skips the cache read, runs the model, and replaces the cached value after a successful run. Failed, aborted, or empty runs leave the cached value in place.
+
+Custom `{ get, set }` caches own their expiry policy. `cacheTtl` does not apply to them; `cacheRefresh` still bypasses their read and updates them after success.
+
+```ts
+// Cache for five minutes instead of one hour.
+summarize({ language: "en", input: text, cache: "local", cacheTtl: 5 * 60 * 1000 });
+
+// Force a fresh inference; later calls reuse the new value.
+summarize({ language: "en", input: text, cache: "local", cacheRefresh: true });
 ```
 
 The internal session cache (warm `Summarizer` instances) is separate and always on, so same-config calls skip the ~1-3s cold start within a tab.

--- a/packages/summarizer/src/cache.test.ts
+++ b/packages/summarizer/src/cache.test.ts
@@ -1,5 +1,10 @@
-import { describe, expect, it } from "vitest";
-import { createSessionStorageCache, defaultCacheKey } from "./cache.js";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  createSessionStorageCache,
+  DEFAULT_CACHE_TTL_MS,
+  defaultCacheKey,
+  resolveCache,
+} from "./cache.js";
 
 const fakeStorage = (): Storage => {
   const store = new Map<string, string>();
@@ -19,13 +24,110 @@ const fakeStorage = (): Storage => {
   };
 };
 
-describe("createSessionStorageCache", () => {
-  it("round-trips a value through the storage backend", () => {
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.setSystemTime(new Date("2026-01-01T00:00:00Z"));
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("createSessionStorageCache TTL envelope", () => {
+  it("round-trips a value through a versioned envelope", () => {
     const storage = fakeStorage();
     const cache = createSessionStorageCache({ storage });
     cache.set("k", "v");
     expect(cache.get("k")).toBe("v");
-    expect(storage.getItem("summarizer:k")).toBe("v");
+    const raw = storage.getItem("summarizer:k");
+    expect(raw).not.toBe("v");
+    expect(JSON.parse(raw ?? "")).toEqual({
+      v: 1,
+      value: "v",
+      expiresAt: Date.now() + DEFAULT_CACHE_TTL_MS,
+    });
+  });
+
+  it("expires entries after the default TTL and removes them", () => {
+    const storage = fakeStorage();
+    const cache = createSessionStorageCache({ storage });
+    cache.set("k", "v");
+    vi.advanceTimersByTime(DEFAULT_CACHE_TTL_MS - 1);
+    expect(cache.get("k")).toBe("v");
+    vi.advanceTimersByTime(1);
+    expect(cache.get("k")).toBeNull();
+    expect(storage.getItem("summarizer:k")).toBeNull();
+  });
+
+  it("honors a caller-provided TTL override", () => {
+    const cache = createSessionStorageCache({
+      storage: fakeStorage(),
+      ttlMs: 5_000,
+    });
+    cache.set("k", "v");
+    vi.advanceTimersByTime(4_999);
+    expect(cache.get("k")).toBe("v");
+    vi.advanceTimersByTime(1);
+    expect(cache.get("k")).toBeNull();
+  });
+
+  it("falls back to the default TTL for invalid overrides", () => {
+    for (const ttl of [0, -1, Number.NaN, Number.POSITIVE_INFINITY]) {
+      const cache = createSessionStorageCache({
+        storage: fakeStorage(),
+        ttlMs: ttl,
+      });
+      cache.set("k", "v");
+      expect(cache.get("k")).toBe("v");
+      vi.advanceTimersByTime(DEFAULT_CACHE_TTL_MS);
+      expect(cache.get("k")).toBeNull();
+    }
+  });
+
+  it("treats legacy raw strings as misses and removes them", () => {
+    const storage = fakeStorage();
+    storage.setItem("summarizer:k", "legacy value");
+    const cache = createSessionStorageCache({ storage });
+    expect(cache.get("k")).toBeNull();
+    expect(storage.getItem("summarizer:k")).toBeNull();
+  });
+
+  it("treats malformed envelopes as misses", () => {
+    const storage = fakeStorage();
+    const cache = createSessionStorageCache({ storage });
+    const badEntries = [
+      "{not json",
+      "null",
+      '"just a string"',
+      JSON.stringify({ v: 2, value: "v", expiresAt: Date.now() + 1000 }),
+      JSON.stringify({ v: 1, expiresAt: Date.now() + 1000 }),
+      JSON.stringify({ v: 1, value: 42, expiresAt: Date.now() + 1000 }),
+      JSON.stringify({ v: 1, value: "v" }),
+      JSON.stringify({ v: 1, value: "v", expiresAt: "soon" }),
+      JSON.stringify({ v: 1, value: "v", expiresAt: Number.NaN }),
+    ];
+    for (const entry of badEntries) {
+      storage.setItem("summarizer:k", entry);
+      expect(cache.get("k")).toBeNull();
+      expect(storage.getItem("summarizer:k")).toBeNull();
+    }
+  });
+
+  it("replaces an invalid entry on the next set", () => {
+    const storage = fakeStorage();
+    storage.setItem("summarizer:k", "legacy value");
+    const cache = createSessionStorageCache({ storage });
+    expect(cache.get("k")).toBeNull();
+    cache.set("k", "fresh");
+    expect(cache.get("k")).toBe("fresh");
+  });
+
+  it("supports a custom prefix", () => {
+    const storage = fakeStorage();
+    const cache = createSessionStorageCache({ storage, prefix: "p:" });
+    cache.set("k", "v");
+    expect(cache.get("k")).toBe("v");
+    expect(storage.getItem("p:k")).not.toBeNull();
   });
 
   it("returns null when storage is missing", () => {
@@ -36,27 +138,65 @@ describe("createSessionStorageCache", () => {
     expect(() => cache.set("k", "v")).not.toThrow();
   });
 
-  it("supports a custom prefix", () => {
+  it("swallows storage failures on get, set, and cleanup", () => {
     const storage = fakeStorage();
-    const cache = createSessionStorageCache({ storage, prefix: "p:" });
-    cache.set("k", "v");
-    expect(storage.getItem("p:k")).toBe("v");
+    storage.setItem("summarizer:k", "legacy value");
+    const throwing = {
+      ...storage,
+      getItem: () => {
+        throw new Error("denied");
+      },
+      setItem: () => {
+        throw new Error("quota");
+      },
+    } as Storage;
+    const cache = createSessionStorageCache({ storage: throwing });
+    expect(cache.get("k")).toBeNull();
+    expect(() => cache.set("k", "v")).not.toThrow();
+
+    const removeThrows = {
+      ...storage,
+      getItem: (k: string) => storage.getItem(k),
+      removeItem: () => {
+        throw new Error("denied");
+      },
+    } as Storage;
+    const cleanupCache = createSessionStorageCache({ storage: removeThrows });
+    expect(cleanupCache.get("k")).toBeNull();
+  });
+});
+
+describe("resolveCache", () => {
+  it("forwards the TTL override to the session storage shortcut", () => {
+    const storage = fakeStorage();
+    const original = Object.getOwnPropertyDescriptor(
+      globalThis,
+      "sessionStorage",
+    );
+    Object.defineProperty(globalThis, "sessionStorage", {
+      value: storage,
+      configurable: true,
+      writable: true,
+    });
+    try {
+      const cache = resolveCache("session", 5_000);
+      cache?.set("k", "v");
+      vi.advanceTimersByTime(4_999);
+      expect(cache?.get("k")).toBe("v");
+      vi.advanceTimersByTime(1);
+      expect(cache?.get("k")).toBeNull();
+    } finally {
+      if (original) {
+        Object.defineProperty(globalThis, "sessionStorage", original);
+      } else {
+        delete (globalThis as { sessionStorage?: Storage }).sessionStorage;
+      }
+    }
   });
 
-  it("swallows errors from the underlying storage on get", () => {
-    const cache = createSessionStorageCache({
-      storage: {
-        getItem: () => {
-          throw new Error("denied");
-        },
-        setItem: () => {},
-        removeItem: () => {},
-        clear: () => {},
-        key: () => null,
-        length: 0,
-      } as Storage,
-    });
-    expect(cache.get("k")).toBeNull();
+  it("passes custom cache objects through untouched", () => {
+    const custom = { get: () => "v", set: () => {} };
+    expect(resolveCache(custom, 5_000)).toBe(custom);
   });
 });
 

--- a/packages/summarizer/src/cache.ts
+++ b/packages/summarizer/src/cache.ts
@@ -16,11 +16,60 @@ export interface SummaryCache {
  */
 export type CacheOption = "session" | "local" | SummaryCache;
 
+/**
+ * Default time-to-live for entries written by the built-in `"session"` /
+ * `"local"` storage shortcuts: one hour. On-device model output changes as
+ * the browser updates the model, so built-in entries expire instead of
+ * persisting indefinitely. Override per call with `cacheTtl`. Custom
+ * `{ get, set }` caches own their expiry policy.
+ */
+export const DEFAULT_CACHE_TTL_MS = 60 * 60 * 1000;
+
+/** Version tag for the storage envelope written by the built-in shortcuts. */
+const ENVELOPE_VERSION = 1;
+
+interface CacheEnvelope {
+  v: number;
+  value: string;
+  expiresAt: number;
+}
+
+/**
+ * Parse a stored entry into a versioned envelope. Legacy raw strings,
+ * malformed JSON, unsupported versions, and invalid timestamps all return
+ * `null` so the caller treats them as misses.
+ */
+const parseEnvelope = (raw: string): CacheEnvelope | null => {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return null;
+  }
+  if (typeof parsed !== "object" || parsed === null) return null;
+  const envelope = parsed as Partial<CacheEnvelope>;
+  if (envelope.v !== ENVELOPE_VERSION) return null;
+  if (typeof envelope.value !== "string") return null;
+  if (
+    typeof envelope.expiresAt !== "number" ||
+    !Number.isFinite(envelope.expiresAt)
+  )
+    return null;
+  return envelope as CacheEnvelope;
+};
+
+const normalizeTtl = (ttlMs: number | undefined): number =>
+  typeof ttlMs === "number" && Number.isFinite(ttlMs) && ttlMs > 0
+    ? ttlMs
+    : DEFAULT_CACHE_TTL_MS;
+
 interface DefaultCacheOptions {
   /** Storage backend. Default: `globalThis.sessionStorage`. */
   storage?: Storage;
   /** Prefix for cache keys. Default: `"summarizer:"`. */
   prefix?: string;
+  /** Entry time-to-live in milliseconds. Default: `DEFAULT_CACHE_TTL_MS`. */
+  ttlMs?: number;
 }
 
 export const createSessionStorageCache = (
@@ -32,20 +81,40 @@ export const createSessionStorageCache = (
     (typeof globalThis !== "undefined"
       ? (globalThis as { sessionStorage?: Storage }).sessionStorage
       : undefined);
+  const ttlMs = normalizeTtl(options.ttlMs);
 
   return {
     get(key) {
       if (!storage) return null;
+      let raw: string | null;
       try {
-        return storage.getItem(prefix + key);
+        raw = storage.getItem(prefix + key);
       } catch {
         return null;
       }
+      if (raw === null) return null;
+      const envelope = parseEnvelope(raw);
+      if (envelope && Date.now() < envelope.expiresAt) return envelope.value;
+      // Legacy raw strings, malformed envelopes, and expired entries are
+      // misses; drop them so the next successful run replaces the slot.
+      try {
+        storage.removeItem(prefix + key);
+      } catch {
+        // best-effort cleanup only.
+      }
+      return null;
     },
     set(key, value) {
       if (!storage) return;
       try {
-        storage.setItem(prefix + key, value);
+        storage.setItem(
+          prefix + key,
+          JSON.stringify({
+            v: ENVELOPE_VERSION,
+            value,
+            expiresAt: Date.now() + ttlMs,
+          }),
+        );
       } catch {
         // quota / disabled storage; best-effort only.
       }
@@ -56,21 +125,23 @@ export const createSessionStorageCache = (
 /**
  * Resolve the public `cache` option into a concrete `{ get, set }` backend.
  * `undefined` → no caching. `"session"` / `"local"` → wrap the matching
- * web-storage backend (no-op fallback if unavailable). Object → passthrough.
+ * web-storage backend (no-op fallback if unavailable) with a TTL envelope.
+ * Object → passthrough; `ttlMs` does not apply to custom backends.
  */
 export const resolveCache = (
   value: CacheOption | undefined,
+  ttlMs?: number,
 ): SummaryCache | undefined => {
   if (value === undefined) return undefined;
   if (value === "session") {
-    return createSessionStorageCache();
+    return createSessionStorageCache({ ttlMs });
   }
   if (value === "local") {
     const storage =
       typeof globalThis !== "undefined"
         ? (globalThis as { localStorage?: Storage }).localStorage
         : undefined;
-    return createSessionStorageCache({ storage });
+    return createSessionStorageCache({ storage, ttlMs });
   }
   return value;
 };

--- a/packages/summarizer/src/index.test.ts
+++ b/packages/summarizer/src/index.test.ts
@@ -145,6 +145,56 @@ describe("summarize", () => {
     expect(api.create).not.toHaveBeenCalled();
   });
 
+  it("bypasses the cache read and replaces the value on cacheRefresh", async () => {
+    const api = installFakeSummarizer({ summary: "Fresh summary." });
+    const cache = inMemoryCache();
+    cache.set("k", "Stale summary.");
+    const result = await summarize({
+      language: "en",
+      input: "Some article body.",
+      cache,
+      cacheKey: "k",
+      cacheRefresh: true,
+    });
+    expect(result).toEqual({ output: "Fresh summary.", cached: false });
+    expect(api.create).toHaveBeenCalled();
+    expect(cache.get("k")).toBe("Fresh summary.");
+  });
+
+  it("does not overwrite a cached value when the run is aborted", async () => {
+    installFakeSummarizer();
+    const cache = inMemoryCache();
+    cache.set("k", "Stale summary.");
+    const controller = new AbortController();
+    controller.abort();
+    await expect(
+      summarize({
+        language: "en",
+        input: "Some article body.",
+        cache,
+        cacheKey: "k",
+        cacheRefresh: true,
+        signal: controller.signal,
+      }),
+    ).rejects.toMatchObject({ name: "AbortError" });
+    expect(cache.get("k")).toBe("Stale summary.");
+  });
+
+  it("does not overwrite a cached value when the response is empty", async () => {
+    installFakeSummarizer({ summary: "   " });
+    const cache = inMemoryCache();
+    cache.set("k", "Stale summary.");
+    const result = await summarize({
+      language: "en",
+      input: "Some article body.",
+      cache,
+      cacheKey: "k",
+      cacheRefresh: true,
+    });
+    expect(result).toEqual({ output: null, cached: false });
+    expect(cache.get("k")).toBe("Stale summary.");
+  });
+
   it("does not collide cache entries when input differs on the same route and language", async () => {
     let calls = 0;
     const api = installFakeSummarizer();
@@ -423,7 +473,10 @@ describe("summarize", () => {
         cacheKey: "k",
       });
       expect(first).toEqual({ output: "Stored.", cached: false });
-      expect(storage.setItem).toHaveBeenCalledWith("summarizer:k", "Stored.");
+      const stored = JSON.parse(store.get("summarizer:k") ?? "");
+      expect(stored.v).toBe(1);
+      expect(stored.value).toBe("Stored.");
+      expect(stored.expiresAt).toBeGreaterThan(Date.now());
 
       const createsAfterFirst = api.create.mock.calls.length;
       const second = await summarize({
@@ -457,7 +510,10 @@ describe("summarize", () => {
         cacheKey: "k",
       });
       expect(first).toEqual({ output: "Stored.", cached: false });
-      expect(storage.setItem).toHaveBeenCalledWith("summarizer:k", "Stored.");
+      const stored = JSON.parse(store.get("summarizer:k") ?? "");
+      expect(stored.v).toBe(1);
+      expect(stored.value).toBe("Stored.");
+      expect(stored.expiresAt).toBeGreaterThan(Date.now());
 
       const createsAfterFirst = api.create.mock.calls.length;
       const second = await summarize({

--- a/packages/summarizer/src/index.ts
+++ b/packages/summarizer/src/index.ts
@@ -21,6 +21,7 @@ import {
 } from "./api.js";
 import {
   type CacheOption,
+  DEFAULT_CACHE_TTL_MS,
   defaultCacheKey,
   resolveCache,
   type SummaryCache,
@@ -37,7 +38,7 @@ export type {
   SummarizerInstance,
   SummaryCache,
 };
-export { checkAvailability, isAvailable };
+export { checkAvailability, DEFAULT_CACHE_TTL_MS, isAvailable };
 
 export interface SummarizeOptions {
   /** Text to summarize. Empty / whitespace input resolves to `{ output: null }`. */
@@ -72,6 +73,19 @@ export interface SummarizeOptions {
   cache?: CacheOption;
   /** Cache key. Default: JSON string of route, input, and summary options. */
   cacheKey?: string;
+  /**
+   * Time-to-live in milliseconds for entries written by the built-in
+   * `"session"` / `"local"` storage shortcuts. Default: one hour
+   * (`DEFAULT_CACHE_TTL_MS`). Ignored for custom `{ get, set }` caches, which
+   * own their expiry policy.
+   */
+  cacheTtl?: number;
+  /**
+   * Force a fresh summary. Skips the cache read, runs the model, and
+   * replaces the cached value after a successful run. Applies to built-in
+   * and custom caches.
+   */
+  cacheRefresh?: boolean;
   /**
    * Streaming update callback (cleaned text, monotonically growing).
    * Receives the **cumulative** buffer, not deltas.
@@ -127,7 +141,7 @@ export const summarize = async (
   ).map(NORMALIZE_LANG);
   const supported = new Set(supportedLanguages);
   const languageHints = supported.has(lang);
-  const cache = resolveCache(options.cache);
+  const cache = resolveCache(options.cache, options.cacheTtl);
   const cacheKey =
     options.cacheKey ??
     defaultCacheKey({
@@ -140,7 +154,7 @@ export const summarize = async (
       preference: options.preference,
       sharedContext: options.sharedContext,
     });
-  if (cache) {
+  if (cache && !options.cacheRefresh) {
     const cached = cache.get(cacheKey);
     if (cached) return { output: cached, cached: true };
   }

--- a/packages/summarizer/src/react/index.ts
+++ b/packages/summarizer/src/react/index.ts
@@ -57,6 +57,8 @@ export const useSummarizer = (
     monitor,
     cache,
     cacheKey,
+    cacheTtl,
+    cacheRefresh,
     enabled = true,
   } = options;
 
@@ -88,6 +90,8 @@ export const useSummarizer = (
       monitor,
       cache,
       cacheKey,
+      cacheTtl,
+      cacheRefresh,
       signal: controller.signal,
       onUpdate: (chunk) => {
         if (controller.signal.aborted) return;
@@ -128,6 +132,8 @@ export const useSummarizer = (
     monitor,
     cache,
     cacheKey,
+    cacheTtl,
+    cacheRefresh,
   ]);
 
   const dismiss = () => {

--- a/packages/translator/README.md
+++ b/packages/translator/README.md
@@ -77,6 +77,8 @@ interface TranslateOptions {
   monitor?: (m: TranslatorMonitor) => void;
   cache?: "session" | "local" | { get, set };
   cacheKey?: string;
+  cacheTtl?: number;      // built-in shortcut TTL in ms; default 1 hour
+  cacheRefresh?: boolean; // skip the cache read, write the fresh result
   signal?: AbortSignal;
 }
 
@@ -123,6 +125,34 @@ translate({
 ```
 
 The default result cache key is a JSON array string of normalized `[sourceLanguage, targetLanguage, input]`. Pass `cacheKey` explicitly for finer-grained invalidation.
+
+### Expiry and refresh
+
+The built-in `"session"` / `"local"` shortcuts store each entry in a versioned envelope with an expiry time. Entries expire after one hour (`DEFAULT_CACHE_TTL_MS`) by default. Pass `cacheTtl` (milliseconds) to override the TTL per call. Expired entries, legacy raw strings, and malformed envelopes count as misses and are removed.
+
+Pass `cacheRefresh: true` to force a fresh inference. The call skips the cache read, runs the model, and replaces the cached value after a successful run. Failed, aborted, or empty runs leave the cached value in place.
+
+Custom `{ get, set }` caches own their expiry policy. `cacheTtl` does not apply to them; `cacheRefresh` still bypasses their read and updates them after success.
+
+```ts
+// Cache for five minutes instead of one hour.
+translate({
+  input: text,
+  sourceLanguage: "en",
+  targetLanguage: "pt",
+  cache: "local",
+  cacheTtl: 5 * 60 * 1000,
+});
+
+// Force a fresh inference; later calls reuse the new value.
+translate({
+  input: text,
+  sourceLanguage: "en",
+  targetLanguage: "pt",
+  cache: "local",
+  cacheRefresh: true,
+});
+```
 
 ## DOM composition
 

--- a/packages/translator/src/cache.test.ts
+++ b/packages/translator/src/cache.test.ts
@@ -1,0 +1,180 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { DEFAULT_CACHE_TTL_MS, resolveCache } from "./cache.js";
+
+const fakeStorage = (): Storage => {
+  const store = new Map<string, string>();
+  return {
+    get length() {
+      return store.size;
+    },
+    clear: () => store.clear(),
+    getItem: (k) => store.get(k) ?? null,
+    key: (i) => Array.from(store.keys())[i] ?? null,
+    removeItem: (k) => {
+      store.delete(k);
+    },
+    setItem: (k, v) => {
+      store.set(k, v);
+    },
+  };
+};
+
+const installSessionStorage = (storage: Storage | undefined): void => {
+  Object.defineProperty(globalThis, "sessionStorage", {
+    value: storage,
+    configurable: true,
+    writable: true,
+  });
+};
+
+let originalSessionStorage: PropertyDescriptor | undefined;
+
+beforeEach(() => {
+  originalSessionStorage = Object.getOwnPropertyDescriptor(
+    globalThis,
+    "sessionStorage",
+  );
+  vi.useFakeTimers();
+  vi.setSystemTime(new Date("2026-01-01T00:00:00Z"));
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  if (originalSessionStorage) {
+    Object.defineProperty(globalThis, "sessionStorage", originalSessionStorage);
+  } else {
+    delete (globalThis as { sessionStorage?: Storage }).sessionStorage;
+  }
+});
+
+describe("storage shortcut TTL envelope", () => {
+  it("round-trips a value through a versioned envelope", () => {
+    const storage = fakeStorage();
+    installSessionStorage(storage);
+    const cache = resolveCache("session");
+    cache?.set("k", "v");
+    expect(cache?.get("k")).toBe("v");
+    const raw = storage.getItem("translator:k");
+    expect(raw).not.toBe("v");
+    expect(JSON.parse(raw ?? "")).toEqual({
+      v: 1,
+      value: "v",
+      expiresAt: Date.now() + DEFAULT_CACHE_TTL_MS,
+    });
+  });
+
+  it("expires entries after the default TTL and removes them", () => {
+    const storage = fakeStorage();
+    installSessionStorage(storage);
+    const cache = resolveCache("session");
+    cache?.set("k", "v");
+    vi.advanceTimersByTime(DEFAULT_CACHE_TTL_MS - 1);
+    expect(cache?.get("k")).toBe("v");
+    vi.advanceTimersByTime(1);
+    expect(cache?.get("k")).toBeNull();
+    expect(storage.getItem("translator:k")).toBeNull();
+  });
+
+  it("honors a caller-provided TTL override", () => {
+    installSessionStorage(fakeStorage());
+    const cache = resolveCache("session", 5_000);
+    cache?.set("k", "v");
+    vi.advanceTimersByTime(4_999);
+    expect(cache?.get("k")).toBe("v");
+    vi.advanceTimersByTime(1);
+    expect(cache?.get("k")).toBeNull();
+  });
+
+  it("falls back to the default TTL for invalid overrides", () => {
+    installSessionStorage(fakeStorage());
+    for (const ttl of [0, -1, Number.NaN, Number.POSITIVE_INFINITY]) {
+      const cache = resolveCache("session", ttl);
+      cache?.set("k", "v");
+      expect(cache?.get("k")).toBe("v");
+      vi.advanceTimersByTime(DEFAULT_CACHE_TTL_MS);
+      expect(cache?.get("k")).toBeNull();
+    }
+  });
+
+  it("treats legacy raw strings as misses and removes them", () => {
+    const storage = fakeStorage();
+    installSessionStorage(storage);
+    storage.setItem("translator:k", "legacy value");
+    const cache = resolveCache("session");
+    expect(cache?.get("k")).toBeNull();
+    expect(storage.getItem("translator:k")).toBeNull();
+  });
+
+  it("treats malformed envelopes as misses", () => {
+    const storage = fakeStorage();
+    installSessionStorage(storage);
+    const cache = resolveCache("session");
+    const badEntries = [
+      "{not json",
+      "null",
+      '"just a string"',
+      JSON.stringify({ v: 2, value: "v", expiresAt: Date.now() + 1000 }),
+      JSON.stringify({ v: 1, expiresAt: Date.now() + 1000 }),
+      JSON.stringify({ v: 1, value: 42, expiresAt: Date.now() + 1000 }),
+      JSON.stringify({ v: 1, value: "v" }),
+      JSON.stringify({ v: 1, value: "v", expiresAt: "soon" }),
+      JSON.stringify({ v: 1, value: "v", expiresAt: Number.NaN }),
+    ];
+    for (const entry of badEntries) {
+      storage.setItem("translator:k", entry);
+      expect(cache?.get("k")).toBeNull();
+      expect(storage.getItem("translator:k")).toBeNull();
+    }
+  });
+
+  it("replaces an invalid entry on the next set", () => {
+    const storage = fakeStorage();
+    installSessionStorage(storage);
+    storage.setItem("translator:k", "legacy value");
+    const cache = resolveCache("session");
+    expect(cache?.get("k")).toBeNull();
+    cache?.set("k", "fresh");
+    expect(cache?.get("k")).toBe("fresh");
+  });
+
+  it("returns null when storage is missing", () => {
+    installSessionStorage(undefined);
+    const cache = resolveCache("session");
+    expect(cache?.get("k")).toBeNull();
+    expect(() => cache?.set("k", "v")).not.toThrow();
+  });
+
+  it("swallows storage failures on get, set, and cleanup", () => {
+    const storage = fakeStorage();
+    storage.setItem("translator:k", "legacy value");
+    const throwing = {
+      ...storage,
+      getItem: () => {
+        throw new Error("denied");
+      },
+      setItem: () => {
+        throw new Error("quota");
+      },
+    } as Storage;
+    installSessionStorage(throwing);
+    const cache = resolveCache("session");
+    expect(cache?.get("k")).toBeNull();
+    expect(() => cache?.set("k", "v")).not.toThrow();
+
+    const removeThrows = {
+      ...storage,
+      getItem: (k: string) => storage.getItem(k),
+      removeItem: () => {
+        throw new Error("denied");
+      },
+    } as Storage;
+    installSessionStorage(removeThrows);
+    const cleanupCache = resolveCache("session");
+    expect(cleanupCache?.get("k")).toBeNull();
+  });
+
+  it("passes custom cache objects through untouched", () => {
+    const custom = { get: () => "v", set: () => {} };
+    expect(resolveCache(custom, 5_000)).toBe(custom);
+  });
+});

--- a/packages/translator/src/cache.ts
+++ b/packages/translator/src/cache.ts
@@ -15,28 +15,96 @@ export interface TranslationCache {
  */
 export type CacheOption = "session" | "local" | TranslationCache;
 
+/**
+ * Default time-to-live for entries written by the built-in `"session"` /
+ * `"local"` storage shortcuts: one hour. On-device model output changes as
+ * the browser updates the model, so built-in entries expire instead of
+ * persisting indefinitely. Override per call with `cacheTtl`. Custom
+ * `{ get, set }` caches own their expiry policy.
+ */
+export const DEFAULT_CACHE_TTL_MS = 60 * 60 * 1000;
+
+/** Version tag for the storage envelope written by the built-in shortcuts. */
+const ENVELOPE_VERSION = 1;
+
+interface CacheEnvelope {
+  v: number;
+  value: string;
+  expiresAt: number;
+}
+
+/**
+ * Parse a stored entry into a versioned envelope. Legacy raw strings,
+ * malformed JSON, unsupported versions, and invalid timestamps all return
+ * `null` so the caller treats them as misses.
+ */
+const parseEnvelope = (raw: string): CacheEnvelope | null => {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return null;
+  }
+  if (typeof parsed !== "object" || parsed === null) return null;
+  const envelope = parsed as Partial<CacheEnvelope>;
+  if (envelope.v !== ENVELOPE_VERSION) return null;
+  if (typeof envelope.value !== "string") return null;
+  if (
+    typeof envelope.expiresAt !== "number" ||
+    !Number.isFinite(envelope.expiresAt)
+  )
+    return null;
+  return envelope as CacheEnvelope;
+};
+
+const normalizeTtl = (ttlMs: number | undefined): number =>
+  typeof ttlMs === "number" && Number.isFinite(ttlMs) && ttlMs > 0
+    ? ttlMs
+    : DEFAULT_CACHE_TTL_MS;
+
 interface DefaultCacheOptions {
   storage?: Storage;
   prefix?: string;
+  ttlMs?: number;
 }
 
 const createStorageCache = (options: DefaultCacheOptions): TranslationCache => {
   const prefix = options.prefix ?? "translator:";
   const storage = options.storage;
+  const ttlMs = normalizeTtl(options.ttlMs);
 
   return {
     get(key) {
       if (!storage) return null;
+      let raw: string | null;
       try {
-        return storage.getItem(prefix + key);
+        raw = storage.getItem(prefix + key);
       } catch {
         return null;
       }
+      if (raw === null) return null;
+      const envelope = parseEnvelope(raw);
+      if (envelope && Date.now() < envelope.expiresAt) return envelope.value;
+      // Legacy raw strings, malformed envelopes, and expired entries are
+      // misses; drop them so the next successful run replaces the slot.
+      try {
+        storage.removeItem(prefix + key);
+      } catch {
+        // best-effort cleanup only.
+      }
+      return null;
     },
     set(key, value) {
       if (!storage) return;
       try {
-        storage.setItem(prefix + key, value);
+        storage.setItem(
+          prefix + key,
+          JSON.stringify({
+            v: ENVELOPE_VERSION,
+            value,
+            expiresAt: Date.now() + ttlMs,
+          }),
+        );
       } catch {
         // quota / disabled storage; best-effort only.
       }
@@ -47,10 +115,12 @@ const createStorageCache = (options: DefaultCacheOptions): TranslationCache => {
 /**
  * Resolve the public `cache` option into a concrete `{ get, set }` backend.
  * `undefined` → no caching. `"session"` / `"local"` → wrap the matching
- * web-storage backend (no-op fallback if unavailable). Object → passthrough.
+ * web-storage backend (no-op fallback if unavailable) with a TTL envelope.
+ * Object → passthrough; `ttlMs` does not apply to custom backends.
  */
 export const resolveCache = (
   value: CacheOption | undefined,
+  ttlMs?: number,
 ): TranslationCache | undefined => {
   if (value === undefined) return undefined;
   if (value === "session") {
@@ -58,14 +128,14 @@ export const resolveCache = (
       typeof globalThis !== "undefined"
         ? (globalThis as { sessionStorage?: Storage }).sessionStorage
         : undefined;
-    return createStorageCache({ storage });
+    return createStorageCache({ storage, ttlMs });
   }
   if (value === "local") {
     const storage =
       typeof globalThis !== "undefined"
         ? (globalThis as { localStorage?: Storage }).localStorage
         : undefined;
-    return createStorageCache({ storage });
+    return createStorageCache({ storage, ttlMs });
   }
   return value;
 };

--- a/packages/translator/src/index.test.ts
+++ b/packages/translator/src/index.test.ts
@@ -182,6 +182,59 @@ describe("translate", () => {
     expect(cache.get("k")).toBe("Hello");
   });
 
+  it("bypasses the cache read and replaces the value on cacheRefresh", async () => {
+    const { api } = installFakeTranslator();
+    const cache = inMemoryCache();
+    cache.set("k", "cached value");
+    const result = await translate({
+      input: "Olá",
+      sourceLanguage: "pt",
+      targetLanguage: "en",
+      cache,
+      cacheKey: "k",
+      cacheRefresh: true,
+    });
+    expect(result).toEqual({ output: "[t]Olá", cached: false });
+    expect(api.create).toHaveBeenCalled();
+    expect(cache.get("k")).toBe("[t]Olá");
+  });
+
+  it("does not overwrite a cached value when the run is aborted", async () => {
+    installFakeTranslator();
+    const cache = inMemoryCache();
+    cache.set("k", "cached value");
+    const controller = new AbortController();
+    controller.abort();
+    await expect(
+      translate({
+        input: "Olá",
+        sourceLanguage: "pt",
+        targetLanguage: "en",
+        cache,
+        cacheKey: "k",
+        cacheRefresh: true,
+        signal: controller.signal,
+      }),
+    ).rejects.toMatchObject({ name: "AbortError" });
+    expect(cache.get("k")).toBe("cached value");
+  });
+
+  it("does not overwrite a cached value when the response is empty", async () => {
+    installFakeTranslator(async () => "");
+    const cache = inMemoryCache();
+    cache.set("k", "cached value");
+    const result = await translate({
+      input: "Olá",
+      sourceLanguage: "pt",
+      targetLanguage: "en",
+      cache,
+      cacheKey: "k",
+      cacheRefresh: true,
+    });
+    expect(result).toEqual({ output: null, cached: false });
+    expect(cache.get("k")).toBe("cached value");
+  });
+
   it("reuses sessions across same-pair calls", async () => {
     const { api } = installFakeTranslator();
     await translate({
@@ -445,7 +498,10 @@ describe("translate", () => {
         cacheKey: "k",
       });
       expect(first).toEqual({ output: "[t]Olá", cached: false });
-      expect(storage.setItem).toHaveBeenCalledWith("translator:k", "[t]Olá");
+      const stored = JSON.parse(store.get("translator:k") ?? "");
+      expect(stored.v).toBe(1);
+      expect(stored.value).toBe("[t]Olá");
+      expect(stored.expiresAt).toBeGreaterThan(Date.now());
 
       const createsAfterFirst = api.create.mock.calls.length;
       const second = await translate({
@@ -481,7 +537,10 @@ describe("translate", () => {
         cacheKey: "k",
       });
       expect(first).toEqual({ output: "[t]Olá", cached: false });
-      expect(storage.setItem).toHaveBeenCalledWith("translator:k", "[t]Olá");
+      const stored = JSON.parse(store.get("translator:k") ?? "");
+      expect(stored.v).toBe(1);
+      expect(stored.value).toBe("[t]Olá");
+      expect(stored.expiresAt).toBeGreaterThan(Date.now());
 
       const createsAfterFirst = api.create.mock.calls.length;
       const second = await translate({

--- a/packages/translator/src/index.ts
+++ b/packages/translator/src/index.ts
@@ -25,6 +25,7 @@ import {
 } from "./api.js";
 import {
   type CacheOption,
+  DEFAULT_CACHE_TTL_MS,
   defaultCacheKey,
   resolveCache,
   type TranslationCache,
@@ -46,6 +47,7 @@ export {
   clearTranslatorSession,
   clearTranslatorSessions,
   configureTranslatorCache,
+  DEFAULT_CACHE_TTL_MS,
   isAvailable,
 };
 
@@ -69,6 +71,19 @@ export interface TranslateOptions {
   cache?: CacheOption;
   /** Cache key. Default: JSON array string of `[sourceLanguage, targetLanguage, input]`. */
   cacheKey?: string;
+  /**
+   * Time-to-live in milliseconds for entries written by the built-in
+   * `"session"` / `"local"` storage shortcuts. Default: one hour
+   * (`DEFAULT_CACHE_TTL_MS`). Ignored for custom `{ get, set }` caches, which
+   * own their expiry policy.
+   */
+  cacheTtl?: number;
+  /**
+   * Force a fresh translation. Skips the cache read, runs the model, and
+   * replaces the cached value after a successful run. Applies to built-in
+   * and custom caches.
+   */
+  cacheRefresh?: boolean;
   /** Abort signal. */
   signal?: AbortSignal;
 }
@@ -119,11 +134,11 @@ export const translate = async (
     return { output: null, cached: false };
   }
 
-  const cache = resolveCache(options.cache);
+  const cache = resolveCache(options.cache, options.cacheTtl);
   const cacheKey =
     options.cacheKey ??
     defaultCacheKey({ sourceLanguage, targetLanguage, text });
-  if (cache) {
+  if (cache && !options.cacheRefresh) {
     const cached = cache.get(cacheKey);
     if (cached) return { output: cached, cached: true };
   }

--- a/packages/translator/src/react/index.ts
+++ b/packages/translator/src/react/index.ts
@@ -44,6 +44,8 @@ export const useTranslator = (
     monitor,
     cache,
     cacheKey,
+    cacheTtl,
+    cacheRefresh,
     enabled = true,
   } = options;
 
@@ -70,6 +72,8 @@ export const useTranslator = (
       monitor,
       cache,
       cacheKey,
+      cacheTtl,
+      cacheRefresh,
       signal: controller.signal,
     })
       .then((result) => {
@@ -100,6 +104,8 @@ export const useTranslator = (
     monitor,
     cache,
     cacheKey,
+    cacheTtl,
+    cacheRefresh,
   ]);
 
   return { status, output, error, fromCache };

--- a/packages/writer/README.md
+++ b/packages/writer/README.md
@@ -72,6 +72,8 @@ interface WriteOptions {
   monitor?: (m: CreateMonitor) => void;
   cache?: "session" | "local" | { get, set };
   cacheKey?: string;
+  cacheTtl?: number;      // built-in shortcut TTL in ms; default 1 hour
+  cacheRefresh?: boolean; // skip the cache read, write the fresh result
   onUpdate?: (text: string) => void; // cumulative buffer, not deltas
   signal?: AbortSignal;
 }
@@ -101,6 +103,26 @@ import {
 ```
 
 The internal session cache is LRU-bounded (default 8). Evicted sessions have their `destroy()` invoked when present.
+
+## Result caching
+
+Off by default; every call hits the model. Pass `cache: "session"` for `sessionStorage`, `cache: "local"` for `localStorage`, or any `{ get, set }`-shaped object for a custom backend.
+
+### Expiry and refresh
+
+The built-in `"session"` / `"local"` shortcuts store each entry in a versioned envelope with an expiry time. Entries expire after one hour (`DEFAULT_CACHE_TTL_MS`) by default. Pass `cacheTtl` (milliseconds) to override the TTL per call. Expired entries, legacy raw strings, and malformed envelopes count as misses and are removed.
+
+Pass `cacheRefresh: true` to force a fresh inference. The call skips the cache read, runs the model, and replaces the cached value after a successful run. Failed, aborted, or empty runs leave the cached value in place.
+
+Custom `{ get, set }` caches own their expiry policy. `cacheTtl` does not apply to them; `cacheRefresh` still bypasses their read and updates them after success.
+
+```ts
+// Cache for five minutes instead of one hour.
+write({ input: task, cache: "local", cacheTtl: 5 * 60 * 1000 });
+
+// Force a fresh inference; later calls reuse the new value.
+write({ input: task, cache: "local", cacheRefresh: true });
+```
 
 ## Output normalization
 

--- a/packages/writer/src/cache.test.ts
+++ b/packages/writer/src/cache.test.ts
@@ -1,0 +1,180 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { DEFAULT_CACHE_TTL_MS, resolveCache } from "./cache.js";
+
+const fakeStorage = (): Storage => {
+  const store = new Map<string, string>();
+  return {
+    get length() {
+      return store.size;
+    },
+    clear: () => store.clear(),
+    getItem: (k) => store.get(k) ?? null,
+    key: (i) => Array.from(store.keys())[i] ?? null,
+    removeItem: (k) => {
+      store.delete(k);
+    },
+    setItem: (k, v) => {
+      store.set(k, v);
+    },
+  };
+};
+
+const installSessionStorage = (storage: Storage | undefined): void => {
+  Object.defineProperty(globalThis, "sessionStorage", {
+    value: storage,
+    configurable: true,
+    writable: true,
+  });
+};
+
+let originalSessionStorage: PropertyDescriptor | undefined;
+
+beforeEach(() => {
+  originalSessionStorage = Object.getOwnPropertyDescriptor(
+    globalThis,
+    "sessionStorage",
+  );
+  vi.useFakeTimers();
+  vi.setSystemTime(new Date("2026-01-01T00:00:00Z"));
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  if (originalSessionStorage) {
+    Object.defineProperty(globalThis, "sessionStorage", originalSessionStorage);
+  } else {
+    delete (globalThis as { sessionStorage?: Storage }).sessionStorage;
+  }
+});
+
+describe("storage shortcut TTL envelope", () => {
+  it("round-trips a value through a versioned envelope", () => {
+    const storage = fakeStorage();
+    installSessionStorage(storage);
+    const cache = resolveCache("session");
+    cache?.set("k", "v");
+    expect(cache?.get("k")).toBe("v");
+    const raw = storage.getItem("writer:k");
+    expect(raw).not.toBe("v");
+    expect(JSON.parse(raw ?? "")).toEqual({
+      v: 1,
+      value: "v",
+      expiresAt: Date.now() + DEFAULT_CACHE_TTL_MS,
+    });
+  });
+
+  it("expires entries after the default TTL and removes them", () => {
+    const storage = fakeStorage();
+    installSessionStorage(storage);
+    const cache = resolveCache("session");
+    cache?.set("k", "v");
+    vi.advanceTimersByTime(DEFAULT_CACHE_TTL_MS - 1);
+    expect(cache?.get("k")).toBe("v");
+    vi.advanceTimersByTime(1);
+    expect(cache?.get("k")).toBeNull();
+    expect(storage.getItem("writer:k")).toBeNull();
+  });
+
+  it("honors a caller-provided TTL override", () => {
+    installSessionStorage(fakeStorage());
+    const cache = resolveCache("session", 5_000);
+    cache?.set("k", "v");
+    vi.advanceTimersByTime(4_999);
+    expect(cache?.get("k")).toBe("v");
+    vi.advanceTimersByTime(1);
+    expect(cache?.get("k")).toBeNull();
+  });
+
+  it("falls back to the default TTL for invalid overrides", () => {
+    installSessionStorage(fakeStorage());
+    for (const ttl of [0, -1, Number.NaN, Number.POSITIVE_INFINITY]) {
+      const cache = resolveCache("session", ttl);
+      cache?.set("k", "v");
+      expect(cache?.get("k")).toBe("v");
+      vi.advanceTimersByTime(DEFAULT_CACHE_TTL_MS);
+      expect(cache?.get("k")).toBeNull();
+    }
+  });
+
+  it("treats legacy raw strings as misses and removes them", () => {
+    const storage = fakeStorage();
+    installSessionStorage(storage);
+    storage.setItem("writer:k", "legacy value");
+    const cache = resolveCache("session");
+    expect(cache?.get("k")).toBeNull();
+    expect(storage.getItem("writer:k")).toBeNull();
+  });
+
+  it("treats malformed envelopes as misses", () => {
+    const storage = fakeStorage();
+    installSessionStorage(storage);
+    const cache = resolveCache("session");
+    const badEntries = [
+      "{not json",
+      "null",
+      '"just a string"',
+      JSON.stringify({ v: 2, value: "v", expiresAt: Date.now() + 1000 }),
+      JSON.stringify({ v: 1, expiresAt: Date.now() + 1000 }),
+      JSON.stringify({ v: 1, value: 42, expiresAt: Date.now() + 1000 }),
+      JSON.stringify({ v: 1, value: "v" }),
+      JSON.stringify({ v: 1, value: "v", expiresAt: "soon" }),
+      JSON.stringify({ v: 1, value: "v", expiresAt: Number.NaN }),
+    ];
+    for (const entry of badEntries) {
+      storage.setItem("writer:k", entry);
+      expect(cache?.get("k")).toBeNull();
+      expect(storage.getItem("writer:k")).toBeNull();
+    }
+  });
+
+  it("replaces an invalid entry on the next set", () => {
+    const storage = fakeStorage();
+    installSessionStorage(storage);
+    storage.setItem("writer:k", "legacy value");
+    const cache = resolveCache("session");
+    expect(cache?.get("k")).toBeNull();
+    cache?.set("k", "fresh");
+    expect(cache?.get("k")).toBe("fresh");
+  });
+
+  it("returns null when storage is missing", () => {
+    installSessionStorage(undefined);
+    const cache = resolveCache("session");
+    expect(cache?.get("k")).toBeNull();
+    expect(() => cache?.set("k", "v")).not.toThrow();
+  });
+
+  it("swallows storage failures on get, set, and cleanup", () => {
+    const storage = fakeStorage();
+    storage.setItem("writer:k", "legacy value");
+    const throwing = {
+      ...storage,
+      getItem: () => {
+        throw new Error("denied");
+      },
+      setItem: () => {
+        throw new Error("quota");
+      },
+    } as Storage;
+    installSessionStorage(throwing);
+    const cache = resolveCache("session");
+    expect(cache?.get("k")).toBeNull();
+    expect(() => cache?.set("k", "v")).not.toThrow();
+
+    const removeThrows = {
+      ...storage,
+      getItem: (k: string) => storage.getItem(k),
+      removeItem: () => {
+        throw new Error("denied");
+      },
+    } as Storage;
+    installSessionStorage(removeThrows);
+    const cleanupCache = resolveCache("session");
+    expect(cleanupCache?.get("k")).toBeNull();
+  });
+
+  it("passes custom cache objects through untouched", () => {
+    const custom = { get: () => "v", set: () => {} };
+    expect(resolveCache(custom, 5_000)).toBe(custom);
+  });
+});

--- a/packages/writer/src/cache.ts
+++ b/packages/writer/src/cache.ts
@@ -15,28 +15,96 @@ export interface WriteCache {
  */
 export type CacheOption = "session" | "local" | WriteCache;
 
+/**
+ * Default time-to-live for entries written by the built-in `"session"` /
+ * `"local"` storage shortcuts: one hour. On-device model output changes as
+ * the browser updates the model, so built-in entries expire instead of
+ * persisting indefinitely. Override per call with `cacheTtl`. Custom
+ * `{ get, set }` caches own their expiry policy.
+ */
+export const DEFAULT_CACHE_TTL_MS = 60 * 60 * 1000;
+
+/** Version tag for the storage envelope written by the built-in shortcuts. */
+const ENVELOPE_VERSION = 1;
+
+interface CacheEnvelope {
+  v: number;
+  value: string;
+  expiresAt: number;
+}
+
+/**
+ * Parse a stored entry into a versioned envelope. Legacy raw strings,
+ * malformed JSON, unsupported versions, and invalid timestamps all return
+ * `null` so the caller treats them as misses.
+ */
+const parseEnvelope = (raw: string): CacheEnvelope | null => {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return null;
+  }
+  if (typeof parsed !== "object" || parsed === null) return null;
+  const envelope = parsed as Partial<CacheEnvelope>;
+  if (envelope.v !== ENVELOPE_VERSION) return null;
+  if (typeof envelope.value !== "string") return null;
+  if (
+    typeof envelope.expiresAt !== "number" ||
+    !Number.isFinite(envelope.expiresAt)
+  )
+    return null;
+  return envelope as CacheEnvelope;
+};
+
+const normalizeTtl = (ttlMs: number | undefined): number =>
+  typeof ttlMs === "number" && Number.isFinite(ttlMs) && ttlMs > 0
+    ? ttlMs
+    : DEFAULT_CACHE_TTL_MS;
+
 interface DefaultCacheOptions {
   storage?: Storage;
   prefix?: string;
+  ttlMs?: number;
 }
 
 const createStorageCache = (options: DefaultCacheOptions): WriteCache => {
   const prefix = options.prefix ?? "writer:";
   const storage = options.storage;
+  const ttlMs = normalizeTtl(options.ttlMs);
 
   return {
     get(key) {
       if (!storage) return null;
+      let raw: string | null;
       try {
-        return storage.getItem(prefix + key);
+        raw = storage.getItem(prefix + key);
       } catch {
         return null;
       }
+      if (raw === null) return null;
+      const envelope = parseEnvelope(raw);
+      if (envelope && Date.now() < envelope.expiresAt) return envelope.value;
+      // Legacy raw strings, malformed envelopes, and expired entries are
+      // misses; drop them so the next successful run replaces the slot.
+      try {
+        storage.removeItem(prefix + key);
+      } catch {
+        // best-effort cleanup only.
+      }
+      return null;
     },
     set(key, value) {
       if (!storage) return;
       try {
-        storage.setItem(prefix + key, value);
+        storage.setItem(
+          prefix + key,
+          JSON.stringify({
+            v: ENVELOPE_VERSION,
+            value,
+            expiresAt: Date.now() + ttlMs,
+          }),
+        );
       } catch {
         // quota / disabled storage; best-effort only.
       }
@@ -47,10 +115,12 @@ const createStorageCache = (options: DefaultCacheOptions): WriteCache => {
 /**
  * Resolve the public `cache` option into a concrete `{ get, set }` backend.
  * `undefined` → no caching. `"session"` / `"local"` → wrap the matching
- * web-storage backend (no-op fallback if unavailable). Object → passthrough.
+ * web-storage backend (no-op fallback if unavailable) with a TTL envelope.
+ * Object → passthrough; `ttlMs` does not apply to custom backends.
  */
 export const resolveCache = (
   value: CacheOption | undefined,
+  ttlMs?: number,
 ): WriteCache | undefined => {
   if (value === undefined) return undefined;
   if (value === "session") {
@@ -58,14 +128,14 @@ export const resolveCache = (
       typeof globalThis !== "undefined"
         ? (globalThis as { sessionStorage?: Storage }).sessionStorage
         : undefined;
-    return createStorageCache({ storage });
+    return createStorageCache({ storage, ttlMs });
   }
   if (value === "local") {
     const storage =
       typeof globalThis !== "undefined"
         ? (globalThis as { localStorage?: Storage }).localStorage
         : undefined;
-    return createStorageCache({ storage });
+    return createStorageCache({ storage, ttlMs });
   }
   return value;
 };

--- a/packages/writer/src/index.test.ts
+++ b/packages/writer/src/index.test.ts
@@ -142,6 +142,53 @@ describe("write", () => {
     expect(api.create).not.toHaveBeenCalled();
   });
 
+  it("bypasses the cache read and replaces the value on cacheRefresh", async () => {
+    const api = installFakeWriter({ output: "Fresh draft." });
+    const cache = inMemoryCache();
+    cache.set("k", "Stale draft.");
+    const result = await write({
+      input: "Draft an email.",
+      cache,
+      cacheKey: "k",
+      cacheRefresh: true,
+    });
+    expect(result).toEqual({ output: "Fresh draft.", cached: false });
+    expect(api.create).toHaveBeenCalled();
+    expect(cache.get("k")).toBe("Fresh draft.");
+  });
+
+  it("does not overwrite a cached value when the run is aborted", async () => {
+    installFakeWriter();
+    const cache = inMemoryCache();
+    cache.set("k", "Stale draft.");
+    const controller = new AbortController();
+    controller.abort();
+    await expect(
+      write({
+        input: "Draft an email.",
+        cache,
+        cacheKey: "k",
+        cacheRefresh: true,
+        signal: controller.signal,
+      }),
+    ).rejects.toMatchObject({ name: "AbortError" });
+    expect(cache.get("k")).toBe("Stale draft.");
+  });
+
+  it("does not overwrite a cached value when the response is empty", async () => {
+    installFakeWriter({ output: "   " });
+    const cache = inMemoryCache();
+    cache.set("k", "Stale draft.");
+    const result = await write({
+      input: "Draft an email.",
+      cache,
+      cacheKey: "k",
+      cacheRefresh: true,
+    });
+    expect(result).toEqual({ output: null, cached: false });
+    expect(cache.get("k")).toBe("Stale draft.");
+  });
+
   it("does not collide cache entries when sharedContext differs", async () => {
     let calls = 0;
     const api = installFakeWriter();
@@ -311,7 +358,10 @@ describe("write", () => {
         cacheKey: "k",
       });
       expect(first).toEqual({ output: "Stored.", cached: false });
-      expect(storage.setItem).toHaveBeenCalledWith("writer:k", "Stored.");
+      const stored = JSON.parse(store.get("writer:k") ?? "");
+      expect(stored.v).toBe(1);
+      expect(stored.value).toBe("Stored.");
+      expect(stored.expiresAt).toBeGreaterThan(Date.now());
 
       const createsAfterFirst = api.create.mock.calls.length;
       const second = await write({
@@ -343,7 +393,10 @@ describe("write", () => {
         cacheKey: "k",
       });
       expect(first).toEqual({ output: "Stored.", cached: false });
-      expect(storage.setItem).toHaveBeenCalledWith("writer:k", "Stored.");
+      const stored = JSON.parse(store.get("writer:k") ?? "");
+      expect(stored.v).toBe(1);
+      expect(stored.value).toBe("Stored.");
+      expect(stored.expiresAt).toBeGreaterThan(Date.now());
 
       const createsAfterFirst = api.create.mock.calls.length;
       const second = await write({

--- a/packages/writer/src/index.ts
+++ b/packages/writer/src/index.ts
@@ -34,7 +34,11 @@ export {
   isAvailable,
 } from "./api.js";
 
-export { defaultCacheKey, resolveCache } from "./cache.js";
+export {
+  DEFAULT_CACHE_TTL_MS,
+  defaultCacheKey,
+  resolveCache,
+} from "./cache.js";
 
 export type {
   CacheOption,
@@ -74,6 +78,19 @@ export interface WriteOptions {
   cache?: CacheOption;
   /** Cache key. Default: JSON string of input, context, language hints, shared context, and output shape. */
   cacheKey?: string;
+  /**
+   * Time-to-live in milliseconds for entries written by the built-in
+   * `"session"` / `"local"` storage shortcuts. Default: one hour
+   * (`DEFAULT_CACHE_TTL_MS`). Ignored for custom `{ get, set }` caches, which
+   * own their expiry policy.
+   */
+  cacheTtl?: number;
+  /**
+   * Force a fresh inference. Skips the cache read, runs the model, and
+   * replaces the cached value after a successful run. Applies to built-in
+   * and custom caches.
+   */
+  cacheRefresh?: boolean;
   /**
    * Streaming update callback (cumulative buffer, monotonically growing).
    * Receives the **cumulative** text, not deltas.
@@ -132,7 +149,7 @@ export const write = async (options: WriteOptions): Promise<WriteResult> => {
   ).map(NORMALIZE_LANG);
   const supported = new Set(supportedLanguages);
   const languageHints = lang ? supported.has(lang) : false;
-  const cache = resolveCache(options.cache);
+  const cache = resolveCache(options.cache, options.cacheTtl);
   const cacheKey =
     options.cacheKey ??
     defaultCacheKey({
@@ -145,7 +162,7 @@ export const write = async (options: WriteOptions): Promise<WriteResult> => {
       language: lang,
       languageHints,
     });
-  if (cache) {
+  if (cache && !options.cacheRefresh) {
     const cached = cache.get(cacheKey);
     if (cached) return { output: cached, cached: true };
   }

--- a/packages/writer/src/react/index.ts
+++ b/packages/writer/src/react/index.ts
@@ -55,6 +55,8 @@ export const useWriter = (options: UseWriterOptions): UseWriterReturn => {
     monitor,
     cache,
     cacheKey,
+    cacheTtl,
+    cacheRefresh,
     enabled = true,
   } = options;
 
@@ -86,6 +88,8 @@ export const useWriter = (options: UseWriterOptions): UseWriterReturn => {
       monitor,
       cache,
       cacheKey,
+      cacheTtl,
+      cacheRefresh,
       signal: controller.signal,
       onUpdate: (chunk) => {
         if (controller.signal.aborted) return;
@@ -126,6 +130,8 @@ export const useWriter = (options: UseWriterOptions): UseWriterReturn => {
     monitor,
     cache,
     cacheKey,
+    cacheTtl,
+    cacheRefresh,
   ]);
 
   const dismiss = () => {


### PR DESCRIPTION
Closes #152

## What

One consistent cache policy across the seven result-producing packages (prompt, summarizer, translator, detector, writer, rewriter, proofreader), per Chrome's built-in AI guidance.

- `cacheTtl?: number`: TTL in milliseconds for the built-in `"session"` / `"local"` storage shortcuts. Default: one hour (`DEFAULT_CACHE_TTL_MS`, exported by every package).
- `cacheRefresh?: boolean`: forces a fresh inference. Skips the cache read, runs the model, and replaces the cached value after a successful run.
- Built-in storage entries now use a versioned envelope (`{"v":1,"value":...,"expiresAt":...}`). Expired entries, legacy raw strings, malformed JSON, unsupported versions, and invalid timestamps count as misses, are removed best-effort, and are replaced on the next successful run.
- Aborted, unavailable, failed, empty, and safety-blocked runs never overwrite a valid cached value.
- Custom `{ get, set }` caches keep their contract and own their expiry policy; `cacheTtl` does not apply to them. `cacheRefresh` still bypasses their read and updates them after success.
- React hooks pass both options through and keep `fromCache` accurate.
- `@web-ai-sdk/all` gains a runtime tripwire for `DEFAULT_CACHE_TTL_MS` on all seven namespaces plus a compile-time check that both options exist on every options type.

## Docs

- Package READMEs gained an "Expiry and refresh" section; `docs/packages/*` pages regenerated with `docs:sync`.
- Guides and React hook pages list the new options.
- The production checklist section "Expire caches and offer refresh" was rewritten: it claimed built-in caches never expire and recommended a hand-rolled TTL cache, which this PR obsoletes.

## Tests

- New fake-time `cache.test.ts` in every package: envelope round-trip, default expiry, TTL override, invalid-override fallback, legacy values, malformed envelopes, missing storage, and storage failures.
- Per-package integration tests: refresh bypass and replace, abort does not overwrite, empty output does not overwrite.
- 448 tests passing across the workspace; full `pnpm gate` (lint, docs:check, build, typecheck, test) green.
- Verified live in Chrome against the real Translator API: envelope write, cache hit, forced refresh, 1s TTL expiring into a real model call, and legacy raw-string migration.

## Release

Changeset bumps the seven packages and `@web-ai-sdk/all` as minor.