### PR TITLE
feat(translator): add streaming and native operation cancellation

### DIFF
--- a/.changeset/witty-donuts-invent.md
+++ b/.changeset/witty-donuts-invent.md
@@ -1,0 +1,11 @@
+---
+"@web-ai-sdk/translator": minor
+---
+
+Add streaming and native operation cancellation to the Translator wrapper.
+
+`translate()` accepts an `onUpdate` callback and consumes the native `translateStreaming()` method when the implementation provides it. Updates deliver the cumulative translation so far, not raw deltas. Implementations without streaming deliver the one-shot result as a single final update.
+
+The caller's `AbortSignal` is now forwarded to the native translation operation. Aborting rejects with `AbortError`, keeps shared sessions reusable for other callers, and never writes partial output to the result cache.
+
+`useTranslator()` reports a new `"streaming"` status and exposes the cumulative partial output while chunks arrive.

--- a/apps/site/src/content/docs/guides/translator.mdx
+++ b/apps/site/src/content/docs/guides/translator.mdx
@@ -1,9 +1,9 @@
 ---
 title: Translator API
-description: Translate text with the built-in Translator API, pair-based session reuse, and optional result caching.
+description: Translate text with the built-in Translator API, streaming, pair-based session reuse, and optional result caching.
 ---
 
-This package wraps the built-in [Translator API](https://developer.chrome.com/docs/ai/translator-api). It adds pair-based session reuse, optional result caching, and abort cleanup. For React, see [useTranslator](/docs/react/use-translator/).
+This package wraps the built-in [Translator API](https://developer.chrome.com/docs/ai/translator-api). It adds streaming, pair-based session reuse, optional result caching, and abort cleanup. For React, see [useTranslator](/docs/react/use-translator/).
 
 Before shipping, review the [Production checklist](/docs/production-checklist/) for task-relevant input, safe rendering, progress, reversible changes, and cache freshness.
 
@@ -34,6 +34,7 @@ interface TranslateOptions {
   monitor?: (m: TranslatorMonitor) => void;
   cache?: "session" | "local" | { get, set };
   cacheKey?: string;
+  onUpdate?: (text: string) => void;
   signal?: AbortSignal;
 }
 ```
@@ -48,7 +49,8 @@ interface TranslateOptions {
 | `monitor` | `(m) => void` | Observe the first-call model download. |
 | `cache` | `"session" \| "local" \| { get, set }` | Opt-in result cache. |
 | `cacheKey` | `string` | Override the default cache key (JSON array string of normalized `[sourceLanguage, targetLanguage, input]`). |
-| `signal` | `AbortSignal` | Abort signal. |
+| `onUpdate` | `(text: string) => void` | Streaming update callback. Receives the cumulative buffer, not deltas. |
+| `signal` | `AbortSignal` | Abort signal. Forwarded to the native translation operation. |
 
 </div>
 
@@ -60,6 +62,23 @@ interface TranslateResult {
   cached: boolean;
 }
 ```
+
+## Streaming
+
+Pass `onUpdate` to receive partial output while the model translates. The wrapper consumes the native [`translateStreaming()`](https://developer.mozilla.org/en-US/docs/Web/API/Translator/translateStreaming) method when the implementation provides it.
+
+```ts
+const result = await translate({
+  input: "Hello, world.",
+  sourceLanguage: "en",
+  targetLanguage: "pt",
+  onUpdate: (text) => console.log("partial", text),
+});
+```
+
+`onUpdate` receives the cumulative translation so far, not raw deltas. Each update contains every previous update as a prefix, so you can render it directly. On implementations without `translateStreaming()`, the wrapper runs the one-shot method and delivers the result as a single final update.
+
+Only the final completed output enters the result cache. Partial, aborted, or failed output is never cached.
 
 ## How it works
 
@@ -98,7 +117,7 @@ The default cache key is `JSON.stringify([source, target, trimmedInput])`, so id
 
 ## Aborting
 
-`AbortSignal` is supported. Aborting mid-call throws `AbortError`; the cache is not written for aborted runs.
+`AbortSignal` is supported. The wrapper forwards it to the native [`translate()` and `translateStreaming()` operations](https://webmachinelearning.github.io/translation-api/), so browsers that honor the operation signal stop native work promptly. Aborting mid-call throws `AbortError`; the cache is not written for aborted runs. Aborting one call keeps the shared warm session usable for other callers.
 
 ```ts
 const controller = new AbortController();

--- a/apps/site/src/content/docs/packages/translator.md
+++ b/apps/site/src/content/docs/packages/translator.md
@@ -1,6 +1,6 @@
 ---
 title: "@web-ai-sdk/translator"
-description: "This package wraps the Web's Built-in Translator API. It caches sessions by language pair and supports optional result caching and abort signals."
+description: "This package wraps the Web's Built-in Translator API. It caches sessions by language pair and supports streaming, optional result caching, and abort signals."
 editUrl: https://github.com/obetomuniz/web-ai-sdk/edit/main/packages/translator/README.md
 ---
 
@@ -8,7 +8,7 @@ editUrl: https://github.com/obetomuniz/web-ai-sdk/edit/main/packages/translator/
 This page is synced from [`packages/translator/README.md`](https://github.com/obetomuniz/web-ai-sdk/blob/main/packages/translator/README.md) by `pnpm --filter @web-ai-sdk-apps/site docs:sync`. Edits should go to the README.
 :::
 
-This package wraps the Web's Built-in [Translator API](https://developer.chrome.com/docs/ai/translator-api). It caches sessions by language pair and supports optional result caching and abort signals.
+This package wraps the Web's Built-in [Translator API](https://developer.chrome.com/docs/ai/translator-api). It caches sessions by language pair and supports streaming, optional result caching, and abort signals.
 
 
 ## Status
@@ -43,6 +43,23 @@ console.log(result.cached); // result: false
 
 `result.output` is the translated text, or `null` when the input is empty or when `sourceLanguage` and `targetLanguage` normalize to the same base language.
 
+## Streaming
+
+Pass `onUpdate` to receive partial output while the model translates. The wrapper consumes the native [`translateStreaming()`](https://developer.mozilla.org/en-US/docs/Web/API/Translator/translateStreaming) method when the implementation provides it.
+
+```ts
+const result = await translate({
+  input: "Hello, world.",
+  sourceLanguage: "en",
+  targetLanguage: "pt",
+  onUpdate: (text) => console.log("partial", text),
+});
+```
+
+`onUpdate` receives the cumulative translation so far, not raw deltas. Each update contains every previous update as a prefix. On implementations without `translateStreaming()`, the wrapper runs the one-shot method and delivers the result as a single final update.
+
+Only the final completed output enters the result cache. Partial, aborted, or failed output is never cached.
+
 ## React
 
 ```tsx
@@ -68,7 +85,7 @@ export function ReadInEnglish({
 }
 ```
 
-State machine: `idle | loading | done | unavailable`. The hook auto-runs when `input` is non-empty and the language pair differs, and it re-runs whenever its options change.
+State machine: `idle | loading | streaming | done | unavailable`. The hook auto-runs when `input` is non-empty and the language pair differs, and it re-runs whenever its options change. `status` becomes `"streaming"` after the first partial update, and `output` grows as chunks land.
 
 ## API
 
@@ -84,7 +101,8 @@ interface TranslateOptions {
   monitor?: (m: TranslatorMonitor) => void;
   cache?: "session" | "local" | { get, set };
   cacheKey?: string;
-  signal?: AbortSignal;
+  onUpdate?: (text: string) => void; // cumulative buffer, not deltas
+  signal?: AbortSignal; // forwarded to the native operation
 }
 
 interface TranslateResult {
@@ -139,7 +157,7 @@ This package intentionally translates strings only. DOM walking, text extraction
 
 The vanilla `translate()` throws `TranslatorUnavailableError` when the API is missing or reports `availability: "unavailable"`. The React hook absorbs this and returns `status: "unavailable"` instead.
 
-`AbortSignal` is supported on both surfaces. The result cache is not written for aborted runs.
+`AbortSignal` is supported on both surfaces, and the wrapper forwards it to the native [`translate()` and `translateStreaming()` operations](https://webmachinelearning.github.io/translation-api/). Browsers that honor the operation signal stop native work promptly. Aborting rejects with an `AbortError` and keeps the shared session usable for other callers. The result cache is not written for aborted runs.
 
 ## License
 

--- a/apps/site/src/content/docs/react/use-translator.mdx
+++ b/apps/site/src/content/docs/react/use-translator.mdx
@@ -37,17 +37,20 @@ The hook auto-runs whenever any input changes. Empty input or matching source/ta
 ## State machine
 
 ```
-idle ───► loading ───► done
-                         │
-unavailable ◄── (no API) │
-                         ▼
-              input empty ─► idle
+idle ───► loading ───► streaming ───► done
+                                        │
+unavailable ◄── (no API)                │
+                                        ▼
+                             input empty ─► idle
 ```
 
 - **`idle`**: hook mounted, input empty or `sourceLanguage === targetLanguage`.
 - **`loading`**: translation in flight (~1-3s cold for a new language pair, sub-second warm).
+- **`streaming`**: partial output arriving. `output` holds the cumulative translation and grows as chunks land.
 - **`done`**: translation complete. `output` is the translated text or `null`.
 - **`unavailable`**: API missing. Render nothing or a fallback.
+
+Implementations without native `translateStreaming()` skip `"streaming"` and move straight to `"done"`.
 
 ## Caching
 
@@ -64,7 +67,7 @@ const { output, fromCache } = useTranslator({
 
 ## Aborting
 
-The hook aborts any in-flight call when inputs change or the component unmounts. You don't need to manage `AbortController` directly.
+The hook aborts any in-flight call when inputs change or the component unmounts. You don't need to manage `AbortController` directly. The abort signal is forwarded to the native operation, so browsers that honor it stop translating promptly. Stale partial output from a cancelled run is never published.
 
 
 ## Reference
@@ -72,9 +75,9 @@ The hook aborts any in-flight call when inputs change or the component unmounts.
 ```ts
 import type { UseTranslatorOptions, UseTranslatorReturn, TranslatorStatus } from "@web-ai-sdk/translator/react";
 
-type TranslatorStatus = "idle" | "loading" | "done" | "unavailable";
+type TranslatorStatus = "idle" | "loading" | "streaming" | "done" | "unavailable";
 
-interface UseTranslatorOptions extends Omit<TranslateOptions, "signal"> {
+interface UseTranslatorOptions extends Omit<TranslateOptions, "onUpdate" | "signal"> {
   enabled?: boolean;       // default: true
   // Inherited from TranslateOptions:
   input: string;

--- a/apps/site/src/features/docs/components/TranslatorDemo.tsx
+++ b/apps/site/src/features/docs/components/TranslatorDemo.tsx
@@ -49,7 +49,8 @@ export const TranslatorDemo = ({
                 ? "Translating…"
                 : status === "idle"
                   ? "Waiting for input"
-                  : `Translation (${targetLanguage})`}
+                  : `Translation (${targetLanguage})`}{" "}
+            {status === "streaming" && <em>(streaming…)</em>}
           </span>
         </header>
         <p className="demo-response__body">

--- a/apps/site/src/features/home/components/PackageExplorer.tsx
+++ b/apps/site/src/features/home/components/PackageExplorer.tsx
@@ -103,8 +103,8 @@ const PACKAGE_ROWS: PackageInfo[] = [
     tag: "Translate a string between a source and target language.",
     bullets: [
       ["Pair caching.", "Sessions are cached by source and target language."],
+      ["Streaming first.", "Receive cumulative text as the model responds."],
       ["String input.", "The SDK does not walk or mutate the DOM."],
-      ["Typed fallback.", "Unavailable environments return a state or error."],
     ],
   },
   {

--- a/apps/site/src/features/home/components/TranslatorDemo.tsx
+++ b/apps/site/src/features/home/components/TranslatorDemo.tsx
@@ -71,6 +71,11 @@ export const TranslatorDemo = () => {
         targetLanguage: to,
         monitor,
         signal: ac.signal,
+        onUpdate: (chunk) => {
+          if (ac.signal.aborted) return;
+          setOutput(chunk);
+          update(chunk);
+        },
       });
       if (ac.signal.aborted) return;
       if (result.output) {

--- a/packages/translator/README.md
+++ b/packages/translator/README.md
@@ -1,6 +1,6 @@
 # @web-ai-sdk/translator
 
-This package wraps the Web's Built-in [Translator API](https://developer.chrome.com/docs/ai/translator-api). It caches sessions by language pair and supports optional result caching and abort signals.
+This package wraps the Web's Built-in [Translator API](https://developer.chrome.com/docs/ai/translator-api). It caches sessions by language pair and supports streaming, optional result caching, and abort signals.
 
 **Docs:** <https://web-ai-sdk.dev/docs/guides/translator/> · **React:** [`useTranslator`](https://web-ai-sdk.dev/docs/react/use-translator/) · **Production:** [Checklist](https://web-ai-sdk.dev/docs/production-checklist/)
 
@@ -36,6 +36,23 @@ console.log(result.cached); // result: false
 
 `result.output` is the translated text, or `null` when the input is empty or when `sourceLanguage` and `targetLanguage` normalize to the same base language.
 
+## Streaming
+
+Pass `onUpdate` to receive partial output while the model translates. The wrapper consumes the native [`translateStreaming()`](https://developer.mozilla.org/en-US/docs/Web/API/Translator/translateStreaming) method when the implementation provides it.
+
+```ts
+const result = await translate({
+  input: "Hello, world.",
+  sourceLanguage: "en",
+  targetLanguage: "pt",
+  onUpdate: (text) => console.log("partial", text),
+});
+```
+
+`onUpdate` receives the cumulative translation so far, not raw deltas. Each update contains every previous update as a prefix. On implementations without `translateStreaming()`, the wrapper runs the one-shot method and delivers the result as a single final update.
+
+Only the final completed output enters the result cache. Partial, aborted, or failed output is never cached.
+
 ## React
 
 ```tsx
@@ -61,7 +78,7 @@ export function ReadInEnglish({
 }
 ```
 
-State machine: `idle | loading | done | unavailable`. The hook auto-runs when `input` is non-empty and the language pair differs, and it re-runs whenever its options change.
+State machine: `idle | loading | streaming | done | unavailable`. The hook auto-runs when `input` is non-empty and the language pair differs, and it re-runs whenever its options change. `status` becomes `"streaming"` after the first partial update, and `output` grows as chunks land.
 
 ## API
 
@@ -77,7 +94,8 @@ interface TranslateOptions {
   monitor?: (m: TranslatorMonitor) => void;
   cache?: "session" | "local" | { get, set };
   cacheKey?: string;
-  signal?: AbortSignal;
+  onUpdate?: (text: string) => void; // cumulative buffer, not deltas
+  signal?: AbortSignal; // forwarded to the native operation
 }
 
 interface TranslateResult {
@@ -132,7 +150,7 @@ This package intentionally translates strings only. DOM walking, text extraction
 
 The vanilla `translate()` throws `TranslatorUnavailableError` when the API is missing or reports `availability: "unavailable"`. The React hook absorbs this and returns `status: "unavailable"` instead.
 
-`AbortSignal` is supported on both surfaces. The result cache is not written for aborted runs.
+`AbortSignal` is supported on both surfaces, and the wrapper forwards it to the native [`translate()` and `translateStreaming()` operations](https://webmachinelearning.github.io/translation-api/). Browsers that honor the operation signal stop native work promptly. Aborting rejects with an `AbortError` and keeps the shared session usable for other callers. The result cache is not written for aborted runs.
 
 ## License
 

--- a/packages/translator/src/api.ts
+++ b/packages/translator/src/api.ts
@@ -6,8 +6,20 @@
  * Spec: https://developer.chrome.com/docs/ai/translator-api
  */
 
+export interface TranslatorTranslateOptions {
+  /** Standard `AbortSignal` forwarded to the native operation. */
+  signal?: AbortSignal;
+}
+
 export interface TranslatorInstance {
-  translate(text: string): Promise<string>;
+  translate(
+    text: string,
+    options?: TranslatorTranslateOptions,
+  ): Promise<string>;
+  translateStreaming?(
+    text: string,
+    options?: TranslatorTranslateOptions,
+  ): ReadableStream<string>;
   destroy?(): void;
 }
 

--- a/packages/translator/src/index.test.ts
+++ b/packages/translator/src/index.test.ts
@@ -514,4 +514,319 @@ describe("translate", () => {
     ).rejects.toMatchObject({ name: "AbortError" });
     expect(cache.set).not.toHaveBeenCalled();
   });
+
+  it("does not touch the native API when the signal is already aborted", async () => {
+    const { api } = installFakeTranslator();
+    const controller = new AbortController();
+    controller.abort();
+    await expect(
+      translate({
+        input: "Olá",
+        sourceLanguage: "pt",
+        targetLanguage: "en",
+        signal: controller.signal,
+      }),
+    ).rejects.toMatchObject({ name: "AbortError" });
+    expect(api.availability).not.toHaveBeenCalled();
+    expect(api.create).not.toHaveBeenCalled();
+  });
+
+  it("forwards the caller's signal to the native one-shot translate", async () => {
+    const { sessions } = installFakeTranslator();
+    const controller = new AbortController();
+    await translate({
+      input: "Olá",
+      sourceLanguage: "pt",
+      targetLanguage: "en",
+      signal: controller.signal,
+    });
+    expect(sessions[0]?.translate).toHaveBeenCalledWith("Olá", {
+      signal: controller.signal,
+    });
+  });
+});
+
+interface StreamingSession {
+  translate: ReturnType<typeof vi.fn>;
+  translateStreaming: ReturnType<typeof vi.fn>;
+  destroy: ReturnType<typeof vi.fn>;
+}
+
+const streamOf = (chunks: string[]): ReadableStream<string> =>
+  new ReadableStream<string>({
+    start(controller) {
+      for (const c of chunks) controller.enqueue(c);
+      controller.close();
+    },
+  });
+
+const installStreamingTranslator = (
+  makeStream: (text: string) => ReadableStream<string>,
+  oneShot: (text: string) => Promise<string> = async (text) => `[t]${text}`,
+) => {
+  const session: StreamingSession = {
+    translate: vi.fn(oneShot),
+    translateStreaming: vi.fn((text: string) => makeStream(text)),
+    destroy: vi.fn(),
+  };
+  const api = {
+    availability: vi.fn(async () => "available" as const),
+    create: vi.fn(async () => session),
+  };
+  (globalThis as { Translator?: typeof api }).Translator = api;
+  return { api, session };
+};
+
+describe("translate streaming", () => {
+  it("reports cumulative updates for incremental (delta) chunks", async () => {
+    const { session } = installStreamingTranslator(() =>
+      streamOf(["Olá", " mundo"]),
+    );
+    const updates: string[] = [];
+    const result = await translate({
+      input: "Hello world",
+      sourceLanguage: "en",
+      targetLanguage: "pt",
+      onUpdate: (text) => updates.push(text),
+    });
+    expect(updates).toEqual(["Olá", "Olá mundo"]);
+    expect(result).toEqual({ output: "Olá mundo", cached: false });
+    expect(session.translate).not.toHaveBeenCalled();
+  });
+
+  it("handles cumulative chunk sequences without duplicating text", async () => {
+    installStreamingTranslator(() => streamOf(["Olá", "Olá mundo"]));
+    const updates: string[] = [];
+    const result = await translate({
+      input: "Hello world",
+      sourceLanguage: "en",
+      targetLanguage: "pt",
+      onUpdate: (text) => updates.push(text),
+    });
+    expect(updates).toEqual(["Olá", "Olá mundo"]);
+    expect(result.output).toBe("Olá mundo");
+  });
+
+  it("forwards the caller's signal to translateStreaming", async () => {
+    const { session } = installStreamingTranslator(() => streamOf(["Olá"]));
+    const controller = new AbortController();
+    await translate({
+      input: "Hello",
+      sourceLanguage: "en",
+      targetLanguage: "pt",
+      signal: controller.signal,
+      onUpdate: () => {},
+    });
+    expect(session.translateStreaming).toHaveBeenCalledWith("Hello", {
+      signal: controller.signal,
+    });
+  });
+
+  it("stays one-shot when onUpdate is not supplied", async () => {
+    const { session } = installStreamingTranslator(() => streamOf(["x"]));
+    const result = await translate({
+      input: "Hello",
+      sourceLanguage: "en",
+      targetLanguage: "pt",
+    });
+    expect(session.translateStreaming).not.toHaveBeenCalled();
+    expect(result.output).toBe("[t]Hello");
+  });
+
+  it("falls back to one-shot with a single final update when streaming is missing", async () => {
+    installFakeTranslator(async () => "Olá");
+    const updates: string[] = [];
+    const result = await translate({
+      input: "Hello",
+      sourceLanguage: "en",
+      targetLanguage: "pt",
+      onUpdate: (text) => updates.push(text),
+    });
+    expect(updates).toEqual(["Olá"]);
+    expect(result).toEqual({ output: "Olá", cached: false });
+  });
+
+  it("caches only the final streamed output", async () => {
+    installStreamingTranslator(() => streamOf(["Olá", " mundo"]));
+    const cache = { get: vi.fn(() => null), set: vi.fn() };
+    await translate({
+      input: "Hello world",
+      sourceLanguage: "en",
+      targetLanguage: "pt",
+      cache,
+      cacheKey: "k",
+      onUpdate: () => {},
+    });
+    expect(cache.set).toHaveBeenCalledTimes(1);
+    expect(cache.set).toHaveBeenCalledWith("k", "Olá mundo");
+  });
+
+  it("serves a cached result without opening a stream", async () => {
+    const { api, session } = installStreamingTranslator(() => streamOf(["x"]));
+    const cache = inMemoryCache();
+    cache.set("k", "From cache.");
+    const updates: string[] = [];
+    const result = await translate({
+      input: "Hello",
+      sourceLanguage: "en",
+      targetLanguage: "pt",
+      cache,
+      cacheKey: "k",
+      onUpdate: (text) => updates.push(text),
+    });
+    expect(result).toEqual({ output: "From cache.", cached: true });
+    expect(updates).toEqual([]);
+    expect(api.create).not.toHaveBeenCalled();
+    expect(session.translateStreaming).not.toHaveBeenCalled();
+  });
+
+  it("resolves an empty stream to null output without caching", async () => {
+    installStreamingTranslator(() => streamOf([]));
+    const cache = { get: vi.fn(() => null), set: vi.fn() };
+    const updates: string[] = [];
+    const result = await translate({
+      input: "Hello",
+      sourceLanguage: "en",
+      targetLanguage: "pt",
+      cache,
+      onUpdate: (text) => updates.push(text),
+    });
+    expect(result).toEqual({ output: null, cached: false });
+    expect(updates).toEqual([]);
+    expect(cache.set).not.toHaveBeenCalled();
+  });
+
+  it("propagates stream failure without writing the cache", async () => {
+    installStreamingTranslator(
+      () =>
+        new ReadableStream<string>({
+          start(controller) {
+            controller.enqueue("Olá");
+            controller.error(new Error("stream failed"));
+          },
+        }),
+    );
+    const cache = { get: vi.fn(() => null), set: vi.fn() };
+    await expect(
+      translate({
+        input: "Hello",
+        sourceLanguage: "en",
+        targetLanguage: "pt",
+        cache,
+        onUpdate: () => {},
+      }),
+    ).rejects.toThrow("stream failed");
+    expect(cache.set).not.toHaveBeenCalled();
+  });
+});
+
+describe("translate abort timings", () => {
+  it("rejects while waiting for a shared session without destroying it", async () => {
+    const session = {
+      translate: vi.fn(async (text: string) => `[t]${text}`),
+      destroy: vi.fn(),
+    };
+    let resolveCreate: (s: typeof session) => void = () => {};
+    const api = {
+      availability: vi.fn(async () => "available" as const),
+      create: vi.fn(
+        () =>
+          new Promise<typeof session>((resolve) => {
+            resolveCreate = resolve;
+          }),
+      ),
+    };
+    (globalThis as { Translator?: typeof api }).Translator = api;
+
+    const controller = new AbortController();
+    const pending = translate({
+      input: "Olá",
+      sourceLanguage: "pt",
+      targetLanguage: "en",
+      signal: controller.signal,
+    });
+    await vi.waitFor(() => expect(api.create).toHaveBeenCalledTimes(1));
+    controller.abort();
+    await expect(pending).rejects.toMatchObject({ name: "AbortError" });
+
+    resolveCreate(session);
+    const second = await translate({
+      input: "Olá",
+      sourceLanguage: "pt",
+      targetLanguage: "en",
+    });
+    expect(second.output).toBe("[t]Olá");
+    expect(api.create).toHaveBeenCalledTimes(1);
+    expect(session.destroy).not.toHaveBeenCalled();
+  });
+
+  it("rejects promptly during a hanging one-shot translation and keeps the session reusable", async () => {
+    let call = 0;
+    const { api, sessions } = installFakeTranslator(
+      (text) =>
+        new Promise<string>((resolve) => {
+          call += 1;
+          if (call > 1) resolve(`[t]${text}`);
+        }),
+    );
+    const cache = { get: vi.fn(() => null), set: vi.fn() };
+    const controller = new AbortController();
+    const pending = translate({
+      input: "Olá",
+      sourceLanguage: "pt",
+      targetLanguage: "en",
+      cache,
+      signal: controller.signal,
+    });
+    await vi.waitFor(() => expect(call).toBe(1));
+    controller.abort();
+    await expect(pending).rejects.toMatchObject({ name: "AbortError" });
+    expect(cache.set).not.toHaveBeenCalled();
+    expect(sessions[0]?.destroy).not.toHaveBeenCalled();
+
+    const second = await translate({
+      input: "Olá",
+      sourceLanguage: "pt",
+      targetLanguage: "en",
+    });
+    expect(second.output).toBe("[t]Olá");
+    expect(api.create).toHaveBeenCalledTimes(1);
+  });
+
+  it("rejects mid-stream, stops updates, cancels the stream, and skips the cache", async () => {
+    let cancelled = false;
+    let emit: (chunk: string) => void = () => {};
+    const { session } = installStreamingTranslator(
+      () =>
+        new ReadableStream<string>({
+          start(controller) {
+            emit = (chunk) => controller.enqueue(chunk);
+          },
+          cancel() {
+            cancelled = true;
+          },
+        }),
+    );
+    const cache = { get: vi.fn(() => null), set: vi.fn() };
+    const updates: string[] = [];
+    const controller = new AbortController();
+    const pending = translate({
+      input: "Hello",
+      sourceLanguage: "en",
+      targetLanguage: "pt",
+      cache,
+      signal: controller.signal,
+      onUpdate: (text) => updates.push(text),
+    });
+    await vi.waitFor(() =>
+      expect(session.translateStreaming).toHaveBeenCalled(),
+    );
+    emit("Olá");
+    await vi.waitFor(() => expect(updates).toEqual(["Olá"]));
+    controller.abort();
+    await expect(pending).rejects.toMatchObject({ name: "AbortError" });
+    expect(updates).toEqual(["Olá"]);
+    expect(cache.set).not.toHaveBeenCalled();
+    await vi.waitFor(() => expect(cancelled).toBe(true));
+  });
 });

--- a/packages/translator/src/index.ts
+++ b/packages/translator/src/index.ts
@@ -22,6 +22,7 @@ import {
   type TranslatorCreateOptions,
   type TranslatorInstance,
   type TranslatorMonitor,
+  type TranslatorTranslateOptions,
 } from "./api.js";
 import {
   type CacheOption,
@@ -40,6 +41,7 @@ export type {
   TranslatorCreateOptions,
   TranslatorInstance,
   TranslatorMonitor,
+  TranslatorTranslateOptions,
 };
 export {
   checkAvailability,
@@ -69,7 +71,14 @@ export interface TranslateOptions {
   cache?: CacheOption;
   /** Cache key. Default: JSON array string of `[sourceLanguage, targetLanguage, input]`. */
   cacheKey?: string;
-  /** Abort signal. */
+  /**
+   * Streaming update callback (cumulative buffer, monotonically growing).
+   * Receives the **cumulative** translation so far, not raw deltas. On
+   * implementations without `translateStreaming()`, the one-shot result is
+   * delivered as a single final update.
+   */
+  onUpdate?: (text: string) => void;
+  /** Abort signal. Forwarded to the native translation operation. */
   signal?: AbortSignal;
 }
 
@@ -95,10 +104,41 @@ class TranslateAbortError extends Error {
 }
 
 /**
+ * Await `promise`, but reject with an `AbortError` as soon as `signal`
+ * aborts. Used around shared-session waits and stream reads so one caller's
+ * abort rejects promptly without destroying work another caller may reuse.
+ */
+const raceAbort = <T>(
+  promise: Promise<T>,
+  signal: AbortSignal | undefined,
+): Promise<T> => {
+  if (!signal) return promise;
+  if (signal.aborted) return Promise.reject(new TranslateAbortError());
+  return new Promise<T>((resolve, reject) => {
+    const onAbort = () => reject(new TranslateAbortError());
+    signal.addEventListener("abort", onAbort, { once: true });
+    promise.then(
+      (value) => {
+        signal.removeEventListener("abort", onAbort);
+        resolve(value);
+      },
+      (err: unknown) => {
+        signal.removeEventListener("abort", onAbort);
+        reject(err);
+      },
+    );
+  });
+};
+
+/**
  * Translate a string from `sourceLanguage` to `targetLanguage`. Returns
  * `{ output: null }` when the input is empty or when source and target
  * match. Throws `TranslatorUnavailableError` when the API isn't present in
  * the environment or reports `availability: "unavailable"`.
+ *
+ * With `onUpdate`, consumes `translateStreaming()` when the implementation
+ * provides it and reports the cumulative translation after each chunk. The
+ * caller's `signal` is forwarded to the native operation on both paths.
  */
 export const translate = async (
   options: TranslateOptions,
@@ -109,6 +149,7 @@ export const translate = async (
       "Translator API is not available in this environment.",
     );
   }
+  if (options.signal?.aborted) throw new TranslateAbortError();
 
   const text = options.input.trim();
   if (!text) return { output: null, cached: false };
@@ -146,7 +187,9 @@ export const translate = async (
 
   let session: TranslatorInstance;
   try {
-    session = await sessionPromise;
+    // raceAbort rejects only this caller; the cached session promise stays
+    // untouched so other callers can still reuse it.
+    session = await raceAbort(sessionPromise, options.signal);
   } catch (err) {
     if (err instanceof TranslateAbortError) throw err;
     const message = (err as Error)?.message ?? String(err);
@@ -154,9 +197,41 @@ export const translate = async (
       `Translator.create() failed: ${message}`,
     );
   }
-  if (options.signal?.aborted) throw new TranslateAbortError();
 
-  const output = await session.translate(text);
+  const taskOptions: TranslatorTranslateOptions = {
+    ...(options.signal ? { signal: options.signal } : {}),
+  };
+
+  // Browser implementations may emit delta or cumulative chunks. Detect the
+  // shape per chunk and merge accordingly.
+  const mergeChunk = (buffer: string, chunk: string): string =>
+    chunk.startsWith(buffer) ? chunk : buffer + chunk;
+
+  let output: string;
+  if (options.onUpdate && typeof session.translateStreaming === "function") {
+    const reader = session.translateStreaming(text, taskOptions).getReader();
+    let buffer = "";
+    try {
+      for (;;) {
+        const { done, value } = await raceAbort(reader.read(), options.signal);
+        if (done) break;
+        buffer = mergeChunk(buffer, value);
+        options.onUpdate(buffer);
+      }
+    } catch (err) {
+      // Stop native work; the reader may already be errored, so best-effort.
+      reader.cancel().catch(() => {});
+      throw err;
+    }
+    output = buffer;
+  } else {
+    output = await raceAbort(
+      session.translate(text, taskOptions),
+      options.signal,
+    );
+    // No native streaming: deliver the one-shot result as one final update.
+    if (output) options.onUpdate?.(output);
+  }
   if (options.signal?.aborted) throw new TranslateAbortError();
 
   if (output && cache) cache.set(cacheKey, output);

--- a/packages/translator/src/react/index.test.tsx
+++ b/packages/translator/src/react/index.test.tsx
@@ -254,6 +254,25 @@ describe("useTranslator", () => {
     expect(result.current.output).toBe("fresh-B");
   });
 
+  it("never commits 'streaming' when the implementation lacks translateStreaming", async () => {
+    // The one-shot fallback delivers a single final update; React batches that
+    // update with the promise resolution, so status must go loading → done.
+    installFakeTranslator();
+    const statuses: string[] = [];
+    const { result } = renderHook(() => {
+      const r = useTranslator({
+        input: "Olá",
+        sourceLanguage: "pt",
+        targetLanguage: "en",
+      });
+      statuses.push(r.status);
+      return r;
+    });
+    await waitFor(() => expect(result.current.status).toBe("done"));
+    expect(result.current.output).toBe("[t]Olá");
+    expect(statuses).not.toContain("streaming");
+  });
+
   it("cancels the stream on unmount", async () => {
     const { streams } = installStreamingTranslator();
     const { unmount } = renderHook(() =>

--- a/packages/translator/src/react/index.test.tsx
+++ b/packages/translator/src/react/index.test.tsx
@@ -157,4 +157,118 @@ describe("useTranslator", () => {
     await waitFor(() => expect(result.current.status).toBe("done"));
     expect(result.current.output).toBe("fresh-B");
   });
+
+  interface FakeStream {
+    input: string;
+    emit(chunk: string): void;
+    close(): void;
+    cancelled: boolean;
+  }
+
+  const installStreamingTranslator = () => {
+    const streams: FakeStream[] = [];
+    const translateStreaming = vi.fn((input: string) => {
+      const handle: FakeStream = {
+        input,
+        emit: () => {},
+        close: () => {},
+        cancelled: false,
+      };
+      const stream = new ReadableStream<string>({
+        start(controller) {
+          handle.emit = (chunk) => controller.enqueue(chunk);
+          handle.close = () => controller.close();
+        },
+        cancel() {
+          handle.cancelled = true;
+        },
+      });
+      streams.push(handle);
+      return stream;
+    });
+    const api = {
+      availability: vi.fn(async () => "available" as const),
+      create: vi.fn(async () => ({
+        translate: vi.fn(async (text: string) => `[t]${text}`),
+        translateStreaming,
+      })),
+    };
+    (globalThis as { Translator?: typeof api }).Translator = api;
+    return { api, streams };
+  };
+
+  it("reports 'streaming' with cumulative output, then 'done'", async () => {
+    const { streams } = installStreamingTranslator();
+    const { result } = renderHook(() =>
+      useTranslator({
+        input: "Hello world",
+        sourceLanguage: "en",
+        targetLanguage: "pt",
+      }),
+    );
+    await waitFor(() => expect(streams).toHaveLength(1));
+    expect(result.current.status).toBe("loading");
+
+    await act(async () => {
+      streams[0]?.emit("Olá");
+    });
+    await waitFor(() => expect(result.current.status).toBe("streaming"));
+    expect(result.current.output).toBe("Olá");
+
+    await act(async () => {
+      streams[0]?.emit(" mundo");
+    });
+    await waitFor(() => expect(result.current.output).toBe("Olá mundo"));
+    expect(result.current.status).toBe("streaming");
+
+    await act(async () => {
+      streams[0]?.close();
+    });
+    await waitFor(() => expect(result.current.status).toBe("done"));
+    expect(result.current.output).toBe("Olá mundo");
+    expect(result.current.error).toBeNull();
+  });
+
+  it("cancels an in-flight stream when input changes and suppresses stale updates", async () => {
+    const { streams } = installStreamingTranslator();
+    const { result, rerender } = renderHook(
+      ({ input }: { input: string }) =>
+        useTranslator({ input, sourceLanguage: "en", targetLanguage: "pt" }),
+      { initialProps: { input: "A" } },
+    );
+    await waitFor(() => expect(streams).toHaveLength(1));
+    await act(async () => {
+      streams[0]?.emit("partial-A");
+    });
+    await waitFor(() => expect(result.current.output).toBe("partial-A"));
+
+    rerender({ input: "B" });
+    await waitFor(() => expect(streams).toHaveLength(2));
+    await waitFor(() => expect(streams[0]?.cancelled).toBe(true));
+
+    await act(async () => {
+      streams[1]?.emit("fresh-B");
+      streams[1]?.close();
+    });
+    await waitFor(() => expect(result.current.status).toBe("done"));
+    expect(result.current.output).toBe("fresh-B");
+  });
+
+  it("cancels the stream on unmount", async () => {
+    const { streams } = installStreamingTranslator();
+    const { unmount } = renderHook(() =>
+      useTranslator({
+        input: "Hello",
+        sourceLanguage: "en",
+        targetLanguage: "pt",
+      }),
+    );
+    await waitFor(() => expect(streams).toHaveLength(1));
+    await act(async () => {
+      streams[0]?.emit("Olá");
+    });
+
+    unmount();
+    await waitFor(() => expect(streams[0]?.cancelled).toBe(true));
+  });
 });

--- a/packages/translator/src/react/index.ts
+++ b/packages/translator/src/react/index.ts
@@ -6,16 +6,22 @@ import {
   translate,
 } from "../index.js";
 
-export type TranslatorStatus = "idle" | "loading" | "done" | "unavailable";
+export type TranslatorStatus =
+  | "idle"
+  | "loading"
+  | "streaming"
+  | "done"
+  | "unavailable";
 
-export interface UseTranslatorOptions extends Omit<TranslateOptions, "signal"> {
+export interface UseTranslatorOptions
+  extends Omit<TranslateOptions, "onUpdate" | "signal"> {
   /** Whether to automatically run on mount / option change. Default: `true`. */
   enabled?: boolean;
 }
 
 export interface UseTranslatorReturn {
   status: TranslatorStatus;
-  /** Translated text, or `null` while idle / unavailable. */
+  /** Translated text (grows during streaming), or `null` while idle / unavailable. */
   output: string | null;
   error: Error | null;
   /** Whether the result was loaded from cache (no model call). */
@@ -71,6 +77,11 @@ export const useTranslator = (
       cache,
       cacheKey,
       signal: controller.signal,
+      onUpdate: (chunk) => {
+        if (controller.signal.aborted) return;
+        setOutput(chunk);
+        setStatus("streaming");
+      },
     })
       .then((result) => {
         if (controller.signal.aborted) return;


### PR DESCRIPTION
Closes #158.

## What

- **Native adapter** (`api.ts`): `TranslatorTranslateOptions` (`signal`), `translate(input, options?)`, and optional `translateStreaming?(input, options?)` matching the public `ReadableStream<string>` shape.
- **Core `translate()`**: new `onUpdate` callback delivers the cumulative translation (delta and cumulative native chunk sequences merge without duplication). The caller's `AbortSignal` is forwarded to the native operation on both paths. A `raceAbort` helper makes aborts reject promptly with `AbortError` at every timing, including while waiting on a shared session, without destroying or evicting a session other callers may reuse. Implementations without `translateStreaming()` fall back to one-shot and deliver the result as a single final update. Only successful final output enters the result cache.
- **React `useTranslator()`**: `TranslatorStatus` gains `"streaming"`; the hook exposes cumulative partial output, aborts on option changes/unmount, and never publishes stale updates.
- **Site**: home `TranslatorDemo` wires `onUpdate` (live stream stats), the package explorer translator card gains the "Streaming first" bullet, and the docs demo shows a "(streaming…)" label.
- **Docs**: package README (synced to the packages page), translator guide, and `useTranslator` page describe cumulative updates, native cancellation, fallback behavior, and cache interaction from public sources.
- **Changeset**: minor bump for `@web-ai-sdk/translator`.

## Verification

- 19 new tests (52 total in the package) cover exact native arguments, incremental and cumulative streams, stream failure, fallback, cache interaction, all abort timings, session non-poisoning, and React streaming state, rerender/unmount cancellation, and stale-update suppression.
- `pnpm gate` passes (lint, docs check, build, typecheck, all workspace tests).
- Verified end-to-end in Chrome against the real Translator API: cumulative monotonic updates with the final output equal to the last update; mid-stream abort rejects with `AbortError` after exactly one update; the shared session stays reusable after an abort.

## Notes

- The changeset file was written by hand in the generated format because `pnpm changeset` is interactive; `changeset status` validates it (minor bump, `@web-ai-sdk/all` patched via internal dependency).
