### PR TITLE
fix(deps): bump fast-uri override to 3.1.5

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,7 +9,7 @@ overrides:
   postcss@^8.0.0: 8.5.19
   js-yaml@^4.0.0: 4.3.0
   read-yaml-file>js-yaml: 3.15.0
-  fast-uri@^3.0.0: 3.1.4
+  fast-uri@^3.0.0: 3.1.5
   svgo@^4.0.0: 4.0.2
   esbuild: 0.28.1
 
@@ -2549,8 +2549,8 @@ packages:
   fast-string-width@3.0.2:
     resolution: {integrity: sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==}
 
-  fast-uri@3.1.4:
-    resolution: {integrity: sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==}
+  fast-uri@3.1.5:
+    resolution: {integrity: sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==}
 
   fast-wrap-ansi@0.2.2:
     resolution: {integrity: sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q==}
@@ -5930,7 +5930,7 @@ snapshots:
   ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.4
+      fast-uri: 3.1.5
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -6413,7 +6413,7 @@ snapshots:
     dependencies:
       fast-string-truncated-width: 3.0.3
 
-  fast-uri@3.1.4: {}
+  fast-uri@3.1.5: {}
 
   fast-wrap-ansi@0.2.2:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -7,7 +7,7 @@ overrides:
   postcss@^8.0.0: "8.5.19"
   js-yaml@^4.0.0: "4.3.0"
   read-yaml-file>js-yaml: 3.15.0
-  fast-uri@^3.0.0: "3.1.4"
+  fast-uri@^3.0.0: "3.1.5"
   svgo@^4.0.0: "4.0.2"
   esbuild: 0.28.1
 


### PR DESCRIPTION
## Summary

Fixes Dependabot alert [#67](https://github.com/obetomuniz/web-ai-sdk/security/dependabot/67) — `fast-uri` host confusion via backslash authority introducer ([GHSA-7p8r-x3mc-p8w7](https://github.com/advisories/GHSA-7p8r-x3mc-p8w7) / CVE-2026-18446, high severity).

`fast-uri` is a transitive dependency of `ajv` and was pinned to the vulnerable 3.1.4 by the existing pnpm override. This bumps the override in `pnpm-workspace.yaml` to 3.1.5, the patched release for the 3.x line, and regenerates the lockfile — it now resolves only `fast-uri@3.1.5`.

## Verification

- `pnpm install` resolves cleanly
- `pnpm build:packages` succeeds
- `pnpm test` — 64 tests pass (15 files in `apps/site`, 1 in `packages/sdk`)