### PR TITLE
feat(playground): compact the composer into a responsive inline surface

### DIFF
--- a/apps/site/src/features/playground/PlaygroundFallback.astro
+++ b/apps/site/src/features/playground/PlaygroundFallback.astro
@@ -208,20 +208,6 @@ const truncateExample = (value: string, limit = 60) =>
         </section>
 
         <div class={ui.composerDock}>
-          <div class={ui.exampleFloat}>
-            <div class={ui.examples} data-playground-examples>
-              {
-                defaultMode.examples.slice(0, 3).map((example) => (
-                  <span class={ui.example} title={example}>
-                    {truncateExample(example)}
-                  </span>
-                ))
-              }
-            </div>
-            <span class={ui.exampleRegenerateWrap}>
-              <span class={ui.exampleRegenerate} aria-hidden="true">+</span>
-            </span>
-          </div>
           <div class={ui.composer}>
             <div class={ui.modeSelector}>
               <span class={ui.modeTrigger} data-playground-mode-trigger data-accent="warn">
@@ -263,6 +249,20 @@ const truncateExample = (value: string, limit = 60) =>
                 ↑
               </button>
             </div>
+          </div>
+          <div class={ui.exampleFloat}>
+            <div class={ui.examples} data-playground-examples>
+              {
+                defaultMode.examples.slice(0, 3).map((example) => (
+                  <span class={ui.example} title={example}>
+                    {truncateExample(example)}
+                  </span>
+                ))
+              }
+            </div>
+            <span class={ui.exampleRegenerateWrap}>
+              <span class={ui.exampleRegenerate} aria-hidden="true">+</span>
+            </span>
           </div>
         </div>
       </div>

--- a/apps/site/src/features/playground/PlaygroundFallback.astro
+++ b/apps/site/src/features/playground/PlaygroundFallback.astro
@@ -208,62 +208,60 @@ const truncateExample = (value: string, limit = 60) =>
         </section>
 
         <div class={ui.composerDock}>
+          <div class={ui.exampleFloat}>
+            <div class={ui.examples} data-playground-examples>
+              {
+                defaultMode.examples.slice(0, 3).map((example) => (
+                  <span class={ui.example} title={example}>
+                    {truncateExample(example)}
+                  </span>
+                ))
+              }
+            </div>
+            <span class={ui.exampleRegenerateWrap}>
+              <span class={ui.exampleRegenerate} aria-hidden="true">+</span>
+            </span>
+          </div>
           <div class={ui.composer}>
+            <div class={ui.modeSelector}>
+              <span class={ui.modeTrigger} data-playground-mode-trigger data-accent="warn">
+                <span
+                  class={ui.modeTriggerName}
+                  data-playground-mode-name
+                  data-accent="warn"
+                >
+                  Platform reach
+                </span>
+                <svg
+                  class={ui.modeTriggerChevron}
+                  viewBox="0 0 16 16"
+                  fill="none"
+                  aria-hidden="true"
+                >
+                  <path
+                    d="m4.5 6 3.5 3.5L11.5 6"
+                    stroke="currentColor"
+                    stroke-width="1.4"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"></path>
+                </svg>
+              </span>
+            </div>
             <div class:list={[ui.composerInput, ui.fallbackMuted]}>
               Ask anything
             </div>
-            <div class={ui.composerRow}>
-              <div class={ui.composerLeading}>
-                <span class={ui.modeTrigger} data-playground-mode-trigger data-accent="warn">
-                  <span
-                    class={ui.modeTriggerName}
-                    data-playground-mode-name
-                    data-accent="warn"
-                  >
-                    Platform reach
-                  </span>
-                  <svg
-                    class={ui.modeTriggerChevron}
-                    viewBox="0 0 16 16"
-                    fill="none"
-                    aria-hidden="true"
-                  >
-                    <path
-                      d="m4.5 6 3.5 3.5L11.5 6"
-                      stroke="currentColor"
-                      stroke-width="1.4"
-                      stroke-linecap="round"
-                      stroke-linejoin="round"></path>
-                  </svg>
-                </span>
-                <div class={ui.exampleRail}>
-                  <div class={ui.examples} data-playground-examples>
-                    {
-                      defaultMode.examples.slice(0, 3).map((example) => (
-                        <span class={ui.example} title={example}>
-                          {truncateExample(example)}
-                        </span>
-                      ))
-                    }
-                  </div>
-                  <span class={ui.exampleRegenerateWrap}>
-                    <span class={ui.exampleRegenerate} aria-hidden="true">+</span>
-                  </span>
-                </div>
-              </div>
-              <div class={ui.composerActions}>
-                <span class={ui.toolSummaryTrigger} data-playground-tool-count>
-                  5 tools
-                </span>
-                <button
-                  type="button"
-                  class={ui.sendButton}
-                  aria-label="Send message"
-                  disabled
-                >
-                  ↑
-                </button>
-              </div>
+            <div class={ui.composerActions}>
+              <span class={ui.toolSummaryTrigger} data-playground-tool-count>
+                5 tools
+              </span>
+              <button
+                type="button"
+                class={ui.sendButton}
+                aria-label="Send message"
+                disabled
+              >
+                ↑
+              </button>
             </div>
           </div>
         </div>

--- a/apps/site/src/features/playground/README.md
+++ b/apps/site/src/features/playground/README.md
@@ -206,6 +206,25 @@ registration hook so behavior can be tested without mounting a browser UI.
 Read operations remain available while a response is running. Mutations return
 an explicit busy result instead of racing the active run.
 
+### 14. The composer is a compact inline surface
+
+The composer places the mode trigger, prompt input, tool summary, and send or
+stop action in one row, styled as a single rounded surface. Example
+suggestions float above the surface and never narrow the prompt input.
+
+The floating example list renders only while the prompt is available, idle,
+and empty. The list container uses one background gradient into the page
+color, so transcript content fades out behind the suggestions.
+
+The input starts at one line. It grows with wrapped or multiline text through
+`field-sizing: content`, up to a capped height, then scrolls internally. The
+primary controls stay anchored to the bottom of the row while the input grows.
+
+The row composition comes from named grid areas in `ui.composer`. Below 640px
+the input takes its own full-width row, the mode trigger and actions move to a
+compact second row, and examples stay hidden. The Astro boot shell mirrors the
+same structure and classes.
+
 ## Maintenance invariants
 
 - Do not add browser API lifecycle code when an SDK package already owns it.

--- a/apps/site/src/features/playground/components/Composer.test.tsx
+++ b/apps/site/src/features/playground/components/Composer.test.tsx
@@ -154,6 +154,15 @@ describe("Composer", () => {
     expect(idle.container.querySelector("[title*='Summarize']")).not.toBeNull();
   });
 
+  it("keeps primary controls before example suggestions in tab order", () => {
+    const { container } = renderComposer();
+    const input = queryInput(container);
+    const example = container.querySelector("[title*='Summarize']");
+    if (!example) throw new Error("example button not found");
+    const position = input.compareDocumentPosition(example);
+    expect(position & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+  });
+
   it("submits an example suggestion directly", () => {
     const { container, props } = renderComposer();
     const example = [...container.querySelectorAll("button")].find((button) =>

--- a/apps/site/src/features/playground/components/Composer.test.tsx
+++ b/apps/site/src/features/playground/components/Composer.test.tsx
@@ -1,0 +1,166 @@
+// @vitest-environment happy-dom
+
+import { act, createRef } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { MODES } from "../experimental/playground/presets.js";
+import { Composer, type ComposerProps } from "./Composer.js";
+
+(
+  globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+let root: Root | undefined;
+
+afterEach(() => {
+  act(() => root?.unmount());
+  root = undefined;
+  document.body.replaceChildren();
+});
+
+function renderComposer(overrides: Partial<ComposerProps> = {}) {
+  const props: ComposerProps = {
+    draft: "",
+    promptOn: true,
+    promptReadiness: "available",
+    error: null,
+    busy: false,
+    activeMode: MODES[0],
+    modeMenuOpen: false,
+    modeMenuRef: createRef<HTMLDivElement | null>(),
+    examples: ["Summarize this page"],
+    generatingExamples: false,
+    canRegenerateExamples: true,
+    tools: [],
+    onDraftChange: vi.fn(),
+    onSubmit: vi.fn(),
+    onSubmitExample: vi.fn(),
+    onToggleModeMenu: vi.fn(),
+    onSelectMode: vi.fn(),
+    onRegenerateExamples: vi.fn(),
+    onAbort: vi.fn(),
+    ...overrides,
+  };
+
+  const container = document.createElement("div");
+  document.body.append(container);
+  root = createRoot(container);
+  act(() => {
+    root?.render(<Composer {...props} />);
+  });
+
+  return { container, props };
+}
+
+function queryInput(container: HTMLElement): HTMLTextAreaElement {
+  const input = container.querySelector("textarea");
+  if (!input) throw new Error("composer textarea not found");
+  return input;
+}
+
+function pressEnter(input: HTMLTextAreaElement, shiftKey: boolean) {
+  act(() => {
+    input.dispatchEvent(
+      new KeyboardEvent("keydown", {
+        key: "Enter",
+        shiftKey,
+        bubbles: true,
+        cancelable: true,
+      }),
+    );
+  });
+}
+
+describe("Composer", () => {
+  it("starts with a single visible input line", () => {
+    const { container } = renderComposer();
+    expect(queryInput(container).getAttribute("rows")).toBe("1");
+  });
+
+  it("submits on Enter and keeps Shift+Enter for newlines", () => {
+    const { container, props } = renderComposer({ draft: "hello" });
+    const input = queryInput(container);
+
+    pressEnter(input, true);
+    expect(props.onSubmit).not.toHaveBeenCalled();
+
+    pressEnter(input, false);
+    expect(props.onSubmit).toHaveBeenCalledTimes(1);
+  });
+
+  it("disables send until the draft has content", () => {
+    const empty = renderComposer({ draft: "   " });
+    const emptySend = empty.container.querySelector(
+      "[data-testid='agent-run']",
+    ) as HTMLButtonElement;
+    expect(emptySend.disabled).toBe(true);
+
+    act(() => root?.unmount());
+    document.body.replaceChildren();
+
+    const filled = renderComposer({ draft: "hello" });
+    const filledSend = filled.container.querySelector(
+      "[data-testid='agent-run']",
+    ) as HTMLButtonElement;
+    expect(filledSend.disabled).toBe(false);
+  });
+
+  it("replaces send with a stop action while busy", () => {
+    const { container, props } = renderComposer({ busy: true, draft: "hello" });
+    expect(container.querySelector("[data-testid='agent-run']")).toBeNull();
+
+    const stop = [...container.querySelectorAll("button")].find(
+      (button) => button.textContent === "Stop",
+    );
+    if (!stop) throw new Error("stop button not found");
+    act(() => stop.click());
+    expect(props.onAbort).toHaveBeenCalledTimes(1);
+  });
+
+  it("disables the input and explains a pending model download", () => {
+    const { container } = renderComposer({
+      promptOn: false,
+      promptReadiness: "downloading",
+    });
+    const input = queryInput(container);
+    expect(input.disabled).toBe(true);
+    expect(input.placeholder).toBe("Waiting for the on-device model");
+    expect(container.querySelector("[role='status']")).not.toBeNull();
+  });
+
+  it("links to browser support when the model is unavailable", () => {
+    const { container } = renderComposer({
+      promptOn: false,
+      promptReadiness: "unavailable",
+    });
+    const link = container.querySelector("[role='status'] a");
+    expect(link?.getAttribute("href")).toContain("docs/browser-support");
+  });
+
+  it("floats example suggestions only while the draft is empty and idle", () => {
+    const typed = renderComposer({ draft: "hello" });
+    expect(typed.container.querySelector("[title*='Summarize']")).toBeNull();
+
+    act(() => root?.unmount());
+    document.body.replaceChildren();
+
+    const running = renderComposer({ busy: true });
+    expect(running.container.querySelector("[title*='Summarize']")).toBeNull();
+
+    act(() => root?.unmount());
+    document.body.replaceChildren();
+
+    const idle = renderComposer();
+    expect(idle.container.querySelector("[title*='Summarize']")).not.toBeNull();
+  });
+
+  it("submits an example suggestion directly", () => {
+    const { container, props } = renderComposer();
+    const example = [...container.querySelectorAll("button")].find((button) =>
+      button.title.includes("Summarize this page"),
+    );
+    if (!example) throw new Error("example button not found");
+    act(() => example.click());
+    expect(props.onSubmitExample).toHaveBeenCalledWith("Summarize this page");
+  });
+});

--- a/apps/site/src/features/playground/components/Composer.tsx
+++ b/apps/site/src/features/playground/components/Composer.tsx
@@ -84,39 +84,6 @@ export function Composer({
         )}
       </div>
 
-      {promptOn && !busy && !error && !draft.trim() && (
-        <div className={ui.exampleFloat}>
-          <div className={ui.examples}>
-            {examples.map((example) => (
-              <button
-                key={example}
-                type="button"
-                className={ui.example}
-                onClick={() => onSubmitExample(example)}
-                title={example}
-              >
-                {truncate(example)}
-              </button>
-            ))}
-          </div>
-          <span className={ui.exampleRegenerateWrap}>
-            <button
-              type="button"
-              className={ui.exampleRegenerate}
-              onClick={onRegenerateExamples}
-              disabled={generatingExamples || !canRegenerateExamples}
-              aria-label="Generate new examples"
-              aria-busy={generatingExamples}
-            >
-              <span aria-hidden="true">+</span>
-            </button>
-            <span role="tooltip" className={ui.exampleRegenerateTooltip}>
-              Generate new examples
-            </span>
-          </span>
-        </div>
-      )}
-
       <form className={ui.composer} onSubmit={submit}>
         <div className={ui.modeSelector} ref={modeMenuRef}>
           <button
@@ -256,6 +223,39 @@ export function Composer({
           )}
         </div>
       </form>
+
+      {promptOn && !busy && !error && !draft.trim() && (
+        <div className={ui.exampleFloat}>
+          <div className={ui.examples}>
+            {examples.map((example) => (
+              <button
+                key={example}
+                type="button"
+                className={ui.example}
+                onClick={() => onSubmitExample(example)}
+                title={example}
+              >
+                {truncate(example)}
+              </button>
+            ))}
+          </div>
+          <span className={ui.exampleRegenerateWrap}>
+            <button
+              type="button"
+              className={ui.exampleRegenerate}
+              onClick={onRegenerateExamples}
+              disabled={generatingExamples || !canRegenerateExamples}
+              aria-label="Generate new examples"
+              aria-busy={generatingExamples}
+            >
+              <span aria-hidden="true">+</span>
+            </button>
+            <span role="tooltip" className={ui.exampleRegenerateTooltip}>
+              Generate new examples
+            </span>
+          </span>
+        </div>
+      )}
     </div>
   );
 }

--- a/apps/site/src/features/playground/components/Composer.tsx
+++ b/apps/site/src/features/playground/components/Composer.tsx
@@ -84,7 +84,135 @@ export function Composer({
         )}
       </div>
 
+      {promptOn && !busy && !error && !draft.trim() && (
+        <div className={ui.exampleFloat}>
+          <div className={ui.examples}>
+            {examples.map((example) => (
+              <button
+                key={example}
+                type="button"
+                className={ui.example}
+                onClick={() => onSubmitExample(example)}
+                title={example}
+              >
+                {truncate(example)}
+              </button>
+            ))}
+          </div>
+          <span className={ui.exampleRegenerateWrap}>
+            <button
+              type="button"
+              className={ui.exampleRegenerate}
+              onClick={onRegenerateExamples}
+              disabled={generatingExamples || !canRegenerateExamples}
+              aria-label="Generate new examples"
+              aria-busy={generatingExamples}
+            >
+              <span aria-hidden="true">+</span>
+            </button>
+            <span role="tooltip" className={ui.exampleRegenerateTooltip}>
+              Generate new examples
+            </span>
+          </span>
+        </div>
+      )}
+
       <form className={ui.composer} onSubmit={submit}>
+        <div className={ui.modeSelector} ref={modeMenuRef}>
+          <button
+            type="button"
+            className={ui.modeTrigger}
+            data-accent={activeMode.accent}
+            onClick={onToggleModeMenu}
+            disabled={busy}
+            aria-label={`Mode: ${activeMode.name}`}
+            aria-expanded={modeMenuOpen}
+            aria-controls="playground-mode-menu"
+          >
+            <span
+              className={ui.modeTriggerName}
+              data-accent={activeMode.accent}
+            >
+              {activeMode.name}
+            </span>
+            <svg
+              className={
+                modeMenuOpen ? ui.modeTriggerChevronOpen : ui.modeTriggerChevron
+              }
+              viewBox="0 0 16 16"
+              fill="none"
+              aria-hidden="true"
+            >
+              <path
+                d="m4.5 6 3.5 3.5L11.5 6"
+                stroke="currentColor"
+                strokeWidth="1.4"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              />
+            </svg>
+          </button>
+          {modeMenuOpen && (
+            <div className={ui.modeMenu}>
+              <div className={ui.modeMenuHeader}>
+                <span className={ui.modeMenuTitle}>
+                  How should this agent work?
+                </span>
+                <span className={ui.modeMenuDescription}>
+                  Choose a focused configuration for this conversation.
+                </span>
+              </div>
+              <fieldset
+                id="playground-mode-menu"
+                className={ui.modeOptions}
+                aria-label="Agent mode"
+              >
+                {MODES.map((mode) => {
+                  const selected = mode.id === activeMode.id;
+                  return (
+                    <button
+                      key={mode.id}
+                      type="button"
+                      aria-pressed={selected}
+                      data-accent={mode.accent}
+                      className={selected ? ui.modeOptionActive : ui.modeOption}
+                      onClick={() => onSelectMode(mode.id)}
+                    >
+                      <span className={ui.modeOptionCopy}>
+                        <span className={ui.modeOptionTitleRow}>
+                          <span className={ui.modeOptionIdentity}>
+                            <span
+                              className={ui.modeAccentDot}
+                              data-accent={mode.accent}
+                              aria-hidden="true"
+                            />
+                            <span
+                              className={ui.modeOptionName}
+                              data-accent={mode.accent}
+                            >
+                              {mode.name}
+                            </span>
+                          </span>
+                          <span className={ui.modeOptionToolCount}>
+                            {mode.tools.length === 0
+                              ? "no tools"
+                              : `${mode.tools.length} tool${mode.tools.length === 1 ? "" : "s"}`}
+                          </span>
+                        </span>
+                        <span className={ui.modeOptionDescription}>
+                          {mode.description}
+                        </span>
+                      </span>
+                    </button>
+                  );
+                })}
+              </fieldset>
+              <div className={ui.modeMenuNote}>
+                Mode changes keep this conversation and its history.
+              </div>
+            </div>
+          )}
+        </div>
         <textarea
           id="playground-message"
           name="message"
@@ -101,7 +229,7 @@ export function Composer({
           value={draft}
           onChange={(event) => onDraftChange(event.target.value)}
           disabled={!promptOn}
-          rows={3}
+          rows={1}
           onKeyDown={(event) => {
             if (event.key === "Enter" && !event.shiftKey) {
               event.preventDefault();
@@ -109,159 +237,23 @@ export function Composer({
             }
           }}
         />
-        <div className={ui.composerRow}>
-          <div className={ui.composerLeading}>
-            <div className={ui.modeSelector} ref={modeMenuRef}>
-              <button
-                type="button"
-                className={ui.modeTrigger}
-                data-accent={activeMode.accent}
-                onClick={onToggleModeMenu}
-                disabled={busy}
-                aria-label={`Mode: ${activeMode.name}`}
-                aria-expanded={modeMenuOpen}
-                aria-controls="playground-mode-menu"
-              >
-                <span
-                  className={ui.modeTriggerName}
-                  data-accent={activeMode.accent}
-                >
-                  {activeMode.name}
-                </span>
-                <svg
-                  className={
-                    modeMenuOpen
-                      ? ui.modeTriggerChevronOpen
-                      : ui.modeTriggerChevron
-                  }
-                  viewBox="0 0 16 16"
-                  fill="none"
-                  aria-hidden="true"
-                >
-                  <path
-                    d="m4.5 6 3.5 3.5L11.5 6"
-                    stroke="currentColor"
-                    strokeWidth="1.4"
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                  />
-                </svg>
-              </button>
-              {modeMenuOpen && (
-                <div className={ui.modeMenu}>
-                  <div className={ui.modeMenuHeader}>
-                    <span className={ui.modeMenuTitle}>
-                      How should this agent work?
-                    </span>
-                    <span className={ui.modeMenuDescription}>
-                      Choose a focused configuration for this conversation.
-                    </span>
-                  </div>
-                  <fieldset
-                    id="playground-mode-menu"
-                    className={ui.modeOptions}
-                    aria-label="Agent mode"
-                  >
-                    {MODES.map((mode) => {
-                      const selected = mode.id === activeMode.id;
-                      return (
-                        <button
-                          key={mode.id}
-                          type="button"
-                          aria-pressed={selected}
-                          data-accent={mode.accent}
-                          className={
-                            selected ? ui.modeOptionActive : ui.modeOption
-                          }
-                          onClick={() => onSelectMode(mode.id)}
-                        >
-                          <span className={ui.modeOptionCopy}>
-                            <span className={ui.modeOptionTitleRow}>
-                              <span className={ui.modeOptionIdentity}>
-                                <span
-                                  className={ui.modeAccentDot}
-                                  data-accent={mode.accent}
-                                  aria-hidden="true"
-                                />
-                                <span
-                                  className={ui.modeOptionName}
-                                  data-accent={mode.accent}
-                                >
-                                  {mode.name}
-                                </span>
-                              </span>
-                              <span className={ui.modeOptionToolCount}>
-                                {mode.tools.length === 0
-                                  ? "no tools"
-                                  : `${mode.tools.length} tool${mode.tools.length === 1 ? "" : "s"}`}
-                              </span>
-                            </span>
-                            <span className={ui.modeOptionDescription}>
-                              {mode.description}
-                            </span>
-                          </span>
-                        </button>
-                      );
-                    })}
-                  </fieldset>
-                  <div className={ui.modeMenuNote}>
-                    Mode changes keep this conversation and its history.
-                  </div>
-                </div>
-              )}
-            </div>
-            <div className={ui.exampleRail}>
-              <div className={ui.examples}>
-                {examples.map((example) => (
-                  <button
-                    key={example}
-                    type="button"
-                    className={ui.example}
-                    onClick={() => onSubmitExample(example)}
-                    disabled={!promptOn || busy}
-                    title={example}
-                  >
-                    {truncate(example)}
-                  </button>
-                ))}
-              </div>
-              <span className={ui.exampleRegenerateWrap}>
-                <button
-                  type="button"
-                  className={ui.exampleRegenerate}
-                  onClick={onRegenerateExamples}
-                  disabled={
-                    busy || generatingExamples || !canRegenerateExamples
-                  }
-                  aria-label="Generate new examples"
-                  aria-busy={generatingExamples}
-                >
-                  <span aria-hidden="true">+</span>
-                </button>
-                <span role="tooltip" className={ui.exampleRegenerateTooltip}>
-                  Generate new examples
-                </span>
-              </span>
-            </div>
-          </div>
-          <div className={ui.composerActions}>
-            <ToolSummary tools={tools} />
-            {busy ? (
-              <button type="button" className={ui.stopButton} onClick={onAbort}>
-                Stop
-              </button>
-            ) : (
-              <button
-                type="submit"
-                className={ui.sendButton}
-                data-testid="agent-run"
-                disabled={!promptOn || !draft.trim()}
-                aria-label="Send message"
-              >
-                <span aria-hidden="true">↑</span>
-              </button>
-            )}
-          </div>
+        <div className={ui.composerActions}>
+          <ToolSummary tools={tools} />
+          {busy ? (
+            <button type="button" className={ui.stopButton} onClick={onAbort}>
+              Stop
+            </button>
+          ) : (
+            <button
+              type="submit"
+              className={ui.sendButton}
+              data-testid="agent-run"
+              disabled={!promptOn || !draft.trim()}
+              aria-label="Send message"
+            >
+              <span aria-hidden="true">↑</span>
+            </button>
+          )}
         </div>
       </form>
     </div>

--- a/apps/site/src/shared/ui.ts
+++ b/apps/site/src/shared/ui.ts
@@ -597,7 +597,7 @@ export const playground = {
   panelToggle:
     "inline-flex size-7 shrink-0 cursor-pointer items-center justify-center rounded-sm bg-transparent text-fg-4 transition-[color,background-color,transform] hover:bg-surface hover:text-fg-2 active:scale-95 focus-visible:bg-surface focus-visible:text-fg focus-visible:outline focus-visible:outline-1 focus-visible:outline-offset-1 focus-visible:outline-accent motion-reduce:transform-none max-[760px]:size-9",
   panelToggleIcon: "size-4",
-  modeSelector: "relative shrink-0",
+  modeSelector: "relative min-w-0 [grid-area:mode]",
   modeTrigger:
     "inline-flex min-h-9 max-w-52 cursor-pointer items-center gap-2 rounded-pill bg-bg px-3 py-2 text-left transition-colors data-[accent=info]:bg-[color-mix(in_oklch,var(--color-info)_9%,var(--color-bg))] data-[accent=ok]:bg-[color-mix(in_oklch,var(--color-ok)_9%,var(--color-bg))] data-[accent=warn]:bg-[color-mix(in_oklch,var(--color-warn)_9%,var(--color-bg))] data-[accent=violet]:bg-[color-mix(in_oklch,var(--color-info)_5%,color-mix(in_oklch,var(--color-err)_5%,var(--color-bg)))] hover:data-[accent=info]:bg-[color-mix(in_oklch,var(--color-info)_14%,var(--color-bg))] hover:data-[accent=ok]:bg-[color-mix(in_oklch,var(--color-ok)_14%,var(--color-bg))] hover:data-[accent=warn]:bg-[color-mix(in_oklch,var(--color-warn)_14%,var(--color-bg))] hover:data-[accent=violet]:bg-[color-mix(in_oklch,var(--color-info)_8%,color-mix(in_oklch,var(--color-err)_8%,var(--color-bg)))] focus-visible:outline focus-visible:outline-1 focus-visible:outline-offset-1 data-[accent=info]:focus-visible:outline-info data-[accent=ok]:focus-visible:outline-ok data-[accent=warn]:focus-visible:outline-warn data-[accent=violet]:focus-visible:outline-[color-mix(in_oklch,var(--color-info)_45%,var(--color-err))] disabled:cursor-not-allowed disabled:opacity-45 max-[640px]:min-h-8 max-[640px]:max-w-40 max-[640px]:gap-1.5 max-[640px]:px-2.5 max-[640px]:py-1.5",
   modeTriggerName:
@@ -639,7 +639,7 @@ export const playground = {
     "mb-4 rounded-sm border border-[color-mix(in_oklch,var(--color-err)_35%,transparent)] bg-[color-mix(in_oklch,var(--color-err)_10%,var(--color-bg))] px-3.5 py-3 font-mono text-[11px] leading-relaxed text-err",
   jump: "absolute right-4 bottom-4 inline-flex size-8 cursor-pointer items-center justify-center rounded-full bg-[color-mix(in_oklch,var(--color-surface-3)_92%,transparent)] font-mono text-[13px] text-fg-2 shadow-card backdrop-blur-sm transition-colors hover:text-fg",
   composer:
-    "relative z-10 grid gap-2 rounded-xl bg-surface p-2.5 shadow-[0_-14px_30px_-18px_rgba(0,0,0,0.95)] transition-colors focus-within:bg-surface-2 max-[640px]:gap-1.5 max-[640px]:p-2",
+    "relative z-10 grid grid-cols-[auto_minmax(0,1fr)_auto] [grid-template-areas:'mode_input_actions'] items-end gap-x-1.5 rounded-3xl bg-surface p-2 shadow-[0_-14px_30px_-18px_rgba(0,0,0,0.95)] transition-colors focus-within:bg-surface-2 max-[640px]:grid-cols-[minmax(0,1fr)_auto] max-[640px]:[grid-template-areas:'input_input'_'mode_actions'] max-[640px]:gap-y-1.5",
   composerDock: "relative z-20",
   composerNotices:
     "pointer-events-none absolute bottom-[calc(100%+0.65rem)] left-0 z-30 grid w-full gap-1.5",
@@ -656,21 +656,19 @@ export const playground = {
   composerNoticeErrorIcon:
     "inline-flex size-5 shrink-0 items-center justify-center rounded-full bg-[color-mix(in_oklch,var(--color-err)_14%,transparent)] text-err [&_svg]:size-3.5 [&_svg_*]:stroke-current [&_svg_*]:stroke-[1.5] [&_svg_*]:[stroke-linecap:round] [&_svg_*]:[stroke-linejoin:round]",
   composerInput:
-    "min-h-20 w-full resize-none border-0 bg-transparent px-1 py-1 font-sans text-[14px] leading-[1.55] text-fg outline-none placeholder:text-fg-4 disabled:cursor-not-allowed disabled:opacity-55 max-[640px]:min-h-16",
+    "[grid-area:input] max-h-40 w-full resize-none overflow-y-auto border-0 bg-transparent px-1.5 py-2 font-sans text-[14px] leading-[1.55] text-fg outline-none [field-sizing:content] [scrollbar-width:thin] placeholder:text-fg-4 disabled:cursor-not-allowed disabled:opacity-55 max-[640px]:max-h-32",
   fallbackMuted: "text-fg-4",
-  composerRow: "flex min-w-0 items-center justify-between gap-2",
-  composerLeading:
-    "flex min-w-0 flex-1 items-center gap-2 max-[720px]:w-full max-[640px]:w-auto",
-  exampleRail: "flex min-w-0 flex-1 items-center gap-1 max-[640px]:hidden",
-  examples: "flex min-w-0 flex-[0_1_auto] flex-nowrap gap-1 overflow-hidden",
+  exampleFloat:
+    "pointer-events-none absolute bottom-full left-0 flex w-full flex-wrap items-center gap-1 bg-[linear-gradient(to_top,var(--color-bg)_62%,transparent)] px-1 pt-8 pb-2.5 max-[640px]:hidden",
+  examples: "flex min-w-0 flex-wrap items-center gap-1",
   example:
-    "max-w-48 cursor-pointer truncate rounded-pill bg-bg px-2.5 py-1.5 font-mono text-[8px] text-fg-4 transition-[color,background-color,transform] hover:bg-surface-3 hover:text-fg-2 active:scale-[0.98] motion-reduce:transform-none disabled:cursor-not-allowed disabled:opacity-45",
-  exampleRegenerateWrap: "group relative shrink-0",
+    "pointer-events-auto max-w-48 cursor-pointer truncate rounded-pill bg-surface-2 px-2 py-1 font-mono text-[8px] text-fg-4 transition-[color,background-color,transform] hover:bg-surface-3 hover:text-fg-2 active:scale-[0.98] motion-reduce:transform-none disabled:cursor-not-allowed disabled:opacity-45",
+  exampleRegenerateWrap: "group pointer-events-auto relative shrink-0",
   exampleRegenerate:
-    "inline-flex size-7 cursor-pointer items-center justify-center rounded-full bg-bg font-mono text-sm leading-none text-fg-3 transition-colors hover:bg-surface-3 hover:text-fg focus-visible:bg-surface-3 focus-visible:text-fg focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-35",
+    "inline-flex size-6 cursor-pointer items-center justify-center rounded-full bg-surface-2 font-mono text-[13px] leading-none text-fg-3 transition-colors hover:bg-surface-3 hover:text-fg focus-visible:bg-surface-3 focus-visible:text-fg focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-35",
   exampleRegenerateTooltip:
     "pointer-events-none invisible absolute bottom-[calc(100%+0.5rem)] left-1/2 z-50 -translate-x-1/2 whitespace-nowrap rounded-md bg-surface-3 px-2.5 py-1.5 font-mono text-[8px] text-fg-2 opacity-0 shadow-card transition-opacity group-hover:visible group-hover:opacity-100 group-focus-within:visible group-focus-within:opacity-100",
-  composerActions: "flex shrink-0 items-center gap-1.5",
+  composerActions: "flex shrink-0 items-center gap-1.5 [grid-area:actions]",
   toolPill: "group relative",
   toolSummaryTrigger:
     "inline-flex min-h-9 cursor-help items-center rounded-pill bg-bg px-3 py-2 font-mono text-[10px] text-fg-3 transition-colors hover:bg-surface-3 hover:text-fg focus-visible:bg-surface-3 focus-visible:text-fg focus-visible:outline-none",


### PR DESCRIPTION
Closes #170.

## What changed

- The composer is now one compact rounded surface. The mode trigger, prompt input, tool summary, and send or stop action share a single row composed with named grid areas in `ui.composer`.
- The prompt input starts at one visible line. It grows with wrapped or multiline text through `field-sizing: content`, up to a capped height (160px desktop, 128px mobile), then scrolls internally. Primary controls stay anchored while it grows.
- Example suggestions float above the surface and render only while the prompt is available, idle, and empty. The list container uses a single gradient into the page background, so transcript content fades out behind the suggestions. The regenerate control sits directly after the last suggestion.
- Below 640px the composer uses a deliberate two-row composition: full-width input on top, mode trigger and actions below. Example suggestions stay hidden there.
- `PlaygroundFallback.astro` mirrors the new structure and classes for boot parity.
- Playground README documents the composer decision.

## Behavior preserved

- `Enter` submits, `Shift+Enter` inserts a newline.
- Mode menu, tool summary popover, generated examples, readiness and error notices, and submit or abort semantics are unchanged.
- The mode menu stacks above the floating suggestions.

## Validation

- `pnpm gate` passes (lint, build, typecheck, tests).
- 8 focused Composer tests cover the single-line start, Enter and Shift+Enter, disabled and busy states, readiness placeholders and the browser-support link, example visibility gating, and example submit.
- Built site verified in Chrome at 1440x900, 768x1024, 390x844, 320px, and 200% zoom equivalent: no page-level horizontal overflow, no clipped or overlapping controls.
- Verified end to end in Chrome with the Prompt API available: live agent run from an example, multiline draft submit, gradient veil over a long transcript.
