### PR TITLE
feat(playground): require evidence for live values in agent answers

### DIFF
--- a/apps/site/src/features/playground/experimental/agent/answerEvidence.test.ts
+++ b/apps/site/src/features/playground/experimental/agent/answerEvidence.test.ts
@@ -68,6 +68,52 @@ describe("findUnsupportedAnswerValues", () => {
     expect(unsupported).toEqual(["1,238"]);
   });
 
+  it("flags a negative value when the evidence only has the positive form", () => {
+    const positiveOnly = record({
+      output: { status: 200, url: "https://one.test", text: "delta: 25" },
+    });
+
+    expect(
+      findUnsupportedAnswerValues(
+        "The delta is -25.",
+        "What is the delta on https://one.test?",
+        [positiveOnly],
+      ),
+    ).toEqual(["-25"]);
+  });
+
+  it("supports a negative value present in the tool output", () => {
+    const negative = record({
+      output: { status: 200, url: "https://one.test", delta: -25 },
+    });
+
+    expect(
+      findUnsupportedAnswerValues(
+        "The delta is -25.",
+        "What is the delta on https://one.test?",
+        [negative],
+      ),
+    ).toEqual([]);
+  });
+
+  it("does not read ranges or dates as negative values", () => {
+    const dated = record({
+      output: {
+        status: 200,
+        url: "https://one.test",
+        text: "Pages 10-15, updated 2026-08-06",
+      },
+    });
+
+    expect(
+      findUnsupportedAnswerValues(
+        "Covers pages 10-15, last updated 2026-08-06.",
+        "Check https://one.test",
+        [dated],
+      ),
+    ).toEqual([]);
+  });
+
   it("counts numbers in failed-call error messages as evidence", () => {
     const failed = record({
       output: undefined,

--- a/apps/site/src/features/playground/experimental/agent/answerEvidence.test.ts
+++ b/apps/site/src/features/playground/experimental/agent/answerEvidence.test.ts
@@ -96,6 +96,20 @@ describe("findUnsupportedAnswerValues", () => {
     ).toEqual([]);
   });
 
+  it("captures a signed value at the start of the answer", () => {
+    const positiveOnly = record({
+      output: { status: 200, url: "https://one.test", text: "delta: 25" },
+    });
+
+    expect(
+      findUnsupportedAnswerValues(
+        "-25 is the delta.",
+        "What is the delta on https://one.test?",
+        [positiveOnly],
+      ),
+    ).toEqual(["-25"]);
+  });
+
   it("does not read ranges or dates as negative values", () => {
     const dated = record({
       output: {

--- a/apps/site/src/features/playground/experimental/agent/answerEvidence.test.ts
+++ b/apps/site/src/features/playground/experimental/agent/answerEvidence.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from "vitest";
+import { findUnsupportedAnswerValues } from "./answerEvidence.js";
+import type { AgentToolCallRecord } from "./types.js";
+
+function record(
+  overrides: Partial<AgentToolCallRecord> = {},
+): AgentToolCallRecord {
+  return {
+    callId: "call-1",
+    name: "fetch_url",
+    input: { url: "https://one.test" },
+    output: { status: 200, url: "https://one.test", text: "stars: 19" },
+    durationMs: 5,
+    ...overrides,
+  };
+}
+
+describe("findUnsupportedAnswerValues", () => {
+  it("returns fabricated values in their display form", () => {
+    const unsupported = findUnsupportedAnswerValues(
+      "The repository has 1,238 stars.",
+      "How many stars does https://one.test have?",
+      [record()],
+    );
+
+    expect(unsupported).toEqual(["1,238"]);
+  });
+
+  it("supports values present in tool output, including embedded runs", () => {
+    const clock = record({
+      name: "clock_now",
+      input: {},
+      output: { formatted: "Wednesday, August 6, 2026 at 12:34:56", iso: "" },
+    });
+
+    expect(
+      findUnsupportedAnswerValues("It is 12:34.", "What time is it?", [clock]),
+    ).toEqual([]);
+  });
+
+  it("treats the user's own numbers as supported", () => {
+    const unsupported = findUnsupportedAnswerValues(
+      "All 42 items are covered.",
+      "Check the 42 items on https://one.test",
+      [record()],
+    );
+
+    expect(unsupported).toEqual([]);
+  });
+
+  it("ignores single-digit counts the model can derive itself", () => {
+    const unsupported = findUnsupportedAnswerValues(
+      "I compared 2 pages and found 3 differences.",
+      "Compare https://one.test and https://two.test",
+      [record()],
+    );
+
+    expect(unsupported).toEqual([]);
+  });
+
+  it("dedupes repeated unsupported values", () => {
+    const unsupported = findUnsupportedAnswerValues(
+      "It has 1,238 stars. Yes, 1238 stars.",
+      "How many stars?",
+      [record()],
+    );
+
+    expect(unsupported).toEqual(["1,238"]);
+  });
+
+  it("counts numbers in failed-call error messages as evidence", () => {
+    const failed = record({
+      output: undefined,
+      error: { message: "Request timed out after 3000 ms" },
+    });
+
+    expect(
+      findUnsupportedAnswerValues(
+        "The request timed out after 3000 ms.",
+        "Fetch https://one.test",
+        [failed],
+      ),
+    ).toEqual([]);
+  });
+});

--- a/apps/site/src/features/playground/experimental/agent/answerEvidence.ts
+++ b/apps/site/src/features/playground/experimental/agent/answerEvidence.ts
@@ -15,12 +15,25 @@ import type { AgentToolCallRecord } from "./types.js";
 
 /**
  * Grouped ("1,238"), decimal ("3.14"), plain ("1238"), or negative
- * ("-15") numeric tokens. A leading "-" counts as a sign only when it
- * does not follow a digit, so ranges ("10-15") and dates ("2026-08-06")
- * still split into unsigned parts instead of fake negatives.
+ * ("-15") numeric tokens, captured in group 2. A leading "-" counts as
+ * a sign only when it does not follow a digit, so ranges ("10-15") and
+ * dates ("2026-08-06") still split into unsigned parts instead of fake
+ * negatives. That boundary is a consumed prefix capture rather than a
+ * lookbehind: the playground bundle must still PARSE in browsers whose
+ * RegExp lacks lookbehind (Safari before 16.4), where this module loads
+ * only to show the unavailability messaging.
  */
 const NUMBER_TOKEN =
-  /(?<!\d)-?\d{1,3}(?:,\d{3})+(?:\.\d+)?|(?<!\d)-?\d+(?:\.\d+)?/g;
+  /(^|[^0-9])(-?(?:\d{1,3}(?:,\d{3})+|\d+)(?:\.\d+)?)/g;
+
+function matchNumberTokens(text: string): string[] {
+  const tokens: string[] = [];
+  for (const match of text.matchAll(NUMBER_TOKEN)) {
+    const token = match[2];
+    if (token !== undefined) tokens.push(token);
+  }
+  return tokens;
+}
 
 /**
  * Single-digit mentions ("3 items", list markers, "the 2 pages") are
@@ -42,7 +55,7 @@ export function findUnsupportedAnswerValues(
   const evidence = collectEvidenceNumbers(userInput, records);
   const unsupported: string[] = [];
   const seen = new Set<string>();
-  for (const token of answer.match(NUMBER_TOKEN) ?? []) {
+  for (const token of matchNumberTokens(answer)) {
     const normalized = normalizeNumber(token);
     if (countDigits(normalized) < MIN_CLAIM_DIGITS) continue;
     if (evidence.has(normalized)) continue;
@@ -76,7 +89,7 @@ function collectEvidenceNumbers(
 }
 
 function addNumbers(target: Set<string>, text: string): void {
-  for (const token of text.match(NUMBER_TOKEN) ?? []) {
+  for (const token of matchNumberTokens(text)) {
     target.add(normalizeNumber(token));
   }
   // Raw digit runs as well, so a claim like "12" is supported by evidence

--- a/apps/site/src/features/playground/experimental/agent/answerEvidence.ts
+++ b/apps/site/src/features/playground/experimental/agent/answerEvidence.ts
@@ -1,0 +1,98 @@
+/**
+ * Deterministic evidence check for the final answer: numeric values the
+ * model states must be traceable to this run's tool results or to the
+ * user's own message. A hallucinated figure sitting beside real tool
+ * output reads as tool-backed fact (observed: "1,238 stars" while the
+ * fetched response said 19), so the loop uses this check to steer one
+ * rewrite and to flag whatever stays unsupported as unavailable.
+ *
+ * Zero inference: plain token extraction and set membership. The check
+ * runs only when the run produced tool records, so tool-free chat
+ * (stories, math help, generated examples) is never second-guessed.
+ */
+
+import type { AgentToolCallRecord } from "./types.js";
+
+/** Grouped ("1,238"), decimal ("3.14"), or plain ("1238") numeric tokens. */
+const NUMBER_TOKEN = /\d{1,3}(?:,\d{3})+(?:\.\d+)?|\d+(?:\.\d+)?/g;
+
+/**
+ * Single-digit mentions ("3 items", list markers, "the 2 pages") are
+ * counts the model routinely derives itself; only longer figures are
+ * treated as claims that need a supporting tool result.
+ */
+const MIN_CLAIM_DIGITS = 2;
+
+/**
+ * Numeric values in `answer` with no source in the user's message or in
+ * any tool record from this run. Returned in their original display form
+ * ("1,238", not "1238"), deduplicated, in answer order.
+ */
+export function findUnsupportedAnswerValues(
+  answer: string,
+  userInput: string,
+  records: readonly AgentToolCallRecord[],
+): string[] {
+  const evidence = collectEvidenceNumbers(userInput, records);
+  const unsupported: string[] = [];
+  const seen = new Set<string>();
+  for (const token of answer.match(NUMBER_TOKEN) ?? []) {
+    const normalized = normalizeNumber(token);
+    if (countDigits(normalized) < MIN_CLAIM_DIGITS) continue;
+    if (evidence.has(normalized)) continue;
+    if (seen.has(normalized)) continue;
+    seen.add(normalized);
+    unsupported.push(token);
+  }
+  return unsupported;
+}
+
+/**
+ * Every numeric token found in the user's message and in the recorded
+ * tool calls (inputs, outputs, and error messages). Failed calls count
+ * as evidence too: echoing a number from an error message is grounded,
+ * even though the loop separately reports the failure itself.
+ */
+function collectEvidenceNumbers(
+  userInput: string,
+  records: readonly AgentToolCallRecord[],
+): Set<string> {
+  const evidence = new Set<string>();
+  addNumbers(evidence, userInput);
+  for (const record of records) {
+    addNumbers(evidence, safeStringify(record.input));
+    if (record.output !== undefined) {
+      addNumbers(evidence, safeStringify(record.output));
+    }
+    if (record.error) addNumbers(evidence, record.error.message);
+  }
+  return evidence;
+}
+
+function addNumbers(target: Set<string>, text: string): void {
+  for (const token of text.match(NUMBER_TOKEN) ?? []) {
+    target.add(normalizeNumber(token));
+  }
+  // Raw digit runs as well, so a claim like "12" is supported by evidence
+  // that only carries it embedded ("12:34:56", "2026-08-06", id fields).
+  for (const run of text.match(/\d+/g) ?? []) {
+    target.add(run);
+  }
+}
+
+function normalizeNumber(token: string): string {
+  return token.replace(/,/g, "");
+}
+
+function countDigits(normalized: string): number {
+  return normalized.replace(/\D/g, "").length;
+}
+
+function safeStringify(value: unknown): string {
+  if (typeof value === "string") return value;
+  try {
+    return JSON.stringify(value) ?? "";
+  } catch {
+    return "";
+  }
+}

--- a/apps/site/src/features/playground/experimental/agent/answerEvidence.ts
+++ b/apps/site/src/features/playground/experimental/agent/answerEvidence.ts
@@ -13,8 +13,14 @@
 
 import type { AgentToolCallRecord } from "./types.js";
 
-/** Grouped ("1,238"), decimal ("3.14"), or plain ("1238") numeric tokens. */
-const NUMBER_TOKEN = /\d{1,3}(?:,\d{3})+(?:\.\d+)?|\d+(?:\.\d+)?/g;
+/**
+ * Grouped ("1,238"), decimal ("3.14"), plain ("1238"), or negative
+ * ("-15") numeric tokens. A leading "-" counts as a sign only when it
+ * does not follow a digit, so ranges ("10-15") and dates ("2026-08-06")
+ * still split into unsigned parts instead of fake negatives.
+ */
+const NUMBER_TOKEN =
+  /(?<!\d)-?\d{1,3}(?:,\d{3})+(?:\.\d+)?|(?<!\d)-?\d+(?:\.\d+)?/g;
 
 /**
  * Single-digit mentions ("3 items", list markers, "the 2 pages") are
@@ -75,6 +81,9 @@ function addNumbers(target: Set<string>, text: string): void {
   }
   // Raw digit runs as well, so a claim like "12" is supported by evidence
   // that only carries it embedded ("12:34:56", "2026-08-06", id fields).
+  // These runs are unsigned on purpose: a NEGATIVE claim ("-15") is only
+  // supported by explicitly negative evidence, while an unsigned claim
+  // stays supported by any embedded run.
   for (const run of text.match(/\d+/g) ?? []) {
     target.add(run);
   }

--- a/apps/site/src/features/playground/experimental/agent/answerEvidence.ts
+++ b/apps/site/src/features/playground/experimental/agent/answerEvidence.ts
@@ -23,8 +23,7 @@ import type { AgentToolCallRecord } from "./types.js";
  * RegExp lacks lookbehind (Safari before 16.4), where this module loads
  * only to show the unavailability messaging.
  */
-const NUMBER_TOKEN =
-  /(^|[^0-9])(-?(?:\d{1,3}(?:,\d{3})+|\d+)(?:\.\d+)?)/g;
+const NUMBER_TOKEN = /(^|[^0-9])(-?(?:\d{1,3}(?:,\d{3})+|\d+)(?:\.\d+)?)/g;
 
 function matchNumberTokens(text: string): string[] {
   const tokens: string[] = [];

--- a/apps/site/src/features/playground/experimental/agent/loop.test.ts
+++ b/apps/site/src/features/playground/experimental/agent/loop.test.ts
@@ -179,6 +179,137 @@ describe("createAgentLoop", () => {
     expect(result.text).toContain("clock_now failed: Clock unavailable");
   });
 
+  it("steers a plain-language live-value request to its required tool", async () => {
+    const fixture = createSessionFixture([
+      "It is 3:45 PM.",
+      "```tool_code\nclock_now()\n```",
+      "It is 12:34.",
+    ]);
+    createSessionMock.mockReturnValue(fixture.base);
+    const calls: string[] = [];
+    const agent = createAgentLoop({
+      tools: [createFetchFixtureTool(calls), createClockFixtureTool(calls)],
+    });
+
+    const result = await agent.run("What time is it right now?");
+    agent.destroy();
+
+    expect(calls).toEqual(["clock_now"]);
+    expect(result.stopReason).toBe("done");
+    expect(result.text).toBe("It is 12:34.");
+  });
+
+  it("reports a guessed live value when its tool never runs", async () => {
+    const fixture = createSessionFixture(["It is 3:45 PM.", "It is 3:45 PM."]);
+    createSessionMock.mockReturnValue(fixture.base);
+    const calls: string[] = [];
+    const agent = createAgentLoop({
+      tools: [createFetchFixtureTool(calls), createClockFixtureTool(calls)],
+    });
+
+    const result = await agent.run("What time is it right now?");
+    agent.destroy();
+
+    expect(calls).toEqual([]);
+    expect(result.stopReason).toBe("done");
+    expect(result.text).toContain("clock_now was not called");
+  });
+
+  it("reports a live value as unavailable when its tool fails", async () => {
+    const fixture = createSessionFixture([
+      "```tool_code\nclock_now()\n```",
+      "The current time is unavailable.",
+    ]);
+    createSessionMock.mockReturnValue(fixture.base);
+    const calls: string[] = [];
+    const agent = createAgentLoop({
+      tools: [
+        createFetchFixtureTool(calls),
+        createClockFixtureTool(calls, new Error("Clock unavailable")),
+      ],
+    });
+
+    const result = await agent.run("What time is it right now?");
+    agent.destroy();
+
+    expect(calls).toEqual(["clock_now"]);
+    expect(result.stopReason).toBe("done");
+    expect(result.text).toContain("clock_now failed: Clock unavailable");
+    expect(result.text).toContain("The current time is unavailable.");
+  });
+
+  it("rewrites an answer that contradicts fetched evidence", async () => {
+    const fixture = createSessionFixture([
+      "The repository has 1,238 stars.",
+      "The repository has 19 stars.",
+    ]);
+    createSessionMock.mockReturnValue(fixture.base);
+    const calls: string[] = [];
+    const agent = createAgentLoop({
+      tools: [
+        createFetchFixtureTool(calls, undefined, "stargazers_count: 19"),
+        createClockFixtureTool(calls),
+      ],
+    });
+
+    const result = await agent.run(
+      "How many stars does https://one.test have?",
+    );
+    agent.destroy();
+
+    expect(calls).toEqual(["fetch_url"]);
+    expect(fixture.inputs).toHaveLength(2);
+    expect(fixture.inputs[1]).toContain("1,238");
+    expect(result.stopReason).toBe("done");
+    expect(result.text).toBe("The repository has 19 stars.");
+  });
+
+  it("flags values that stay unsupported after the rewrite", async () => {
+    const fixture = createSessionFixture([
+      "The repository has 1,238 stars.",
+      "It still has 1,238 stars.",
+    ]);
+    createSessionMock.mockReturnValue(fixture.base);
+    const calls: string[] = [];
+    const agent = createAgentLoop({
+      tools: [
+        createFetchFixtureTool(calls, undefined, "stargazers_count: 19"),
+        createClockFixtureTool(calls),
+      ],
+    });
+
+    const result = await agent.run(
+      "How many stars does https://one.test have?",
+    );
+    agent.destroy();
+
+    expect(result.stopReason).toBe("done");
+    expect(result.text).toContain("1,238 is not supported by any tool result");
+    expect(result.text).toContain("treat it as unavailable");
+    expect(result.text).toContain("It still has 1,238 stars.");
+  });
+
+  it("keeps grounded tool-backed answers untouched", async () => {
+    const fixture = createSessionFixture(["The repository has 19 stars."]);
+    createSessionMock.mockReturnValue(fixture.base);
+    const calls: string[] = [];
+    const agent = createAgentLoop({
+      tools: [
+        createFetchFixtureTool(calls, undefined, "stargazers_count: 19"),
+        createClockFixtureTool(calls),
+      ],
+    });
+
+    const result = await agent.run(
+      "How many stars does https://one.test have?",
+    );
+    agent.destroy();
+
+    expect(fixture.inputs).toHaveLength(1);
+    expect(result.stopReason).toBe("done");
+    expect(result.text).toBe("The repository has 19 stars.");
+  });
+
   it("uses the existing step budget for the remaining-tool correction", async () => {
     const fixture = createSessionFixture(["The URLs are done."]);
     createSessionMock.mockReturnValue(fixture.base);
@@ -203,6 +334,7 @@ describe("createAgentLoop", () => {
 function createFetchFixtureTool(
   calls: string[],
   fetchedUrls?: string[],
+  pageText?: string,
 ): AgentTool<{ url: string }, { status: number; url: string; text: string }> {
   return {
     name: "fetch_url",
@@ -215,7 +347,7 @@ function createFetchFixtureTool(
     async execute({ url }) {
       calls.push("fetch_url");
       fetchedUrls?.push(url);
-      return { status: 200, url, text: `Content from ${url}` };
+      return { status: 200, url, text: pageText ?? `Content from ${url}` };
     },
   };
 }
@@ -228,6 +360,9 @@ function createClockFixtureTool(
     name: "clock_now",
     description: "Return the current time.",
     inputSchema: { type: "object" },
+    requiredCallIf(ctx) {
+      return /\btime\b/i.test(ctx.userInput);
+    },
     async execute() {
       calls.push("clock_now");
       if (failure) throw failure;

--- a/apps/site/src/features/playground/experimental/agent/loop.ts
+++ b/apps/site/src/features/playground/experimental/agent/loop.ts
@@ -30,6 +30,7 @@ import {
   PromptUnavailableError,
   type Session,
 } from "@web-ai-sdk/prompt";
+import { findUnsupportedAnswerValues } from "./answerEvidence.js";
 import { runDispatcher } from "./dispatcher.js";
 import {
   DIRECT_ANSWER_RETRY,
@@ -318,12 +319,30 @@ export function createAgentLoop(options: CreateAgentOptions = {}): Agent {
       knownUrls: knownFetchUrls,
       fetchedSources,
     };
+    // Evidence-required tool work: tools the user named explicitly, plus
+    // tools that declared (via `requiredCallIf`) that this request needs
+    // their output - e.g. `clock_now` for a current-time question asked
+    // in plain words. Both feed the same retry-and-report machinery, so
+    // a live value is never presented as factual when its supporting
+    // tool was skipped or failed.
+    const requiredToolNames = [
+      ...new Set([
+        ...explicitlyRequestedToolNames,
+        ...tools
+          .filter((tool) => tool.name !== fetchTool?.name)
+          .filter((tool) => tool.requiredCallIf?.(runCtx) === true)
+          .map((tool) => tool.name),
+      ]),
+    ];
     let autoFetchDone = false;
     // Guards the one-time "answer directly, no tools" self-heal below.
     let directRetryDone = false;
     // Guards the one-time correction when eager fetches are followed by a
     // premature final answer that skips explicitly requested tool work.
     let remainingToolRetryDone = false;
+    // Guards the one-time rewrite when the answer states values that no
+    // tool result from this run supports.
+    let unsupportedValueRetryDone = false;
     const recordFetches = (records: AgentToolCallRecord[]) => {
       for (const r of records) {
         const src = extractFetchSourceText(r);
@@ -347,14 +366,14 @@ export function createAgentLoop(options: CreateAgentOptions = {}): Agent {
       recordFetches(records);
     };
     const uncompletedRequestedTools = () =>
-      explicitlyRequestedToolNames.filter(
+      requiredToolNames.filter(
         (name) =>
           !toolCallRecords.some(
             (record) => record.name === name && !record.error,
           ),
       );
     const unattemptedRequestedTools = () =>
-      explicitlyRequestedToolNames.filter(
+      requiredToolNames.filter(
         (name) => !toolCallRecords.some((record) => record.name === name),
       );
 
@@ -545,19 +564,48 @@ export function createAgentLoop(options: CreateAgentOptions = {}): Agent {
           } else {
             answer = stripToolCode(reply) || reply.trim();
           }
+
+          // Evidence check for tool-backed runs: numeric values in the
+          // answer must appear in this run's tool records or the user's
+          // message. A fabricated figure beside real tool output reads
+          // as grounded fact (observed: a star count contradicting the
+          // fetched response), so steer ONE rewrite while a step
+          // remains; whatever stays unsupported is flagged below as
+          // unavailable rather than presented as factual.
+          const unsupportedValues =
+            toolCallRecords.length > 0
+              ? findUnsupportedAnswerValues(answer, input, toolCallRecords)
+              : [];
+          if (
+            unsupportedValues.length > 0 &&
+            !unsupportedValueRetryDone &&
+            stepIndex + 1 < maxSteps
+          ) {
+            unsupportedValueRetryDone = true;
+            if (streamedAnswerText) {
+              yield { type: "step_reset", index: stepIndex };
+            }
+            yield { type: "step_end", index: stepIndex };
+            turnInput = buildUnsupportedValueRetryTurn(unsupportedValues);
+            continue;
+          }
+
           // Flag any user URL that never fetched successfully (after the
           // auto-fetch backstop, that means a real CORS/network failure).
           const unfetched = fetchTool
             ? inputUrls.filter((u) => !fetchedOk.has(normUrl(u)))
             : [];
           finalText = maybeReportIncompleteToolRequests(
-            maybeFlagUnverifiedUrl(answer, {
-              hasFetchTool: !!fetchTool,
-              totalUrls: inputUrls.length,
-              unfetched,
-              anyTried: fetchTried.size > 0,
-            }),
-            explicitlyRequestedToolNames,
+            maybeFlagUnverifiedUrl(
+              maybeFlagUnsupportedValues(answer, unsupportedValues),
+              {
+                hasFetchTool: !!fetchTool,
+                totalUrls: inputUrls.length,
+                unfetched,
+                anyTried: fetchTried.size > 0,
+              },
+            ),
+            requiredToolNames,
             toolCallRecords,
           );
           yield {
@@ -682,7 +730,7 @@ export function createAgentLoop(options: CreateAgentOptions = {}): Agent {
         if (incomplete.length > 0) {
           finalText = maybeReportIncompleteToolRequests(
             "",
-            explicitlyRequestedToolNames,
+            requiredToolNames,
             toolCallRecords,
           );
           failure = {
@@ -1048,10 +1096,41 @@ function buildRemainingToolTurn(names: readonly string[]): string {
   const formatted = names.map((name) => `\`${name}\``).join(", ");
   const noun = names.length === 1 ? "tool has" : "tools have";
   return [
-    `The user explicitly requested ${formatted}, but the ${noun} not been called yet.`,
+    `The user's request requires ${formatted}, but the ${noun} not been called yet.`,
     "Emit ONLY a tool_code block that calls the remaining tool work now.",
     "Do not answer the user until that work has completed; if a call fails, report the failure instead of silently skipping it.",
   ].join(" ");
+}
+
+function buildUnsupportedValueRetryTurn(values: readonly string[]): string {
+  const formatted = values.map((value) => `\`${value}\``).join(", ");
+  const noun = values.length === 1 ? "a value" : "values";
+  return [
+    `Your previous answer states ${noun} that no tool result from this run supports: ${formatted}.`,
+    "Rewrite the answer now using ONLY values that appear in the tool results or in the user's message.",
+    "If a requested value has no supporting tool result, say that value is unavailable - do not guess it.",
+  ].join(" ");
+}
+
+/**
+ * Deterministic disclaimer for values that survived the rewrite without
+ * a supporting tool result: name them and mark them unavailable, so a
+ * guess is never presented as a grounded fact. The transcript's tool
+ * records identify what the run DID support.
+ */
+function maybeFlagUnsupportedValues(
+  answer: string,
+  unsupported: readonly string[],
+): string {
+  if (unsupported.length === 0) return answer;
+  const trimmed = answer.trim();
+  if (!trimmed) return answer;
+  const list = unsupported.join(", ");
+  const note =
+    unsupported.length === 1
+      ? `> ⚠ The value ${list} is not supported by any tool result from this run - treat it as unavailable.\n\n`
+      : `> ⚠ These values are not supported by any tool result from this run - treat them as unavailable: ${list}.\n\n`;
+  return `${note}${trimmed}`;
 }
 
 function maybeReportIncompleteToolRequests(

--- a/apps/site/src/features/playground/experimental/agent/tools/clock.ts
+++ b/apps/site/src/features/playground/experimental/agent/tools/clock.ts
@@ -38,6 +38,12 @@ export const clockNowTool: AgentTool<ClockInput, ClockOutput> = {
   acceptCall(_input, ctx) {
     return isCurrentTimeRequest(ctx.userInput);
   },
+  // Same predicate both ways: a current-time question is the only reason
+  // to run this tool (acceptCall), and once the user asks one, an answer
+  // without a successful run would be a guessed time (requiredCallIf).
+  requiredCallIf(ctx) {
+    return isCurrentTimeRequest(ctx.userInput);
+  },
   async execute({ timeZone }) {
     const now = new Date();
     const resolved =

--- a/apps/site/src/features/playground/experimental/agent/types.ts
+++ b/apps/site/src/features/playground/experimental/agent/types.ts
@@ -76,6 +76,16 @@ export interface AgentTool<TInput = AgentToolInput, TOutput = AgentToolOutput> {
    */
   acceptCall?(input: Record<string, unknown>, ctx: AgentRunContext): boolean;
   /**
+   * Evidence gate: return true when the user's request needs a
+   * successful call of this tool before the run may answer (e.g.
+   * `clock_now` for "what time is it"). When true and the model tries to
+   * finalize without one, the loop steers one corrective turn and then
+   * reports the missing value as unavailable instead of letting a
+   * guessed live value stand. The URL-fetching tool is exempt - eager
+   * fetching and its per-URL failure notices already cover it.
+   */
+  requiredCallIf?(ctx: AgentRunContext): boolean;
+  /**
    * End the run by returning this tool's output directly (skip the
    * post-tool synthesis model turn). Use for deterministic tools whose
    * output is already user-facing.


### PR DESCRIPTION
## Summary

Grounds the playground agent's final answers in tool results from the current run, per the acceptance criteria in #161.

**Guessed values when the supporting tool never ran or failed** (the "time without `clock_now`" case): `AgentTool` gains an optional `requiredCallIf(ctx)` evidence gate. A tool declares when the user's request needs its output - `clock_now` reuses its current-time predicate - and the loop merges those tools with the explicit-name request list. Finalizing without a successful call steers one corrective turn; a still-missing or failed call produces the deterministic incomplete-work notice instead of a guessed live value.

**Values contradicting successful tool output** (the "1,238 stars vs fetched 19" evidence): a new `answerEvidence.ts` module runs a zero-inference grounding check at finalize. Numeric values in the answer must appear in this run's tool records (inputs, outputs, error messages) or the user's message. Unsupported values steer one rewrite turn that names them; whatever survives is flagged as unavailable rather than presented as factual. The check only runs when tool records exist, exempts single-digit counts, and normalizes comma-grouped forms, so tool-free chat and derived small numbers are never second-guessed.

The transcript's per-step tool records, together with the value-naming notices, make the supporting tool result identifiable.

## Testing

- 11 new deterministic tests cover skipped, failed, contradicted, persisting-after-rewrite, and successful tool results; full site suite 74/74, `astro check` and biome clean, production build passes.
- Verified live in Chrome against the production preview: the fetch-only star-count control answers 19 (grounded, unchanged behavior); the mixed fetch + `clock_now` run from the issue's evidence reports 19 stars plus the real clock time with both tools executing; a plain-language "what time is it?" is steered through `clock_now`; a 404 fetch yields the failure notice and no guessed count.

Closes #161