### PR TITLE
feat(lifecycle): add intent-driven prepare and release leases

### DIFF
--- a/.changeset/lucky-lions-prepare.md
+++ b/.changeset/lucky-lions-prepare.md
@@ -1,0 +1,12 @@
+---
+"@web-ai-sdk/prompt": minor
+"@web-ai-sdk/summarizer": minor
+"@web-ai-sdk/translator": minor
+"@web-ai-sdk/detector": minor
+"@web-ai-sdk/writer": minor
+"@web-ai-sdk/rewriter": minor
+"@web-ai-sdk/proofreader": minor
+"@web-ai-sdk/all": minor
+---
+
+Add intent-driven prepare and release leases to every task package. New prepareLanguageModel / prepareSummarizer / prepareTranslator / prepareLanguageDetector / prepareWriter / prepareRewriter / prepareProofreader start native session creation when user intent is clear and return a lease ({ ready, release }). The matching operation reuses the prepared session without a second create. Leases pin sessions against LRU eviction; release is idempotent and the final release destroys the session once no other lease or in-flight call uses it. Session cache controls are now uniform: prompt gains configureLanguageModelCache / clearLanguageModelSession(s), and summarizer now exports its configureSummarizerCache / clearSummarizerSession(s). Clearing detaches leased sessions and destroys them when the last pin drops. Breaking: writer, rewriter, and proofreader no longer export getOrCreateWriter / getOrCreateRewriter / getOrCreateProofreader, getWriterApi / getRewriterApi / getProofreaderApi, defaultCacheKey, or resolveCache; use the prepare lease and cache controls instead.

--- a/apps/site/astro.config.mjs
+++ b/apps/site/astro.config.mjs
@@ -174,7 +174,6 @@ export default defineConfig({
         {
           label: "Guides",
           items: [
-            { label: "Meta-package", slug: "docs/guides/meta-package" },
             { label: "Prompt", slug: "docs/guides/prompt" },
             { label: "WebMCP", slug: "docs/guides/webmcp" },
             { label: "Summarizer", slug: "docs/guides/summarizer" },
@@ -183,6 +182,11 @@ export default defineConfig({
             { label: "Writer", slug: "docs/guides/writer" },
             { label: "Rewriter", slug: "docs/guides/rewriter" },
             { label: "Proofreader", slug: "docs/guides/proofreader" },
+            { label: "Meta-package", slug: "docs/guides/meta-package" },
+            {
+              label: "Session lifecycle",
+              slug: "docs/guides/session-lifecycle",
+            },
           ],
         },
         {

--- a/apps/site/src/content/docs/guides/detector.mdx
+++ b/apps/site/src/content/docs/guides/detector.mdx
@@ -7,6 +7,8 @@ This package wraps the built-in [Language Detector API](https://developer.chrome
 
 Before shipping, review the [Production checklist](/docs/production-checklist/) for intent-driven preparation, task-relevant input, progress, and cache freshness.
 
+Use `prepareLanguageDetector` to warm a session on user intent and release it when the feature closes. See the [Session lifecycle guide](/docs/guides/session-lifecycle/).
+
 ## Usage
 
 ```ts

--- a/apps/site/src/content/docs/guides/prompt.mdx
+++ b/apps/site/src/content/docs/guides/prompt.mdx
@@ -3,19 +3,13 @@ title: Prompt API
 description: Use ask() for one-shot prompts or createSession() for multi-turn conversations with the built-in LanguageModel API.
 ---
 
-import { PromptDemo } from "../../../features/docs/components/PromptDemo.tsx";
-
 This package wraps the built-in [Prompt API](https://developer.chrome.com/docs/ai/prompt-api) (`LanguageModel`). Use `ask()` for one-shot prompts. Use `createSession()` for multi-turn conversations.
 
 The package [README](https://github.com/obetomuniz/web-ai-sdk/tree/main/packages/prompt#readme) covers installation and the API reference. This page explains the vanilla API. For React, see [usePrompt](/docs/react/use-prompt/) and [useSession](/docs/react/use-session/).
 
 Before shipping, review the [Production checklist](/docs/production-checklist/) for intent-driven preparation, session isolation, input selection, safe rendering, progress, reversible edits, and cache freshness.
 
-## Live demo
-
-<PromptDemo client:only="react" />
-
-Type a question and click "Ask". Tokens stream in as the model produces them. The demo runs on this page through the React adapter; the vanilla `ask()` below has the same behavior.
+Use `prepareLanguageModel` to warm a session on user intent and release it when the feature closes. See the [Session lifecycle guide](/docs/guides/session-lifecycle/).
 
 ## One-shot: `ask()`
 

--- a/apps/site/src/content/docs/guides/proofreader.mdx
+++ b/apps/site/src/content/docs/guides/proofreader.mdx
@@ -7,6 +7,8 @@ This package wraps the built-in [Proofreader API](https://developer.chrome.com/d
 
 Before shipping, review the [Production checklist](/docs/production-checklist/) for preserving originals, Accept/Reject/Undo flows, safe rendering, and cache freshness.
 
+Use `prepareProofreader` to warm a session on user intent and release it when the feature closes. See the [Session lifecycle guide](/docs/guides/session-lifecycle/).
+
 ## Usage
 
 ```ts

--- a/apps/site/src/content/docs/guides/rewriter.mdx
+++ b/apps/site/src/content/docs/guides/rewriter.mdx
@@ -7,6 +7,8 @@ This package wraps the built-in [Rewriter API](https://developer.chrome.com/docs
 
 Before shipping, review the [Production checklist](/docs/production-checklist/) for safe rendering, progress, Accept/Reject/Undo flows, and cache freshness.
 
+Use `prepareRewriter` to warm a session on user intent and release it when the feature closes. See the [Session lifecycle guide](/docs/guides/session-lifecycle/).
+
 ## Usage
 
 ```ts

--- a/apps/site/src/content/docs/guides/session-lifecycle.mdx
+++ b/apps/site/src/content/docs/guides/session-lifecycle.mdx
@@ -1,0 +1,98 @@
+---
+title: Session lifecycle
+description: Prepare sessions on user intent, reuse them across calls, and release them when a feature closes.
+---
+
+Built-in AI sessions run on-device models. Creating a session can take seconds and can trigger a model download. Every live session holds model memory until the tab closes.
+
+Chrome's [Built-in AI dos and don'ts](https://developer.chrome.com/docs/ai/built-in-ai-dos-donts) turns that cost into three rules: prepare the model at a reasonable time, reuse sessions instead of re-creating them, and destroy sessions you no longer need. This guide shows how the SDK covers each rule and which parts your application controls.
+
+## What you get without any code
+
+Every task package keeps a bounded LRU cache of warm native sessions, keyed by the session-affecting options. Calls with the same configuration reuse the warm session and skip the cold start. `ask()` in Prompt goes further: it keeps one warm base session and runs each call on a fresh clone, so unrelated prompts never share context.
+
+This covers the reuse rule by default. The remaining two rules need one signal only your application has: user intent.
+
+## Prepare on user intent
+
+The SDK cannot know when a user is about to use an AI feature. Your application does: a panel opens, a field gains focus, a pointer hovers the action. `prepare<Noun>(options)` starts native session creation at that moment, before any input exists.
+
+```ts
+import { prepareSummarizer, summarize } from "@web-ai-sdk/summarizer";
+
+// The user opened the summary panel: warm the session now.
+const summarizerModel = prepareSummarizer({ language: "en", type: "key-points" });
+
+// The user clicked: the matching call reuses the prepared session.
+const result = await summarize({
+  input: articleText,
+  language: "en",
+  type: "key-points",
+});
+
+// The user closed the panel: destroy the session and free its memory.
+summarizerModel.release();
+```
+
+Reuse happens when the prepare options match the session-affecting options of the later call. A mismatch is never an error; the call creates its own session lazily, as it would without preparation.
+
+Do not prepare on module import or page load. Preparation can download a model and holds memory, so it needs real intent behind it.
+
+## Release when the feature closes
+
+`prepare` returns a lease: `{ ready: Promise<void>; release(): void }`. Call `release()` when the user leaves the feature. The session is destroyed as soon as it is safe, which frees the model memory instead of waiting for the tab to close.
+
+`release()` is idempotent, so wiring it to more than one teardown path is safe:
+
+```ts
+const translatorModel = prepareTranslator({ sourceLanguage: "en", targetLanguage: "es" });
+
+closeButton.addEventListener("click", () => {
+  translationPanel.hidden = true;
+  translatorModel.release();
+});
+```
+
+Safety rules the SDK enforces for you:
+
+- Multiple prepares for one configuration share one native session. Each caller holds its own lease.
+- Releasing one lease never destroys a session that another lease or an in-flight call still uses. The final release destroys it exactly once.
+- Releasing before creation settles destroys the session after creation succeeds.
+- Sessions with active leases never fall out of the LRU cache.
+- Preparing one configuration cannot release or reuse another configuration.
+
+## Observe readiness and failure
+
+`ready` resolves when the native session exists. Use it to switch UI states: enable the action, or hide a "downloading model" hint. `prepare` never throws synchronously; a missing API or a failed creation rejects `ready` with the package's typed unavailability error.
+
+```ts
+const translatorModel = prepareTranslator({ sourceLanguage: "en", targetLanguage: "fr" });
+
+translatorModel.ready
+  .then(() => showReadyState())
+  .catch(() => showFallback());
+```
+
+Failure is a real path. Chrome refuses some downloads without a user gesture, storage can be full, and a device can be unsupported. A failed preparation leaves the cache, so a later prepare retries cleanly.
+
+## Function names per package
+
+| Package | Prepare | Lease type |
+| --- | --- | --- |
+| [`@web-ai-sdk/prompt`](/docs/packages/prompt/) | `prepareLanguageModel` | `LanguageModelLease` |
+| [`@web-ai-sdk/summarizer`](/docs/packages/summarizer/) | `prepareSummarizer` | `SummarizerLease` |
+| [`@web-ai-sdk/translator`](/docs/packages/translator/) | `prepareTranslator` | `TranslatorLease` |
+| [`@web-ai-sdk/detector`](/docs/packages/detector/) | `prepareLanguageDetector` | `LanguageDetectorLease` |
+| [`@web-ai-sdk/writer`](/docs/packages/writer/) | `prepareWriter` | `WriterLease` |
+| [`@web-ai-sdk/rewriter`](/docs/packages/rewriter/) | `prepareRewriter` | `RewriterLease` |
+| [`@web-ai-sdk/proofreader`](/docs/packages/proofreader/) | `prepareProofreader` | `ProofreaderLease` |
+
+Each package README documents its session-affecting option fields. Prompt's `createSession()` stays outside this system; it always creates a caller-owned session you destroy yourself.
+
+Every package also exports `configure<Noun>Cache({ max })`, `clear<Noun>Sessions()`, and `clear<Noun>Session(options)` for direct cache control. Clearing detaches sessions pinned by a lease or an in-flight call and destroys them when the last pin drops.
+
+## References
+
+- [Built-in AI dos and don'ts](https://developer.chrome.com/docs/ai/built-in-ai-dos-donts): the Chrome guidance this design follows.
+- [Built-in AI APIs overview](https://developer.chrome.com/docs/ai/built-in): availability and download behavior per API.
+- [Production checklist](/docs/production-checklist/): the wider ownership split between the SDK and your application.

--- a/apps/site/src/content/docs/guides/session-lifecycle.mdx
+++ b/apps/site/src/content/docs/guides/session-lifecycle.mdx
@@ -75,6 +75,48 @@ translatorModel.ready
 
 Failure is a real path. Chrome refuses some downloads without a user gesture, storage can be full, and a device can be unsupported. A failed preparation leaves the cache, so a later prepare retries cleanly.
 
+## With the React hooks
+
+The React hooks need no extra wiring. Hold a lease in an effect; the hook's matching call reuses the warm session, and unmount releases it.
+
+`usePrompt` runs on demand, which makes the payoff visible: the model warms while the panel is open, so the first `ask()` starts instantly.
+
+```tsx
+import { useEffect } from "react";
+import { prepareLanguageModel } from "@web-ai-sdk/prompt";
+import { usePrompt } from "@web-ai-sdk/prompt/react";
+
+const SYSTEM_PROMPT = "Answer in one short paragraph.";
+
+export function AnswerPanel() {
+  // Hold a lease for the panel's lifetime. Unmount releases the base session.
+  useEffect(() => {
+    const languageModel = prepareLanguageModel({ systemPrompt: SYSTEM_PROMPT });
+    return languageModel.release;
+  }, []);
+
+  // ask() clones from the warm base; no second create.
+  const { status, output, ask } = usePrompt({ systemPrompt: SYSTEM_PROMPT });
+
+  if (status === "unavailable") return null;
+  return (
+    <section>
+      <button
+        onClick={() => ask("Why is the sky blue?")}
+        disabled={status === "loading" || status === "streaming"}
+      >
+        Ask
+      </button>
+      {output ? <p>{output}</p> : null}
+    </section>
+  );
+}
+```
+
+Leases are shared, so you can also prepare earlier, for example in the hover handler of the button that mounts this panel. Releasing that earlier lease cannot destroy the session while the panel still holds its own.
+
+`useSession` is the one exception: it wraps `createSession()`, which creates a caller-owned session outside the warm cache. It manages its own lifecycle, so `prepareLanguageModel` does not warm it.
+
 ## Function names per package
 
 | Package | Prepare | Lease type |

--- a/apps/site/src/content/docs/guides/summarizer.mdx
+++ b/apps/site/src/content/docs/guides/summarizer.mdx
@@ -7,6 +7,8 @@ This package wraps the built-in [Summarizer API](https://developer.chrome.com/do
 
 Before shipping, review the [Production checklist](/docs/production-checklist/) for task-relevant text extraction, safe rendering, progress, user control, and cache freshness.
 
+Use `prepareSummarizer` to warm a session on user intent and release it when the feature closes. See the [Session lifecycle guide](/docs/guides/session-lifecycle/).
+
 ## Usage
 
 ```ts

--- a/apps/site/src/content/docs/guides/translator.mdx
+++ b/apps/site/src/content/docs/guides/translator.mdx
@@ -7,6 +7,8 @@ This package wraps the built-in [Translator API](https://developer.chrome.com/do
 
 Before shipping, review the [Production checklist](/docs/production-checklist/) for task-relevant input, safe rendering, progress, reversible changes, and cache freshness.
 
+Use `prepareTranslator` to warm a session on user intent and release it when the feature closes. See the [Session lifecycle guide](/docs/guides/session-lifecycle/).
+
 ## Usage
 
 ```ts

--- a/apps/site/src/content/docs/guides/writer.mdx
+++ b/apps/site/src/content/docs/guides/writer.mdx
@@ -7,6 +7,8 @@ This package wraps the built-in [Writer API](https://developer.chrome.com/docs/a
 
 Before shipping, review the [Production checklist](/docs/production-checklist/) for safe rendering, progress, reversible suggestions, user control, and cache freshness.
 
+Use `prepareWriter` to warm a session on user intent and release it when the feature closes. See the [Session lifecycle guide](/docs/guides/session-lifecycle/).
+
 ## Usage
 
 ```ts

--- a/apps/site/src/content/docs/packages/all.md
+++ b/apps/site/src/content/docs/packages/all.md
@@ -65,7 +65,7 @@ await summarizer.summarize({ language: "en", input: document.body.innerText });
 const tools = await webmcp.getTools();
 ```
 
-The root entry namespaces each scoped package because several exports (e.g. `checkAvailability`, `isAvailable`, `defaultCacheKey`) appear in more than one package and would collide on a flat re-export.
+The root entry namespaces each scoped package because several exports (e.g. `checkAvailability`, `isAvailable`, `DEFAULT_CACHE_TTL_MS`) appear in more than one package and would collide on a flat re-export.
 
 ## Why a meta-package?
 

--- a/apps/site/src/content/docs/packages/detector.md
+++ b/apps/site/src/content/docs/packages/detector.md
@@ -91,9 +91,30 @@ Feature-detect helper.
 
 Forwards to `LanguageDetector.availability()`. Returns `null` if the global is missing or the call throws.
 
-### Lower-level helpers (advanced)
+### Prepare and release
 
-`getLanguageDetectorApi`, `getOrCreateLanguageDetector`, `defaultCacheKey`; exported so you can compose your own pipeline (e.g. share a session across multiple call sites, or roll your own retry).
+`prepareLanguageDetector(options)` starts native session creation when user intent is clear, before the input exists. It returns a `LanguageDetectorLease`: `{ ready: Promise<void>; release(): void }`. Options are optional; the zero-config call prepares the default detector.
+
+```ts
+import { prepareLanguageDetector, detect } from "@web-ai-sdk/detector";
+
+// User focuses the input field: warm the session now.
+const detectorModel = prepareLanguageDetector();
+
+// The matching call reuses the prepared session; no second create.
+const result = await detect({ input: "Olá, mundo" });
+
+// User dismisses the feature: let the session go.
+detectorModel.release();
+```
+
+- `prepareLanguageDetector` never throws synchronously. Unavailability and creation failure reject `ready` with `DetectorUnavailableError`.
+- `release()` is idempotent. The final release destroys the session once no other lease or in-flight call uses it.
+- Releasing before creation settles destroys the session after creation succeeds.
+- Failed creation evicts the entry, so a later prepare retries.
+- Sessions with active leases never evict from the LRU cache.
+
+Reuse requires the same session-affecting options as the `detect` call. For this package those are `expectedInputLanguages` and `monitor` (`PrepareLanguageDetectorOptions`).
 
 ## Caching
 
@@ -102,7 +123,7 @@ Two layers, same as the other packages:
 - **Session cache** (internal, in-memory, always on): a `Map<stringifiedOptions, LanguageDetector>` so consecutive calls with the same `expectedInputLanguages` shape reuse the warm session. Cold-start is fast on this model (~100-300ms) but warm is still sub-50ms.
 - **Result cache** (opt-in): pass a `cache` (anything matching `{ get, set }`) to memoize the full sorted list by trimmed text. Omit it for a fresh model call every time.
 
-Use `configureLanguageDetectorCache({ max })` to bound the warm session cache (default `8`). `clearLanguageDetectorSessions()` drops every warm session, and `clearLanguageDetectorSession({ expectedInputLanguages })` drops one matching detector configuration.
+Use `configureLanguageDetectorCache({ max })` to bound the warm session cache (default `8`). `clearLanguageDetectorSessions()` drops every warm session, and `clearLanguageDetectorSession({ expectedInputLanguages })` drops one matching detector configuration. Clearing detaches sessions pinned by a lease or an in-flight call and destroys them when the last pin drops.
 
 ```ts
 // Off by default; every call hits the model.

--- a/apps/site/src/content/docs/packages/detector.md
+++ b/apps/site/src/content/docs/packages/detector.md
@@ -114,7 +114,7 @@ detectorModel.release();
 - Failed creation evicts the entry, so a later prepare retries.
 - Sessions with active leases never evict from the LRU cache.
 
-Reuse requires the same session-affecting options as the `detect` call. For this package those are `expectedInputLanguages` and `monitor` (`PrepareLanguageDetectorOptions`).
+Reuse requires the same session-affecting options as the `detect` call. For this package that is `expectedInputLanguages` (`PrepareLanguageDetectorOptions`). `monitor` observes creation only and never affects reuse.
 
 ## Caching
 

--- a/apps/site/src/content/docs/packages/prompt.md
+++ b/apps/site/src/content/docs/packages/prompt.md
@@ -532,7 +532,7 @@ Semantics:
 - Failed creation evicts the entry, so a later prepare retries.
 - Leased bases never evict from the LRU cache.
 
-Reuse requires the same session-affecting options as `ask()`. `PrepareLanguageModelOptions` covers `systemPrompt`, `samplingMode`, `temperature`, `topK`, `language`, `supportedLanguages`, `expectedInputs`, `expectedOutputs`, `tools`, and `monitor`.
+Reuse requires the same session-affecting options as `ask()`. `PrepareLanguageModelOptions` covers `systemPrompt`, `samplingMode`, `temperature`, `topK`, `language`, `supportedLanguages`, `expectedInputs`, `expectedOutputs`, and `tools`. `monitor` observes creation only and never affects reuse.
 
 `createSession()` is unaffected. It always creates a caller-owned session outside this cache.
 

--- a/apps/site/src/content/docs/packages/prompt.md
+++ b/apps/site/src/content/docs/packages/prompt.md
@@ -484,8 +484,10 @@ Forwards to `LanguageModel.availability()`. Returns `null` if the global is miss
 
 Two layers, same as `@web-ai-sdk/summarizer`:
 
-- **Session cache** (internal, in-memory, on for `ask()`): a bounded LRU of base instances keyed by serialized creation options. When supported, each call uses an isolated clone. `createSession()` bypasses this cache.
+- **Session cache** (in-memory, on for `ask()`): a bounded LRU of base instances keyed by serialized creation options. When supported, each call uses an isolated clone. `prepareLanguageModel()` warms this cache. `createSession()` bypasses it.
 - **Result cache** (opt-in): pass a `cache` (anything matching `{ get, set }`) to memoize final responses by `(input, systemPrompt, samplingMode / temperature / topK)`. Omit it for a fresh model call every time.
+
+The session cache has public controls. `configureLanguageModelCache({ max })` bounds the base-session LRU; the default is 8. `clearLanguageModelSessions()` drops every cached base. `clearLanguageModelSession(createOptions)` drops one. Clearing detaches bases pinned by a lease or an in-flight `ask()` and destroys them when the last pin drops.
 
 ```ts
 // Off by default; every call hits the model.
@@ -500,6 +502,39 @@ ask({ input: "hi", cache: "local" });
 // Or roll your own.
 ask({ input: "hi", cache: myMap, cacheKey: "greeting" });
 ```
+
+### Prepare and release
+
+`prepareLanguageModel(options)` starts base-session creation when user intent is clear, before the first `ask()` input exists. It returns a `LanguageModelLease`: `{ ready: Promise<void>; release(): void }`.
+
+```ts
+import { ask, prepareLanguageModel } from "@web-ai-sdk/prompt";
+
+const systemPrompt = "You are a concise support assistant.";
+
+// User opened the panel; intent is clear, no input yet.
+const languageModel = prepareLanguageModel({ systemPrompt });
+
+// The matching call clones from the warm base with no second create().
+const result = await ask({ input, systemPrompt });
+
+// User dismissed the panel without asking anything.
+languageModel.release();
+```
+
+Semantics:
+
+- `prepareLanguageModel()` never throws synchronously.
+- Unavailability and creation failure reject `ready` with `PromptUnavailableError`.
+- Invalid sampling options reject `ready` with the same error `ask()` would throw.
+- `release()` is idempotent. The final release destroys the base once no other lease or in-flight `ask()` uses it.
+- Releasing before creation settles destroys the base after creation succeeds.
+- Failed creation evicts the entry, so a later prepare retries.
+- Leased bases never evict from the LRU cache.
+
+Reuse requires the same session-affecting options as `ask()`. `PrepareLanguageModelOptions` covers `systemPrompt`, `samplingMode`, `temperature`, `topK`, `language`, `supportedLanguages`, `expectedInputs`, `expectedOutputs`, `tools`, and `monitor`.
+
+`createSession()` is unaffected. It always creates a caller-owned session outside this cache.
 
 ### Expiry and refresh
 

--- a/apps/site/src/content/docs/packages/proofreader.md
+++ b/apps/site/src/content/docs/packages/proofreader.md
@@ -150,7 +150,7 @@ proofreaderModel.release();
 - Failed creation evicts the entry, so a later prepare retries.
 - Sessions with active leases never evict from the LRU cache.
 
-Reuse requires the same session-affecting options as the `proofread` call. `PrepareProofreaderOptions` covers `expectedInputLanguages` and `monitor`.
+Reuse requires the same session-affecting options as the `proofread` call. `PrepareProofreaderOptions` covers `expectedInputLanguages`. `monitor` observes creation only and never affects reuse.
 
 ## Result caching
 

--- a/apps/site/src/content/docs/packages/proofreader.md
+++ b/apps/site/src/content/docs/packages/proofreader.md
@@ -115,7 +115,42 @@ Drop every cached proofreader session. Sessions live for the tab lifetime by def
 
 ### Session cache controls
 
-`configureProofreaderCache({ max })` bounds the internal warm `Proofreader` session cache (default `8`). `clearProofreaderSessions()` drops every warm session, and `clearProofreaderSession({ expectedInputLanguages })` drops one matching proofreader configuration.
+`configureProofreaderCache({ max })` bounds the internal warm `Proofreader` session cache (default `8`). `clearProofreaderSessions()` drops every warm session, and `clearProofreaderSession({ expectedInputLanguages })` drops one matching proofreader configuration. Clearing detaches sessions pinned by a lease or an in-flight call and destroys them when the last pin drops.
+
+### Prepare and release
+
+`prepareProofreader(options?)` starts native session creation when user intent is clear, before the input exists. It returns a `ProofreaderLease`:
+
+```ts
+interface ProofreaderLease {
+  ready: Promise<void>; // settles when native creation settles
+  release(): void;      // idempotent
+}
+```
+
+```ts
+import { prepareProofreader, proofread } from "@web-ai-sdk/proofreader";
+
+// User focused the editor; warm the session now.
+const proofreaderModel = prepareProofreader({ expectedInputLanguages: ["en"] });
+
+// The matching call reuses the prepared session with no second create.
+const result = await proofread({
+  input: "I seen him yesterday at the store.",
+  expectedInputLanguages: ["en"],
+});
+
+// User left the editor.
+proofreaderModel.release();
+```
+
+- `prepareProofreader` never throws synchronously. Unavailability and creation failure reject `ready` with `ProofreaderUnavailableError`.
+- `release()` is idempotent. The final release destroys the session once no other lease or in-flight call uses it.
+- Releasing before creation settles destroys the session after creation succeeds.
+- Failed creation evicts the entry, so a later prepare retries.
+- Sessions with active leases never evict from the LRU cache.
+
+Reuse requires the same session-affecting options as the `proofread` call. `PrepareProofreaderOptions` covers `expectedInputLanguages` and `monitor`.
 
 ## Result caching
 

--- a/apps/site/src/content/docs/packages/rewriter.md
+++ b/apps/site/src/content/docs/packages/rewriter.md
@@ -143,7 +143,7 @@ rewriterModel.release();
 - Failed creation evicts the entry, so a later prepare retries.
 - Sessions with active leases never evict from the LRU cache.
 
-Reuse requires the same session-affecting options as the `rewrite` call. `PrepareRewriterOptions` covers `language`, `supportedLanguages`, `tone`, `format`, `length`, `sharedContext`, and `monitor`.
+Reuse requires the same session-affecting options as the `rewrite` call. `PrepareRewriterOptions` covers `language`, `supportedLanguages`, `tone`, `format`, `length`, and `sharedContext`. `monitor` observes creation only and never affects reuse.
 
 ## Result caching
 

--- a/apps/site/src/content/docs/packages/rewriter.md
+++ b/apps/site/src/content/docs/packages/rewriter.md
@@ -108,7 +108,42 @@ import {
 } from "@web-ai-sdk/rewriter";
 ```
 
-The internal session cache is LRU-bounded (default 8). Evicted sessions have their `destroy()` invoked when present.
+The internal session cache is LRU-bounded (default 8). Evicted sessions have their `destroy()` invoked when present. Clearing detaches sessions pinned by a lease or an in-flight call and destroys them when the last pin drops.
+
+### Prepare and release
+
+`prepareRewriter(options)` starts native session creation when user intent is clear, before the input exists. It returns a `RewriterLease`:
+
+```ts
+interface RewriterLease {
+  ready: Promise<void>; // settles when native creation settles
+  release(): void;      // idempotent
+}
+```
+
+```ts
+import { prepareRewriter, rewrite } from "@web-ai-sdk/rewriter";
+
+// User opened the polish panel; warm the session now.
+const rewriterModel = prepareRewriter({ tone: "more-formal" });
+
+// The matching call reuses the prepared session with no second create.
+const result = await rewrite({
+  input: "hey, can u send me that doc when u get a sec? thx",
+  tone: "more-formal",
+});
+
+// User dismissed the panel.
+rewriterModel.release();
+```
+
+- `prepareRewriter` never throws synchronously. Unavailability and creation failure reject `ready` with `RewriterUnavailableError`.
+- `release()` is idempotent. The final release destroys the session once no other lease or in-flight call uses it.
+- Releasing before creation settles destroys the session after creation succeeds.
+- Failed creation evicts the entry, so a later prepare retries.
+- Sessions with active leases never evict from the LRU cache.
+
+Reuse requires the same session-affecting options as the `rewrite` call. `PrepareRewriterOptions` covers `language`, `supportedLanguages`, `tone`, `format`, `length`, `sharedContext`, and `monitor`.
 
 ## Result caching
 

--- a/apps/site/src/content/docs/packages/summarizer.md
+++ b/apps/site/src/content/docs/packages/summarizer.md
@@ -108,6 +108,39 @@ Feature-detect helper.
 
 Forwards to the spec's `availability()` call. Returns `null` if the global is missing or the call throws.
 
+### Prepare and release
+
+`prepareSummarizer(options)` starts native session creation when user intent is clear, before the input exists. It returns a `SummarizerLease`: `{ ready: Promise<void>; release(): void }`.
+
+```ts
+import { prepareSummarizer, summarize } from "@web-ai-sdk/summarizer";
+
+// User hovers the "Summarize" button: warm the session now.
+const summarizerModel = prepareSummarizer({ language: "en", type: "key-points" });
+
+// The matching call reuses the prepared session; no second create.
+const result = await summarize({
+  input: articleText,
+  language: "en",
+  type: "key-points",
+});
+
+// User dismisses the feature: let the session go.
+summarizerModel.release();
+```
+
+- `prepareSummarizer` never throws synchronously. Unavailability and creation failure reject `ready` with `SummarizerUnavailableError`.
+- `release()` is idempotent. The final release destroys the session once no other lease or in-flight call uses it.
+- Releasing before creation settles destroys the session after creation succeeds.
+- Failed creation evicts the entry, so a later prepare retries.
+- Sessions with active leases never evict from the LRU cache.
+
+Reuse requires the same session-affecting options as the `summarize` call. For this package those are `language`, `supportedLanguages`, `type`, `length`, `format`, `preference`, `sharedContext`, and `monitor` (`PrepareSummarizerOptions`).
+
+### Session cache controls
+
+`configureSummarizerCache({ max })` bounds the internal warm `Summarizer` session cache (default `8`). `clearSummarizerSessions()` drops every warm session, and `clearSummarizerSession(createOptions)` drops one matching configuration. Clearing detaches sessions pinned by a lease or an in-flight call and destroys them when the last pin drops.
+
 ## Performance preference
 
 `preference` is a hint about the speed/quality tradeoff the browser makes when picking the underlying model:
@@ -149,7 +182,7 @@ summarize({ language: "en", input: text, cache: "local", cacheTtl: 5 * 60 * 1000
 summarize({ language: "en", input: text, cache: "local", cacheRefresh: true });
 ```
 
-The internal session cache (warm `Summarizer` instances) is separate and always on, so same-config calls skip the ~1-3s cold start within a tab.
+The internal session cache (warm `Summarizer` instances) is separate and always on, so same-config calls skip the ~1-3s cold start within a tab. Bound or clear it via the Session cache controls above.
 
 ## Output normalization
 

--- a/apps/site/src/content/docs/packages/summarizer.md
+++ b/apps/site/src/content/docs/packages/summarizer.md
@@ -135,7 +135,7 @@ summarizerModel.release();
 - Failed creation evicts the entry, so a later prepare retries.
 - Sessions with active leases never evict from the LRU cache.
 
-Reuse requires the same session-affecting options as the `summarize` call. For this package those are `language`, `supportedLanguages`, `type`, `length`, `format`, `preference`, `sharedContext`, and `monitor` (`PrepareSummarizerOptions`).
+Reuse requires the same session-affecting options as the `summarize` call. For this package those are `language`, `supportedLanguages`, `type`, `length`, `format`, `preference`, and `sharedContext` (`PrepareSummarizerOptions`). `monitor` observes creation only and never affects reuse.
 
 ### Session cache controls
 

--- a/apps/site/src/content/docs/packages/translator.md
+++ b/apps/site/src/content/docs/packages/translator.md
@@ -152,7 +152,7 @@ translatorModel.release();
 - Failed creation evicts the entry, so a later prepare retries.
 - Sessions with active leases never evict from the LRU cache.
 
-Reuse requires the same session-affecting options as the `translate` call. For this package those are `sourceLanguage`, `targetLanguage`, and `monitor` (`PrepareTranslatorOptions`).
+Reuse requires the same session-affecting options as the `translate` call. For this package those are `sourceLanguage` and `targetLanguage` (`PrepareTranslatorOptions`). `monitor` observes creation only and never affects reuse.
 
 ## Caching
 

--- a/apps/site/src/content/docs/packages/translator.md
+++ b/apps/site/src/content/docs/packages/translator.md
@@ -123,11 +123,36 @@ Forwards to the spec's `availability()` call. Returns `null` if the global is mi
 
 ### Session cache controls
 
-`configureTranslatorCache({ max })` bounds the internal warm `Translator` session cache (default `8`). `clearTranslatorSessions()` drops every warm session, and `clearTranslatorSession({ sourceLanguage, targetLanguage })` drops one matching language pair.
+`configureTranslatorCache({ max })` bounds the internal warm `Translator` session cache (default `8`). `clearTranslatorSessions()` drops every warm session, and `clearTranslatorSession({ sourceLanguage, targetLanguage })` drops one matching language pair. Clearing detaches sessions pinned by a lease or an in-flight call and destroys them when the last pin drops.
 
-### Lower-level helpers (advanced)
+### Prepare and release
 
-`getTranslatorApi`, `getOrCreateTranslator`, and `defaultCacheKey` are exported so you can compose your own pipeline or cache policy.
+`prepareTranslator(options)` starts native session creation when user intent is clear, before the input exists. It returns a `TranslatorLease`: `{ ready: Promise<void>; release(): void }`.
+
+```ts
+import { prepareTranslator, translate } from "@web-ai-sdk/translator";
+
+// User opens the translation menu: warm the session now.
+const translatorModel = prepareTranslator({ sourceLanguage: "en", targetLanguage: "pt" });
+
+// The matching call reuses the prepared session; no second create.
+const result = await translate({
+  input: "Hello, world.",
+  sourceLanguage: "en",
+  targetLanguage: "pt",
+});
+
+// User dismisses the feature: let the session go.
+translatorModel.release();
+```
+
+- `prepareTranslator` never throws synchronously. Unavailability and creation failure reject `ready` with `TranslatorUnavailableError`.
+- `release()` is idempotent. The final release destroys the session once no other lease or in-flight call uses it.
+- Releasing before creation settles destroys the session after creation succeeds.
+- Failed creation evicts the entry, so a later prepare retries.
+- Sessions with active leases never evict from the LRU cache.
+
+Reuse requires the same session-affecting options as the `translate` call. For this package those are `sourceLanguage`, `targetLanguage`, and `monitor` (`PrepareTranslatorOptions`).
 
 ## Caching
 

--- a/apps/site/src/content/docs/packages/writer.md
+++ b/apps/site/src/content/docs/packages/writer.md
@@ -109,7 +109,43 @@ import {
 } from "@web-ai-sdk/writer";
 ```
 
-The internal session cache is LRU-bounded (default 8). Evicted sessions have their `destroy()` invoked when present.
+The internal session cache is LRU-bounded (default 8). Evicted sessions have their `destroy()` invoked when present. Clearing detaches sessions pinned by a lease or an in-flight call and destroys them when the last pin drops.
+
+### Prepare and release
+
+`prepareWriter(options)` starts native session creation when user intent is clear, before the input exists. It returns a `WriterLease`:
+
+```ts
+interface WriterLease {
+  ready: Promise<void>; // settles when native creation settles
+  release(): void;      // idempotent
+}
+```
+
+```ts
+import { prepareWriter, write } from "@web-ai-sdk/writer";
+
+// User opened the compose panel; warm the session now.
+const writerModel = prepareWriter({ tone: "formal", length: "medium" });
+
+// The matching call reuses the prepared session with no second create.
+const result = await write({
+  input: "An inquiry to my bank about how to enable wire transfers.",
+  tone: "formal",
+  length: "medium",
+});
+
+// User dismissed the panel.
+writerModel.release();
+```
+
+- `prepareWriter` never throws synchronously. Unavailability and creation failure reject `ready` with `WriterUnavailableError`.
+- `release()` is idempotent. The final release destroys the session once no other lease or in-flight call uses it.
+- Releasing before creation settles destroys the session after creation succeeds.
+- Failed creation evicts the entry, so a later prepare retries.
+- Sessions with active leases never evict from the LRU cache.
+
+Reuse requires the same session-affecting options as the `write` call. `PrepareWriterOptions` covers `language`, `supportedLanguages`, `tone`, `format`, `length`, `sharedContext`, and `monitor`.
 
 ## Result caching
 

--- a/apps/site/src/content/docs/packages/writer.md
+++ b/apps/site/src/content/docs/packages/writer.md
@@ -145,7 +145,7 @@ writerModel.release();
 - Failed creation evicts the entry, so a later prepare retries.
 - Sessions with active leases never evict from the LRU cache.
 
-Reuse requires the same session-affecting options as the `write` call. `PrepareWriterOptions` covers `language`, `supportedLanguages`, `tone`, `format`, `length`, `sharedContext`, and `monitor`.
+Reuse requires the same session-affecting options as the `write` call. `PrepareWriterOptions` covers `language`, `supportedLanguages`, `tone`, `format`, `length`, and `sharedContext`. `monitor` observes creation only and never affects reuse.
 
 ## Result caching
 

--- a/apps/site/src/content/docs/production-checklist.mdx
+++ b/apps/site/src/content/docs/production-checklist.mdx
@@ -16,7 +16,7 @@ The SDK does not select page content, interpret user intent, sanitize formatted 
 
 ## Prepare after clear user intent
 
-Prepare a session after the user enters an AI feature. Do not prepare every model on page load. For Prompt, pass system instructions when you create the session.
+Prepare a session after the user enters an AI feature. Do not prepare every model on page load. Every task package exports a `prepare` function that warms the session and returns a release handle; see the [Session lifecycle guide](/docs/guides/session-lifecycle/). For chat-shaped Prompt use, pass system instructions when you create the session.
 
 ```ts
 import { createSession } from "@web-ai-sdk/prompt";

--- a/apps/site/src/content/docs/react/use-detector.mdx
+++ b/apps/site/src/content/docs/react/use-detector.mdx
@@ -9,6 +9,8 @@ React adapter for `@web-ai-sdk/detector`. Auto-detects the language of `input` o
 
 Before shipping, review the [Production checklist](/docs/production-checklist/) for task-relevant input, progress, and cache freshness.
 
+To warm the session before the hook first runs, call `prepareLanguageDetector` from the core package on user intent. See the [Session lifecycle guide](/docs/guides/session-lifecycle/).
+
 ## Live demo
 
 <DetectorDemo client:only="react" />

--- a/apps/site/src/content/docs/react/use-prompt.mdx
+++ b/apps/site/src/content/docs/react/use-prompt.mdx
@@ -9,6 +9,8 @@ React adapter for `@web-ai-sdk/prompt`. Runs single-shot prompts on demand via `
 
 Before shipping, review the [Production checklist](/docs/production-checklist/) for intent-driven preparation, safe streaming, progress, user control, and cache freshness.
 
+To warm the session before the hook first runs, call `prepareLanguageModel` from the core package on user intent. See the [Session lifecycle guide](/docs/guides/session-lifecycle/).
+
 ## Live demo
 
 <PromptDemo client:only="react" />

--- a/apps/site/src/content/docs/react/use-proofreader.mdx
+++ b/apps/site/src/content/docs/react/use-proofreader.mdx
@@ -9,6 +9,8 @@ React adapter for `@web-ai-sdk/proofreader`. Auto-runs on mount and re-runs when
 
 Before shipping, review the [Production checklist](/docs/production-checklist/) for preserving originals, Accept/Reject/Undo flows, safe rendering, and cache freshness.
 
+To warm the session before the hook first runs, call `prepareProofreader` from the core package on user intent. See the [Session lifecycle guide](/docs/guides/session-lifecycle/).
+
 ## Live demo
 
 <ProofreaderDemo client:only="react" />

--- a/apps/site/src/content/docs/react/use-rewriter.mdx
+++ b/apps/site/src/content/docs/react/use-rewriter.mdx
@@ -9,6 +9,8 @@ React adapter for `@web-ai-sdk/rewriter`. Auto-runs on mount, re-runs when `inpu
 
 Before shipping, review the [Production checklist](/docs/production-checklist/) for safe streaming, progress, Accept/Reject/Undo flows, and cache freshness.
 
+To warm the session before the hook first runs, call `prepareRewriter` from the core package on user intent. See the [Session lifecycle guide](/docs/guides/session-lifecycle/).
+
 ## Live demo
 
 <RewriterDemo client:only="react" />

--- a/apps/site/src/content/docs/react/use-session.mdx
+++ b/apps/site/src/content/docs/react/use-session.mdx
@@ -21,6 +21,8 @@ When enabled, mounting the hook starts native creation. The hook stays `"loading
 
 Before shipping, review the [Production checklist](/docs/production-checklist/) for initial instructions, base-plus-clone tasks, destruction, safe rendering, progress, and reversible UI.
 
+`useSession` owns its session directly, outside the shared warm cache. For how `ask()` and the task packages manage warm sessions, see the [Session lifecycle guide](/docs/guides/session-lifecycle/).
+
 ## Usage
 
 ```tsx

--- a/apps/site/src/content/docs/react/use-summarizer.mdx
+++ b/apps/site/src/content/docs/react/use-summarizer.mdx
@@ -9,6 +9,8 @@ React adapter for `@web-ai-sdk/summarizer`. Auto-runs on mount, re-runs when `in
 
 Before shipping, review the [Production checklist](/docs/production-checklist/) for task-relevant text extraction, safe streaming, progress, and cache freshness.
 
+To warm the session before the hook first runs, call `prepareSummarizer` from the core package on user intent. See the [Session lifecycle guide](/docs/guides/session-lifecycle/).
+
 ## Live demo
 
 <SummarizerDemo client:only="react" />

--- a/apps/site/src/content/docs/react/use-translator.mdx
+++ b/apps/site/src/content/docs/react/use-translator.mdx
@@ -9,6 +9,8 @@ React adapter for `@web-ai-sdk/translator`. Auto-translates `input` from `source
 
 Before shipping, review the [Production checklist](/docs/production-checklist/) for safe rendering, progress, reversible changes, and cache freshness.
 
+To warm the session before the hook first runs, call `prepareTranslator` from the core package on user intent. See the [Session lifecycle guide](/docs/guides/session-lifecycle/).
+
 ## Live demo
 
 <TranslatorDemo client:only="react" />

--- a/apps/site/src/content/docs/react/use-writer.mdx
+++ b/apps/site/src/content/docs/react/use-writer.mdx
@@ -9,6 +9,8 @@ React adapter for `@web-ai-sdk/writer`. Auto-runs on mount, re-runs when `input`
 
 Before shipping, review the [Production checklist](/docs/production-checklist/) for safe streaming, progress, reversible suggestions, and cache freshness.
 
+To warm the session before the hook first runs, call `prepareWriter` from the core package on user intent. See the [Session lifecycle guide](/docs/guides/session-lifecycle/).
+
 ## Live demo
 
 <WriterDemo client:only="react" />

--- a/packages/detector/README.md
+++ b/packages/detector/README.md
@@ -107,7 +107,7 @@ detectorModel.release();
 - Failed creation evicts the entry, so a later prepare retries.
 - Sessions with active leases never evict from the LRU cache.
 
-Reuse requires the same session-affecting options as the `detect` call. For this package those are `expectedInputLanguages` and `monitor` (`PrepareLanguageDetectorOptions`).
+Reuse requires the same session-affecting options as the `detect` call. For this package that is `expectedInputLanguages` (`PrepareLanguageDetectorOptions`). `monitor` observes creation only and never affects reuse.
 
 ## Caching
 

--- a/packages/detector/README.md
+++ b/packages/detector/README.md
@@ -84,9 +84,30 @@ Feature-detect helper.
 
 Forwards to `LanguageDetector.availability()`. Returns `null` if the global is missing or the call throws.
 
-### Lower-level helpers (advanced)
+### Prepare and release
 
-`getLanguageDetectorApi`, `getOrCreateLanguageDetector`, `defaultCacheKey`; exported so you can compose your own pipeline (e.g. share a session across multiple call sites, or roll your own retry).
+`prepareLanguageDetector(options)` starts native session creation when user intent is clear, before the input exists. It returns a `LanguageDetectorLease`: `{ ready: Promise<void>; release(): void }`. Options are optional; the zero-config call prepares the default detector.
+
+```ts
+import { prepareLanguageDetector, detect } from "@web-ai-sdk/detector";
+
+// User focuses the input field: warm the session now.
+const detectorModel = prepareLanguageDetector();
+
+// The matching call reuses the prepared session; no second create.
+const result = await detect({ input: "Olá, mundo" });
+
+// User dismisses the feature: let the session go.
+detectorModel.release();
+```
+
+- `prepareLanguageDetector` never throws synchronously. Unavailability and creation failure reject `ready` with `DetectorUnavailableError`.
+- `release()` is idempotent. The final release destroys the session once no other lease or in-flight call uses it.
+- Releasing before creation settles destroys the session after creation succeeds.
+- Failed creation evicts the entry, so a later prepare retries.
+- Sessions with active leases never evict from the LRU cache.
+
+Reuse requires the same session-affecting options as the `detect` call. For this package those are `expectedInputLanguages` and `monitor` (`PrepareLanguageDetectorOptions`).
 
 ## Caching
 
@@ -95,7 +116,7 @@ Two layers, same as the other packages:
 - **Session cache** (internal, in-memory, always on): a `Map<stringifiedOptions, LanguageDetector>` so consecutive calls with the same `expectedInputLanguages` shape reuse the warm session. Cold-start is fast on this model (~100-300ms) but warm is still sub-50ms.
 - **Result cache** (opt-in): pass a `cache` (anything matching `{ get, set }`) to memoize the full sorted list by trimmed text. Omit it for a fresh model call every time.
 
-Use `configureLanguageDetectorCache({ max })` to bound the warm session cache (default `8`). `clearLanguageDetectorSessions()` drops every warm session, and `clearLanguageDetectorSession({ expectedInputLanguages })` drops one matching detector configuration.
+Use `configureLanguageDetectorCache({ max })` to bound the warm session cache (default `8`). `clearLanguageDetectorSessions()` drops every warm session, and `clearLanguageDetectorSession({ expectedInputLanguages })` drops one matching detector configuration. Clearing detaches sessions pinned by a lease or an in-flight call and destroys them when the last pin drops.
 
 ```ts
 // Off by default; every call hits the model.

--- a/packages/detector/src/api.ts
+++ b/packages/detector/src/api.ts
@@ -281,6 +281,9 @@ export const acquireLanguageDetector = (
       released = true;
       entry.inFlightCount -= 1;
       settleEntry(entry);
+      // The dropped pin may leave the cache over its cap; re-trim now
+      // instead of waiting for the next create or configure call.
+      trim();
     },
   };
 };

--- a/packages/detector/src/api.ts
+++ b/packages/detector/src/api.ts
@@ -93,10 +93,26 @@ interface CacheConfig {
 
 const cacheConfig: CacheConfig = { max: DEFAULT_MAX_CACHED_SESSIONS };
 
+interface SessionEntry {
+  key: string;
+  session: Promise<LanguageDetectorInstance>;
+  /** Active prepare leases. Leased entries never evict. */
+  leaseCount: number;
+  /** Operations currently running inference on this session. */
+  inFlightCount: number;
+  /** Still reachable through `sessionCache`. */
+  inMap: boolean;
+  /** Destruction already scheduled; guards double-destroy. */
+  destroyed: boolean;
+}
+
 // Map iteration order is insertion order, which lets us use it as an LRU:
 // on hit we re-insert to bump recency, and on overflow we evict the
 // oldest (first) entry.
-const sessionCache = new Map<string, Promise<LanguageDetectorInstance>>();
+const sessionCache = new Map<string, SessionEntry>();
+
+const isPinned = (entry: SessionEntry): boolean =>
+  entry.leaseCount > 0 || entry.inFlightCount > 0;
 
 const normalizeCacheMax = (max: number): number =>
   Number.isFinite(max) ? Math.max(0, Math.floor(max)) : 0;
@@ -120,11 +136,11 @@ export const configureLanguageDetectorCache = (
   trim();
 };
 
-const destroySession = (entry: Promise<LanguageDetectorInstance>): void => {
-  entry
-    .then((session) => {
+const destroySession = (session: Promise<LanguageDetectorInstance>): void => {
+  session
+    .then((instance) => {
       try {
-        session.destroy?.();
+        instance.destroy?.();
       } catch {
         // best-effort; the spec doesn't require destroy to be infallible.
       }
@@ -134,22 +150,46 @@ const destroySession = (entry: Promise<LanguageDetectorInstance>): void => {
     });
 };
 
+const detachEntry = (entry: SessionEntry): void => {
+  if (!entry.inMap) return;
+  entry.inMap = false;
+  sessionCache.delete(entry.key);
+};
+
+/**
+ * Destroy a detached entry once nothing pins it. Pinned entries are settled
+ * again when their last lease releases or their last in-flight call ends.
+ */
+const settleEntry = (entry: SessionEntry): void => {
+  if (entry.inMap || entry.destroyed || isPinned(entry)) return;
+  entry.destroyed = true;
+  destroySession(entry.session);
+};
+
 const trim = (): void => {
-  while (sessionCache.size > cacheConfig.max) {
-    const oldestKey = sessionCache.keys().next().value;
-    if (oldestKey === undefined) return;
-    const evicted = sessionCache.get(oldestKey);
-    sessionCache.delete(oldestKey);
-    if (evicted) destroySession(evicted);
+  if (sessionCache.size <= cacheConfig.max) return;
+  for (const entry of [...sessionCache.values()]) {
+    if (sessionCache.size <= cacheConfig.max) return;
+    // Leased or in-flight entries never evict, so the cache may temporarily
+    // exceed `max` while they stay pinned.
+    if (isPinned(entry)) continue;
+    detachEntry(entry);
+    settleEntry(entry);
   }
 };
 
-/** Drop every cached language detector session. */
+/**
+ * Drop every cached language detector session. Sessions live for the tab
+ * lifetime by default; call this to free them eagerly when navigating away
+ * from a feature that won't be revisited. Sessions pinned by a lease or an
+ * in-flight call leave the cache now and are destroyed once the last pin
+ * drops.
+ */
 export const clearLanguageDetectorSessions = (): void => {
-  for (const entry of sessionCache.values()) {
-    destroySession(entry);
+  for (const entry of [...sessionCache.values()]) {
+    detachEntry(entry);
+    settleEntry(entry);
   }
-  sessionCache.clear();
 };
 
 const canonicalExpectedInputLanguages = (
@@ -167,39 +207,122 @@ const cacheKeyFor = (options: LanguageDetectorAvailabilityOptions): string =>
 export const clearLanguageDetectorSession = (
   options: LanguageDetectorAvailabilityOptions,
 ): void => {
-  const key = cacheKeyFor(options);
-  const entry = sessionCache.get(key);
+  const entry = sessionCache.get(cacheKeyFor(options));
   if (!entry) return;
-  sessionCache.delete(key);
-  destroySession(entry);
+  detachEntry(entry);
+  settleEntry(entry);
 };
 
 /**
- * Get or create a `LanguageDetector` session for the given options.
- * Sessions live for the tab lifetime so consecutive calls with the same
- * shape skip the cold start. On `create()` failure the cache slot is
- * purged so the next call retries instead of returning a poisoned promise.
+ * Get or create the cache entry for the given options. Sessions live for the
+ * tab lifetime so consecutive calls with the same shape skip the cold start.
+ * On `create()` failure the cache slot is purged so the next call retries
+ * instead of returning a poisoned promise.
  */
-export const getOrCreateLanguageDetector = (
+const getOrCreateEntry = (
   api: LanguageDetectorApi,
   options: LanguageDetectorCreateOptions,
-): Promise<LanguageDetectorInstance> => {
+): SessionEntry => {
   // Drop `signal` and `monitor` from the cache key; they're per-call
   // ephemera that shouldn't fragment session reuse.
   const key = cacheKeyFor(options);
-  let session = sessionCache.get(key);
-  if (session) {
+  const existing = sessionCache.get(key);
+  if (existing) {
+    // Bump recency: delete + reinsert so this entry moves to the end of the
+    // LRU order.
     sessionCache.delete(key);
-    sessionCache.set(key, session);
-    return session;
+    sessionCache.set(key, existing);
+    return existing;
   }
-  session = api.create(options).catch((err) => {
-    sessionCache.delete(key);
-    throw err;
-  });
-  sessionCache.set(key, session);
+  const entry: SessionEntry = {
+    key,
+    session: api.create(options).catch((err) => {
+      detachEntry(entry);
+      throw err;
+    }),
+    leaseCount: 0,
+    inFlightCount: 0,
+    inMap: true,
+    destroyed: false,
+  };
+  // A prepare-only caller may never observe the session promise; keep the
+  // stored branch handled so failed creation cannot surface as an unhandled
+  // rejection.
+  entry.session.catch(() => {});
+  sessionCache.set(key, entry);
+  return entry;
+};
+
+export interface AcquiredLanguageDetector {
+  session: Promise<LanguageDetectorInstance>;
+  /** Release the in-flight pin. Idempotent. */
+  done(): void;
+}
+
+/**
+ * Get or create a `LanguageDetector` session and pin it for one operation.
+ * The pin defers destruction (final lease release, clear, eviction) until
+ * `done()` runs, so in-flight inference can never lose its session.
+ */
+export const acquireLanguageDetector = (
+  api: LanguageDetectorApi,
+  options: LanguageDetectorCreateOptions,
+): AcquiredLanguageDetector => {
+  const entry = getOrCreateEntry(api, options);
+  // Pin before trimming so a fresh entry can never evict itself when every
+  // other entry is pinned.
+  entry.inFlightCount += 1;
   trim();
-  return session;
+  let released = false;
+  return {
+    session: entry.session,
+    done: () => {
+      if (released) return;
+      released = true;
+      entry.inFlightCount -= 1;
+      settleEntry(entry);
+    },
+  };
+};
+
+export interface LanguageDetectorSessionLease {
+  /** Settles with the underlying `create()` outcome. */
+  ready: Promise<void>;
+  /** Idempotent. The final release detaches and destroys once safe. */
+  release(): void;
+}
+
+/**
+ * Start (or join) session creation for the given options and hold a lease on
+ * the entry. Leases pin the entry against LRU eviction. The final release
+ * removes the entry from the cache and destroys the session as soon as no
+ * in-flight call uses it; released-before-ready sessions are destroyed when
+ * creation later succeeds.
+ */
+export const leaseLanguageDetector = (
+  api: LanguageDetectorApi,
+  options: LanguageDetectorCreateOptions,
+): LanguageDetectorSessionLease => {
+  const entry = getOrCreateEntry(api, options);
+  // Pin before trimming so a fresh entry can never evict itself when every
+  // other entry is pinned.
+  entry.leaseCount += 1;
+  trim();
+  let released = false;
+  const ready = entry.session.then(() => undefined);
+  // Keep unobserved leases from surfacing unhandled rejections.
+  ready.catch(() => {});
+  return {
+    ready,
+    release: () => {
+      if (released) return;
+      released = true;
+      entry.leaseCount -= 1;
+      if (entry.leaseCount > 0) return;
+      detachEntry(entry);
+      settleEntry(entry);
+    },
+  };
 };
 
 /** Test-only escape hatch; drop every cached session. */

--- a/packages/detector/src/index.ts
+++ b/packages/detector/src/index.ts
@@ -123,6 +123,7 @@ class DetectorAbortError extends Error {
  * Session-affecting subset of `DetectOptions`. `prepareLanguageDetector` and
  * `detect` derive the same native create options from these fields, so a
  * prepared session is reused by the matching call.
+ * `monitor` observes creation only; it never affects the cache key.
  */
 export type PrepareLanguageDetectorOptions = Pick<
   DetectOptions,
@@ -135,8 +136,9 @@ interface SessionConfig {
 }
 
 /**
- * Single source of the option-to-session mapping. The session cache keys by
- * `createOptions`, so `detect` and `prepareLanguageDetector` must both go
+ * Single source of the option-to-session mapping. The session cache key derives from
+ * the stable fields of `createOptions` (`monitor` never fragments reuse),
+ * so `detect` and `prepareLanguageDetector` must both go
  * through this derivation.
  */
 const resolveSessionConfig = (

--- a/packages/detector/src/index.ts
+++ b/packages/detector/src/index.ts
@@ -9,6 +9,7 @@
  */
 
 import {
+  acquireLanguageDetector,
   type ConfigureLanguageDetectorCacheOptions,
   type CreateMonitor,
   checkAvailability,
@@ -17,13 +18,13 @@ import {
   configureLanguageDetectorCache,
   type DetectionResult,
   getLanguageDetectorApi,
-  getOrCreateLanguageDetector,
   isAvailable,
   type LanguageDetectorApi,
   type LanguageDetectorAvailability,
   type LanguageDetectorAvailabilityOptions,
   type LanguageDetectorCreateOptions,
   type LanguageDetectorInstance,
+  leaseLanguageDetector,
 } from "./api.js";
 import {
   type CacheOption,
@@ -119,6 +120,87 @@ class DetectorAbortError extends Error {
 }
 
 /**
+ * Session-affecting subset of `DetectOptions`. `prepareLanguageDetector` and
+ * `detect` derive the same native create options from these fields, so a
+ * prepared session is reused by the matching call.
+ */
+export type PrepareLanguageDetectorOptions = Pick<
+  DetectOptions,
+  "expectedInputLanguages" | "monitor"
+>;
+
+interface SessionConfig {
+  expectedInputLanguages: string[] | undefined;
+  createOptions: LanguageDetectorCreateOptions;
+}
+
+/**
+ * Single source of the option-to-session mapping. The session cache keys by
+ * `createOptions`, so `detect` and `prepareLanguageDetector` must both go
+ * through this derivation.
+ */
+const resolveSessionConfig = (
+  options: PrepareLanguageDetectorOptions,
+): SessionConfig => {
+  const expectedInputLanguages = options.expectedInputLanguages
+    ? [...options.expectedInputLanguages]
+    : undefined;
+
+  const createOptions: LanguageDetectorCreateOptions = {
+    ...(expectedInputLanguages ? { expectedInputLanguages } : {}),
+    ...(options.monitor ? { monitor: options.monitor } : {}),
+  };
+
+  return { expectedInputLanguages, createOptions };
+};
+
+export interface LanguageDetectorLease {
+  /**
+   * Resolves when the native session is created. Rejects with
+   * `DetectorUnavailableError` when the API is missing or creation fails.
+   */
+  ready: Promise<void>;
+  /**
+   * Idempotent. The final release destroys the session once no other lease
+   * or in-flight call uses it.
+   */
+  release(): void;
+}
+
+/**
+ * Start native session creation as soon as user intent is clear, before the
+ * input exists. The matching `detect` call reuses the prepared session
+ * without a second create. Never throws synchronously; unavailability and
+ * creation failures reject `ready`. Failed preparations leave the cache so a
+ * later call can retry.
+ */
+export const prepareLanguageDetector = (
+  options: PrepareLanguageDetectorOptions = {},
+): LanguageDetectorLease => {
+  const api = getLanguageDetectorApi();
+  if (!api?.create) {
+    const ready = Promise.reject(
+      new DetectorUnavailableError(
+        "LanguageDetector API is not available in this environment.",
+      ),
+    );
+    // Keep unobserved leases from surfacing unhandled rejections.
+    ready.catch(() => {});
+    return { ready, release: () => {} };
+  }
+  const { createOptions } = resolveSessionConfig(options);
+  const lease = leaseLanguageDetector(api, createOptions);
+  const ready = lease.ready.catch((err) => {
+    const message = (err as Error)?.message ?? String(err);
+    throw new DetectorUnavailableError(
+      `LanguageDetector.create() failed: ${message}`,
+    );
+  });
+  ready.catch(() => {});
+  return { ready, release: lease.release };
+};
+
+/**
  * Detect the language of a string. Returns the top match with confidence,
  * plus the full sorted list for callers that want to inspect alternates.
  * Returns `{ output: null, ... }` for empty input or when the top
@@ -139,9 +221,8 @@ export const detect = async (options: DetectOptions): Promise<DetectResult> => {
   }
 
   const minConfidence = options.minConfidence ?? 0;
-  const expectedInputLanguages = options.expectedInputLanguages
-    ? [...options.expectedInputLanguages]
-    : undefined;
+  const { expectedInputLanguages, createOptions } =
+    resolveSessionConfig(options);
 
   const cache = resolveCache(options.cache, options.cacheTtl);
   const cacheKey =
@@ -169,11 +250,6 @@ export const detect = async (options: DetectOptions): Promise<DetectResult> => {
     }
   }
 
-  const baseCreateOptions: LanguageDetectorCreateOptions = {
-    ...(expectedInputLanguages ? { expectedInputLanguages } : {}),
-    ...(options.monitor ? { monitor: options.monitor } : {}),
-  };
-
   // Pass the same shape to availability() as we do to create() so the probe
   // applies to the requested configuration.
   const availability = await api
@@ -186,42 +262,47 @@ export const detect = async (options: DetectOptions): Promise<DetectResult> => {
   }
   if (options.signal?.aborted) throw new DetectorAbortError();
 
-  const sessionPromise = getOrCreateLanguageDetector(api, baseCreateOptions);
-
-  // Wrap session-create failures with context so consumers can branch on
-  // a single typed error instead of parsing browser-specific messages.
-  let session: LanguageDetectorInstance;
+  // The pin defers destruction (lease release, clear, eviction) until this
+  // call finishes.
+  const acquired = acquireLanguageDetector(api, createOptions);
   try {
-    session = await sessionPromise;
-  } catch (err) {
-    if (err instanceof DetectorAbortError) throw err;
-    const message = (err as Error)?.message ?? String(err);
-    throw new DetectorUnavailableError(
-      `LanguageDetector.create() failed: ${message}`,
-    );
-  }
-  if (options.signal?.aborted) throw new DetectorAbortError();
+    // Wrap session-create failures with context so consumers can branch on
+    // a single typed error instead of parsing browser-specific messages.
+    let session: LanguageDetectorInstance;
+    try {
+      session = await acquired.session;
+    } catch (err) {
+      if (err instanceof DetectorAbortError) throw err;
+      const message = (err as Error)?.message ?? String(err);
+      throw new DetectorUnavailableError(
+        `LanguageDetector.create() failed: ${message}`,
+      );
+    }
+    if (options.signal?.aborted) throw new DetectorAbortError();
 
-  const results = await session.detect(text);
-  if (options.signal?.aborted) throw new DetectorAbortError();
+    const results = await session.detect(text);
+    if (options.signal?.aborted) throw new DetectorAbortError();
 
-  // The spec says results are sorted by confidence descending; sort again
-  // defensively in case an implementation drifts.
-  const sorted = [...results].sort((a, b) => b.confidence - a.confidence);
-  if (cache && sorted.length > 0) {
-    cache.set(cacheKey, JSON.stringify(sorted));
-  }
+    // The spec says results are sorted by confidence descending; sort again
+    // defensively in case an implementation drifts.
+    const sorted = [...results].sort((a, b) => b.confidence - a.confidence);
+    if (cache && sorted.length > 0) {
+      cache.set(cacheKey, JSON.stringify(sorted));
+    }
 
-  const top = sorted[0];
-  if (!top || top.confidence < minConfidence) {
-    return { output: null, cached: false };
+    const top = sorted[0];
+    if (!top || top.confidence < minConfidence) {
+      return { output: null, cached: false };
+    }
+    return {
+      output: {
+        language: top.detectedLanguage,
+        confidence: top.confidence,
+        all: sorted,
+      },
+      cached: false,
+    };
+  } finally {
+    acquired.done();
   }
-  return {
-    output: {
-      language: top.detectedLanguage,
-      confidence: top.confidence,
-      all: sorted,
-    },
-    cached: false,
-  };
 };

--- a/packages/detector/src/prepare.test.ts
+++ b/packages/detector/src/prepare.test.ts
@@ -218,4 +218,17 @@ describe("prepareLanguageDetector", () => {
     await tick();
     expect(instances[0]?.destroy).toHaveBeenCalledTimes(1);
   });
+
+  it("re-trims the cache when the last in-flight pin drops", async () => {
+    const { api, instances } = installFakeApi();
+    configureLanguageDetectorCache({ max: 0 });
+
+    await detect({ input: "hola", expectedInputLanguages: ["es"] });
+    await tick();
+    expect(instances[0]?.destroy).toHaveBeenCalledTimes(1);
+
+    // Nothing stayed cached, so the same call creates a fresh session.
+    await detect({ input: "hola", expectedInputLanguages: ["es"] });
+    expect(api.create).toHaveBeenCalledTimes(2);
+  });
 });

--- a/packages/detector/src/prepare.test.ts
+++ b/packages/detector/src/prepare.test.ts
@@ -1,0 +1,221 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  __clearSessionCacheForTests,
+  configureLanguageDetectorCache,
+} from "./api.js";
+import {
+  clearLanguageDetectorSessions,
+  DetectorUnavailableError,
+  detect,
+  prepareLanguageDetector,
+} from "./index.js";
+
+interface FakeDetector {
+  detect: ReturnType<typeof vi.fn>;
+  destroy: ReturnType<typeof vi.fn>;
+}
+
+const RESULTS = [
+  { detectedLanguage: "en", confidence: 0.95 },
+  { detectedLanguage: "es", confidence: 0.04 },
+];
+
+const makeInstance = (): FakeDetector => ({
+  detect: vi.fn(async () => RESULTS),
+  destroy: vi.fn(),
+});
+
+const installFakeApi = () => {
+  const instances: FakeDetector[] = [];
+  const api = {
+    availability: vi.fn(async () => "available" as const),
+    create: vi.fn(async () => {
+      const instance = makeInstance();
+      instances.push(instance);
+      return instance;
+    }),
+  };
+  (globalThis as { LanguageDetector?: unknown }).LanguageDetector = api;
+  return { api, instances };
+};
+
+const tick = () => new Promise<void>((resolve) => setTimeout(resolve, 0));
+
+beforeEach(() => {
+  __clearSessionCacheForTests();
+});
+
+afterEach(() => {
+  (globalThis as { LanguageDetector?: unknown }).LanguageDetector = undefined;
+});
+
+describe("prepareLanguageDetector", () => {
+  it("starts creation immediately and the matching detect reuses it", async () => {
+    const { api } = installFakeApi();
+    const lease = prepareLanguageDetector({ expectedInputLanguages: ["en"] });
+    expect(api.create).toHaveBeenCalledTimes(1);
+    await lease.ready;
+
+    const result = await detect({
+      input: "hello",
+      expectedInputLanguages: ["en"],
+    });
+    expect(result.output?.language).toBe("en");
+    expect(api.create).toHaveBeenCalledTimes(1);
+    lease.release();
+  });
+
+  it("never throws when the API is missing; ready rejects instead", async () => {
+    const lease = prepareLanguageDetector({ expectedInputLanguages: ["en"] });
+    await expect(lease.ready).rejects.toBeInstanceOf(DetectorUnavailableError);
+    expect(() => lease.release()).not.toThrow();
+  });
+
+  it("shares one session between concurrent leases and destroys exactly once", async () => {
+    const { api, instances } = installFakeApi();
+    const first = prepareLanguageDetector({ expectedInputLanguages: ["en"] });
+    const second = prepareLanguageDetector({ expectedInputLanguages: ["en"] });
+    expect(api.create).toHaveBeenCalledTimes(1);
+    await Promise.all([first.ready, second.ready]);
+
+    first.release();
+    first.release();
+    await tick();
+    expect(instances[0]?.destroy).not.toHaveBeenCalled();
+
+    second.release();
+    second.release();
+    await tick();
+    expect(instances[0]?.destroy).toHaveBeenCalledTimes(1);
+  });
+
+  it("release before creation settles destroys the session once created", async () => {
+    const { api } = installFakeApi();
+    let resolveCreate: (instance: FakeDetector) => void = () => {};
+    const instance = makeInstance();
+    api.create.mockImplementationOnce(
+      () =>
+        new Promise<FakeDetector>((resolve) => {
+          resolveCreate = resolve;
+        }),
+    );
+
+    const lease = prepareLanguageDetector({ expectedInputLanguages: ["en"] });
+    lease.release();
+    await tick();
+    expect(instance.destroy).not.toHaveBeenCalled();
+
+    resolveCreate(instance);
+    await tick();
+    expect(instance.destroy).toHaveBeenCalledTimes(1);
+
+    // The released entry left the cache, so preparing again creates anew.
+    const retry = prepareLanguageDetector({ expectedInputLanguages: ["en"] });
+    expect(api.create).toHaveBeenCalledTimes(2);
+    await retry.ready;
+    retry.release();
+  });
+
+  it("creation failure rejects ready, evicts the entry, and allows retry", async () => {
+    const { api } = installFakeApi();
+    api.create.mockRejectedValueOnce(new Error("no space"));
+
+    const failed = prepareLanguageDetector({ expectedInputLanguages: ["en"] });
+    await expect(failed.ready).rejects.toBeInstanceOf(DetectorUnavailableError);
+    failed.release();
+
+    const retry = prepareLanguageDetector({ expectedInputLanguages: ["en"] });
+    expect(api.create).toHaveBeenCalledTimes(2);
+    await expect(retry.ready).resolves.toBeUndefined();
+    retry.release();
+  });
+
+  it("defers destruction while inference is in flight", async () => {
+    const { instances } = installFakeApi();
+    const lease = prepareLanguageDetector({ expectedInputLanguages: ["en"] });
+    await lease.ready;
+
+    const instance = instances[0];
+    if (!instance) throw new Error("expected a created instance");
+    let resolveDetect: (results: typeof RESULTS) => void = () => {};
+    instance.detect.mockImplementationOnce(
+      () =>
+        new Promise<typeof RESULTS>((resolve) => {
+          resolveDetect = resolve;
+        }),
+    );
+
+    const running = detect({ input: "hello", expectedInputLanguages: ["en"] });
+    await tick();
+    lease.release();
+    await tick();
+    expect(instance.destroy).not.toHaveBeenCalled();
+
+    resolveDetect(RESULTS);
+    await expect(running).resolves.toMatchObject({
+      output: { language: "en" },
+      cached: false,
+    });
+    await tick();
+    expect(instance.destroy).toHaveBeenCalledTimes(1);
+  });
+
+  it("pins leased entries against LRU eviction", async () => {
+    const { instances } = installFakeApi();
+    configureLanguageDetectorCache({ max: 1 });
+
+    const lease = prepareLanguageDetector({ expectedInputLanguages: ["en"] });
+    await lease.ready;
+    await detect({ input: "hola", expectedInputLanguages: ["es"] });
+    await tick();
+
+    // Inserting a third entry trims to max; the leased "en" session survives
+    // and the unpinned "es" session is evicted.
+    const third = prepareLanguageDetector({ expectedInputLanguages: ["ja"] });
+    await third.ready;
+    await tick();
+    expect(instances[0]?.destroy).not.toHaveBeenCalled();
+    expect(instances[1]?.destroy).toHaveBeenCalledTimes(1);
+
+    lease.release();
+    third.release();
+  });
+
+  it("isolates leases per option key", async () => {
+    const { api, instances } = installFakeApi();
+    const english = prepareLanguageDetector({
+      expectedInputLanguages: ["en"],
+    });
+    await english.ready;
+
+    await detect({ input: "hola", expectedInputLanguages: ["es"] });
+    expect(api.create).toHaveBeenCalledTimes(2);
+
+    english.release();
+    await tick();
+    expect(instances[0]?.destroy).toHaveBeenCalledTimes(1);
+    expect(instances[1]?.destroy).not.toHaveBeenCalled();
+
+    // The other configuration stays cached and reusable.
+    await detect({ input: "hola", expectedInputLanguages: ["es"] });
+    expect(api.create).toHaveBeenCalledTimes(2);
+  });
+
+  it("clear detaches leased sessions and destroys them on final release", async () => {
+    const { api, instances } = installFakeApi();
+    const lease = prepareLanguageDetector({ expectedInputLanguages: ["en"] });
+    await lease.ready;
+
+    clearLanguageDetectorSessions();
+    await tick();
+    expect(instances[0]?.destroy).not.toHaveBeenCalled();
+
+    // The detached session no longer serves new calls.
+    await detect({ input: "hello", expectedInputLanguages: ["en"] });
+    expect(api.create).toHaveBeenCalledTimes(2);
+
+    lease.release();
+    await tick();
+    expect(instances[0]?.destroy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/prompt/README.md
+++ b/packages/prompt/README.md
@@ -525,7 +525,7 @@ Semantics:
 - Failed creation evicts the entry, so a later prepare retries.
 - Leased bases never evict from the LRU cache.
 
-Reuse requires the same session-affecting options as `ask()`. `PrepareLanguageModelOptions` covers `systemPrompt`, `samplingMode`, `temperature`, `topK`, `language`, `supportedLanguages`, `expectedInputs`, `expectedOutputs`, `tools`, and `monitor`.
+Reuse requires the same session-affecting options as `ask()`. `PrepareLanguageModelOptions` covers `systemPrompt`, `samplingMode`, `temperature`, `topK`, `language`, `supportedLanguages`, `expectedInputs`, `expectedOutputs`, and `tools`. `monitor` observes creation only and never affects reuse.
 
 `createSession()` is unaffected. It always creates a caller-owned session outside this cache.
 

--- a/packages/prompt/README.md
+++ b/packages/prompt/README.md
@@ -477,8 +477,10 @@ Forwards to `LanguageModel.availability()`. Returns `null` if the global is miss
 
 Two layers, same as `@web-ai-sdk/summarizer`:
 
-- **Session cache** (internal, in-memory, on for `ask()`): a bounded LRU of base instances keyed by serialized creation options. When supported, each call uses an isolated clone. `createSession()` bypasses this cache.
+- **Session cache** (in-memory, on for `ask()`): a bounded LRU of base instances keyed by serialized creation options. When supported, each call uses an isolated clone. `prepareLanguageModel()` warms this cache. `createSession()` bypasses it.
 - **Result cache** (opt-in): pass a `cache` (anything matching `{ get, set }`) to memoize final responses by `(input, systemPrompt, samplingMode / temperature / topK)`. Omit it for a fresh model call every time.
+
+The session cache has public controls. `configureLanguageModelCache({ max })` bounds the base-session LRU; the default is 8. `clearLanguageModelSessions()` drops every cached base. `clearLanguageModelSession(createOptions)` drops one. Clearing detaches bases pinned by a lease or an in-flight `ask()` and destroys them when the last pin drops.
 
 ```ts
 // Off by default; every call hits the model.
@@ -493,6 +495,39 @@ ask({ input: "hi", cache: "local" });
 // Or roll your own.
 ask({ input: "hi", cache: myMap, cacheKey: "greeting" });
 ```
+
+### Prepare and release
+
+`prepareLanguageModel(options)` starts base-session creation when user intent is clear, before the first `ask()` input exists. It returns a `LanguageModelLease`: `{ ready: Promise<void>; release(): void }`.
+
+```ts
+import { ask, prepareLanguageModel } from "@web-ai-sdk/prompt";
+
+const systemPrompt = "You are a concise support assistant.";
+
+// User opened the panel; intent is clear, no input yet.
+const languageModel = prepareLanguageModel({ systemPrompt });
+
+// The matching call clones from the warm base with no second create().
+const result = await ask({ input, systemPrompt });
+
+// User dismissed the panel without asking anything.
+languageModel.release();
+```
+
+Semantics:
+
+- `prepareLanguageModel()` never throws synchronously.
+- Unavailability and creation failure reject `ready` with `PromptUnavailableError`.
+- Invalid sampling options reject `ready` with the same error `ask()` would throw.
+- `release()` is idempotent. The final release destroys the base once no other lease or in-flight `ask()` uses it.
+- Releasing before creation settles destroys the base after creation succeeds.
+- Failed creation evicts the entry, so a later prepare retries.
+- Leased bases never evict from the LRU cache.
+
+Reuse requires the same session-affecting options as `ask()`. `PrepareLanguageModelOptions` covers `systemPrompt`, `samplingMode`, `temperature`, `topK`, `language`, `supportedLanguages`, `expectedInputs`, `expectedOutputs`, `tools`, and `monitor`.
+
+`createSession()` is unaffected. It always creates a caller-owned session outside this cache.
 
 ### Expiry and refresh
 

--- a/packages/prompt/src/api.ts
+++ b/packages/prompt/src/api.ts
@@ -428,6 +428,9 @@ export const acquireLanguageModel = (
       released = true;
       entry.inFlightCount -= 1;
       settleEntry(entry);
+      // The dropped pin may leave the cache over its cap; re-trim now
+      // instead of waiting for the next create or configure call.
+      trim();
     },
   };
 };

--- a/packages/prompt/src/api.ts
+++ b/packages/prompt/src/api.ts
@@ -238,29 +238,57 @@ interface CacheConfig {
 
 const cacheConfig: CacheConfig = { max: DEFAULT_MAX_CACHED_SESSIONS };
 
+interface SessionEntry {
+  key: string;
+  session: Promise<LanguageModelInstance>;
+  /** Active prepare leases. Leased entries never evict. */
+  leaseCount: number;
+  /** `ask()` calls currently using this base session. */
+  inFlightCount: number;
+  /** Still reachable through `sessionCache`. */
+  inMap: boolean;
+  /** Destruction already scheduled; guards double-destroy. */
+  destroyed: boolean;
+}
+
 // Map iteration order is insertion order, which lets us use it as an LRU:
 // on hit we re-insert to bump recency, and on overflow we evict the
 // oldest (first) entry.
-const sessionCache = new Map<string, Promise<LanguageModelInstance>>();
+const sessionCache = new Map<string, SessionEntry>();
 const cloneUnavailableCacheKeys = new Map<string, true>();
+
+const isPinned = (entry: SessionEntry): boolean =>
+  entry.leaseCount > 0 || entry.inFlightCount > 0;
 
 const normalizeCacheMax = (max: number): number =>
   Number.isFinite(max) ? Math.max(0, Math.floor(max)) : 0;
 
+export interface ConfigureLanguageModelCacheOptions {
+  /** Soft cap on cached base sessions. Default: `8`. */
+  max?: number;
+}
+
 /**
- * Test-only escape hatch; reconfigure the session LRU cap. Not part of the
- * public API.
+ * Bound the internal base-session cache used by `ask()` and
+ * `prepareLanguageModel()`. Excess entries are evicted in LRU order (their
+ * `destroy?()` is invoked when present). Lowering `max` immediately evicts
+ * down to the new ceiling. `createSession()` sessions are caller-owned and
+ * unaffected.
  */
-export const __configureCacheForTests = (max: number): void => {
-  cacheConfig.max = normalizeCacheMax(max);
+export const configureLanguageModelCache = (
+  options: ConfigureLanguageModelCacheOptions = {},
+): void => {
+  if (options.max !== undefined) {
+    cacheConfig.max = normalizeCacheMax(options.max);
+  }
   trim();
 };
 
-const destroySession = (entry: Promise<LanguageModelInstance>): void => {
-  entry
-    .then((session) => {
+const destroySession = (session: Promise<LanguageModelInstance>): void => {
+  session
+    .then((instance) => {
       try {
-        session.destroy?.();
+        instance.destroy?.();
       } catch {
         // best-effort; the spec doesn't require destroy to be infallible.
       }
@@ -270,13 +298,32 @@ const destroySession = (entry: Promise<LanguageModelInstance>): void => {
     });
 };
 
+const detachEntry = (entry: SessionEntry): void => {
+  if (!entry.inMap) return;
+  entry.inMap = false;
+  sessionCache.delete(entry.key);
+};
+
+/**
+ * Destroy a detached entry once nothing pins it. Pinned entries are settled
+ * again when their last lease releases or their last in-flight call ends.
+ */
+const settleEntry = (entry: SessionEntry): void => {
+  if (entry.inMap || entry.destroyed || isPinned(entry)) return;
+  entry.destroyed = true;
+  destroySession(entry.session);
+};
+
 const trim = (): void => {
-  while (sessionCache.size > cacheConfig.max) {
-    const oldestKey = sessionCache.keys().next().value;
-    if (oldestKey === undefined) return;
-    const evicted = sessionCache.get(oldestKey);
-    sessionCache.delete(oldestKey);
-    if (evicted) destroySession(evicted);
+  if (sessionCache.size > cacheConfig.max) {
+    for (const entry of [...sessionCache.values()]) {
+      if (sessionCache.size <= cacheConfig.max) break;
+      // Leased or in-flight entries never evict, so the cache may temporarily
+      // exceed `max` while they stay pinned.
+      if (isPinned(entry)) continue;
+      detachEntry(entry);
+      settleEntry(entry);
+    }
   }
   while (cloneUnavailableCacheKeys.size > cacheConfig.max) {
     const oldestKey = cloneUnavailableCacheKeys.keys().next().value;
@@ -286,41 +333,156 @@ const trim = (): void => {
 };
 
 /**
- * Get or create a `LanguageModel` session for the given options. Sessions live
- * for the tab lifetime so consecutive calls with the same shape skip the
- * ~1-3s cold start. On `create()` failure the cache slot is purged so the
- * next call retries instead of returning a poisoned promise.
- *
- * The cache is shared across `ask()` calls only. `createSession()` bypasses
- * this cache so chat-shaped apps get independent sessions per call.
+ * Drop every cached base session. Sessions live for the tab lifetime by
+ * default; call this to free them eagerly when navigating away from a feature
+ * that won't be revisited. Sessions pinned by a lease or an in-flight call
+ * leave the cache now and are destroyed once the last pin drops.
+ * `createSession()` sessions are caller-owned and unaffected.
  */
-export const getOrCreateLanguageModel = (
+export const clearLanguageModelSessions = (): void => {
+  for (const entry of [...sessionCache.values()]) {
+    detachEntry(entry);
+    settleEntry(entry);
+  }
+};
+
+/**
+ * Drop the cached base session whose create-options match `options`.
+ */
+export const clearLanguageModelSession = (
+  options: LanguageModelCreateOptions,
+): void => {
+  const entry = sessionCache.get(JSON.stringify(options));
+  if (!entry) return;
+  detachEntry(entry);
+  settleEntry(entry);
+};
+
+/**
+ * Get or create the cache entry for the given options. Sessions live for the
+ * tab lifetime so consecutive calls with the same shape skip the ~1-3s cold
+ * start. On `create()` failure the cache slot is purged so the next call
+ * retries instead of returning a poisoned promise.
+ *
+ * The cache is shared across `ask()` and `prepareLanguageModel()` only.
+ * `createSession()` bypasses this cache so chat-shaped apps get independent
+ * sessions per call.
+ */
+const getOrCreateEntry = (
   api: LanguageModelApi,
   options: LanguageModelCreateOptions,
-): Promise<LanguageModelInstance> => {
+): SessionEntry => {
   const key = JSON.stringify(options);
-  let session = sessionCache.get(key);
-  if (session) {
+  const existing = sessionCache.get(key);
+  if (existing) {
     // Bump recency: delete + reinsert so this entry moves to the end of the
     // LRU order.
     sessionCache.delete(key);
-    sessionCache.set(key, session);
-    return session;
+    sessionCache.set(key, existing);
+    return existing;
   }
-  session = api.create(options).catch((err) => {
-    sessionCache.delete(key);
-    throw err;
-  });
-  sessionCache.set(key, session);
-  trim();
-  return session;
+  const entry: SessionEntry = {
+    key,
+    session: api.create(options).catch((err) => {
+      detachEntry(entry);
+      throw err;
+    }),
+    leaseCount: 0,
+    inFlightCount: 0,
+    inMap: true,
+    destroyed: false,
+  };
+  // A prepare-only caller may never observe the session promise; keep the
+  // stored branch handled so failed creation cannot surface as an unhandled
+  // rejection.
+  entry.session.catch(() => {});
+  sessionCache.set(key, entry);
+  return entry;
 };
 
-/** Internal: remove one create-options entry from the warm-session cache. */
+export interface AcquiredLanguageModel {
+  session: Promise<LanguageModelInstance>;
+  /** Release the in-flight pin. Idempotent. */
+  done(): void;
+}
+
+/**
+ * Get or create a base `LanguageModel` session and pin it for one `ask()`
+ * call. The pin defers destruction (final lease release, clear, eviction)
+ * until `done()` runs, so in-flight use can never lose its session.
+ */
+export const acquireLanguageModel = (
+  api: LanguageModelApi,
+  options: LanguageModelCreateOptions,
+): AcquiredLanguageModel => {
+  const entry = getOrCreateEntry(api, options);
+  // Pin before trimming so a fresh entry can never evict itself when every
+  // other entry is pinned.
+  entry.inFlightCount += 1;
+  trim();
+  let released = false;
+  return {
+    session: entry.session,
+    done: () => {
+      if (released) return;
+      released = true;
+      entry.inFlightCount -= 1;
+      settleEntry(entry);
+    },
+  };
+};
+
+export interface LanguageModelSessionLease {
+  /** Settles with the underlying `create()` outcome. */
+  ready: Promise<void>;
+  /** Idempotent. The final release detaches and destroys once safe. */
+  release(): void;
+}
+
+/**
+ * Start (or join) base-session creation for the given options and hold a
+ * lease on the entry. Leases pin the entry against LRU eviction. The final
+ * release removes the entry from the cache and destroys the session as soon
+ * as no in-flight call uses it; released-before-ready sessions are destroyed
+ * when creation later succeeds.
+ */
+export const leaseLanguageModel = (
+  api: LanguageModelApi,
+  options: LanguageModelCreateOptions,
+): LanguageModelSessionLease => {
+  const entry = getOrCreateEntry(api, options);
+  // Pin before trimming so a fresh entry can never evict itself when every
+  // other entry is pinned.
+  entry.leaseCount += 1;
+  trim();
+  let released = false;
+  const ready = entry.session.then(() => undefined);
+  // Keep unobserved leases from surfacing unhandled rejections.
+  ready.catch(() => {});
+  return {
+    ready,
+    release: () => {
+      if (released) return;
+      released = true;
+      entry.leaseCount -= 1;
+      if (entry.leaseCount > 0) return;
+      detachEntry(entry);
+      settleEntry(entry);
+    },
+  };
+};
+
+/**
+ * Internal: remove one create-options entry from the warm-session cache
+ * without destroying it. `ask()` uses this when the base turns out not to
+ * support `clone()`; the entry's own pin drain then destroys the instance.
+ */
 export const dropCachedLanguageModel = (
   options: LanguageModelCreateOptions,
 ): void => {
-  sessionCache.delete(JSON.stringify(options));
+  const entry = sessionCache.get(JSON.stringify(options));
+  if (!entry) return;
+  detachEntry(entry);
 };
 
 export const markLanguageModelCloneUnavailable = (

--- a/packages/prompt/src/index.test.ts
+++ b/packages/prompt/src/index.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   __clearSessionCacheForTests,
-  __configureCacheForTests,
+  configureLanguageModelCache,
 } from "./api.js";
 import {
   ask,
@@ -618,7 +618,7 @@ describe("ask", () => {
   });
 
   it("bounds remembered no-clone create-option shapes", async () => {
-    __configureCacheForTests(1);
+    configureLanguageModelCache({ max: 1 });
     const fake = installFakeLanguageModel({
       sessionFactory: () => ({
         prompt: vi.fn(async () => "reply"),

--- a/packages/prompt/src/index.ts
+++ b/packages/prompt/src/index.ts
@@ -9,11 +9,15 @@
  */
 
 import {
+  acquireLanguageModel,
+  type ConfigureLanguageModelCacheOptions,
   type CreateMonitor,
   checkAvailability,
+  clearLanguageModelSession,
+  clearLanguageModelSessions,
+  configureLanguageModelCache,
   dropCachedLanguageModel,
   getLanguageModelApi,
-  getOrCreateLanguageModel,
   isAvailable,
   isLanguageModelCloneUnavailable,
   type LanguageModelApi,
@@ -30,6 +34,7 @@ import {
   type LanguageModelPromptOptions,
   type LanguageModelSamplingMode,
   type LanguageModelTool,
+  leaseLanguageModel,
   markLanguageModelCloneUnavailable,
 } from "./api.js";
 import {
@@ -56,6 +61,7 @@ import {
 
 export type {
   CacheOption,
+  ConfigureLanguageModelCacheOptions,
   CreateMonitor,
   CreateSessionOptions,
   DefaultCacheKeyInput,
@@ -78,6 +84,9 @@ export type {
 };
 export {
   checkAvailability,
+  clearLanguageModelSession,
+  clearLanguageModelSessions,
+  configureLanguageModelCache,
   createSession,
   DEFAULT_CACHE_TTL_MS,
   isAvailable,
@@ -161,13 +170,146 @@ export interface AskResult {
   cached: boolean;
 }
 
-const destroyedFallbackBases = new WeakSet<LanguageModelInstance>();
-
 const wrapCreateError = (err: unknown): PromptUnavailableError => {
   const message = (err as Error)?.message ?? String(err);
   return new PromptUnavailableError(
     `LanguageModel.create() failed: ${message}`,
   );
+};
+
+/**
+ * Session-affecting subset of `AskOptions`. `prepareLanguageModel` and
+ * `ask` derive the same native create options from these fields, so a
+ * prepared base session is reused by the matching call.
+ */
+export type PrepareLanguageModelOptions = Pick<
+  AskOptions,
+  | "systemPrompt"
+  | "samplingMode"
+  | "temperature"
+  | "topK"
+  | "language"
+  | "supportedLanguages"
+  | "expectedInputs"
+  | "expectedOutputs"
+  | "tools"
+  | "monitor"
+>;
+
+interface BaseSessionConfig {
+  createOptions: LanguageModelCreateOptions;
+  effectiveLanguageHint: string | undefined;
+}
+
+/**
+ * Single source of the option-to-base-session mapping. The session cache keys
+ * by `createOptions`, so `ask` and `prepareLanguageModel` must both go
+ * through this derivation.
+ */
+const resolveBaseSessionConfig = (
+  options: PrepareLanguageModelOptions,
+): BaseSessionConfig => {
+  const langHints = buildLangHints(
+    options.language,
+    options.supportedLanguages,
+  );
+  const [languageHintedInput] = options.expectedInputs
+    ? []
+    : (langHints.expectedInputs?.[0]?.languages ?? []);
+  const [languageHintedOutput] = options.expectedOutputs
+    ? []
+    : (langHints.expectedOutputs?.[0]?.languages ?? []);
+  // Mirror buildLangHints() exactly: supportedLanguages are intentionally not
+  // normalized in the cache key unless they produce runtime language hints.
+  const effectiveLanguageHint = languageHintedInput ?? languageHintedOutput;
+
+  const initialPrompts: LanguageModelMessage[] = options.systemPrompt
+    ? [{ role: "system", content: options.systemPrompt }]
+    : [];
+
+  const createOptions: LanguageModelCreateOptions = {
+    ...(initialPrompts.length > 0 ? { initialPrompts } : {}),
+    ...(options.samplingMode !== undefined
+      ? { samplingMode: options.samplingMode }
+      : {}),
+    ...(options.temperature !== undefined
+      ? { temperature: options.temperature }
+      : {}),
+    ...(options.topK !== undefined ? { topK: options.topK } : {}),
+    ...(options.expectedInputs
+      ? { expectedInputs: options.expectedInputs }
+      : langHints.expectedInputs
+        ? { expectedInputs: langHints.expectedInputs }
+        : {}),
+    ...(options.expectedOutputs
+      ? { expectedOutputs: options.expectedOutputs }
+      : langHints.expectedOutputs
+        ? { expectedOutputs: langHints.expectedOutputs }
+        : {}),
+    ...(options.tools ? { tools: options.tools } : {}),
+    ...(options.monitor ? { monitor: options.monitor } : {}),
+  };
+
+  return { createOptions, effectiveLanguageHint };
+};
+
+export interface LanguageModelLease {
+  /**
+   * Resolves when the native base session is created. Rejects with
+   * `PromptUnavailableError` when the API is missing or creation fails.
+   */
+  ready: Promise<void>;
+  /**
+   * Idempotent. The final release destroys the base session once no other
+   * lease or in-flight call uses it.
+   */
+  release(): void;
+}
+
+/**
+ * Start base-session creation as soon as user intent is clear, before the
+ * input exists. The matching `ask()` call clones from the prepared base
+ * without a second create. Never throws synchronously; unavailability,
+ * invalid options, and creation failures reject `ready`. Failed preparations
+ * leave the cache so a later call can retry. `createSession()` is unaffected;
+ * it always creates a caller-owned session.
+ */
+export const prepareLanguageModel = (
+  options: PrepareLanguageModelOptions = {},
+): LanguageModelLease => {
+  const noopLease = (reason: unknown): LanguageModelLease => {
+    const ready = Promise.reject(reason);
+    // Keep unobserved leases from surfacing unhandled rejections.
+    ready.catch(() => {});
+    return { ready, release: () => {} };
+  };
+
+  const api = getLanguageModelApi();
+  if (!api?.create) {
+    return noopLease(
+      new PromptUnavailableError(
+        "Prompt API (LanguageModel) is not available in this environment.",
+      ),
+    );
+  }
+
+  let createOptions: LanguageModelCreateOptions;
+  try {
+    assertValidSamplingOptions(options);
+    createOptions = resolveBaseSessionConfig(options).createOptions;
+  } catch (err) {
+    // Same invalid-option contract as ask(), surfaced through ready so
+    // prepare never throws synchronously.
+    return noopLease(err);
+  }
+
+  const lease = leaseLanguageModel(api, createOptions);
+  const ready = lease.ready.catch((err) => {
+    if (err instanceof PromptAbortError) throw err;
+    throw wrapCreateError(err);
+  });
+  ready.catch(() => {});
+  return { ready, release: lease.release };
 };
 
 const createOneShotLanguageModel = async (
@@ -179,16 +321,6 @@ const createOneShotLanguageModel = async (
   } catch (err) {
     if (err instanceof PromptAbortError) throw err;
     throw wrapCreateError(err);
-  }
-};
-
-const destroyFallbackBaseOnce = (session: LanguageModelInstance): void => {
-  if (destroyedFallbackBases.has(session)) return;
-  destroyedFallbackBases.add(session);
-  try {
-    session.destroy?.();
-  } catch {
-    // best-effort; unused no-clone probes should never mask prompt results.
   }
 };
 
@@ -217,19 +349,8 @@ export const ask = async (options: AskOptions): Promise<AskResult> => {
 
   assertValidSamplingOptions(options);
 
-  const langHints = buildLangHints(
-    options.language,
-    options.supportedLanguages,
-  );
-  const [languageHintedInput] = options.expectedInputs
-    ? []
-    : (langHints.expectedInputs?.[0]?.languages ?? []);
-  const [languageHintedOutput] = options.expectedOutputs
-    ? []
-    : (langHints.expectedOutputs?.[0]?.languages ?? []);
-  // Mirror buildLangHints() exactly: supportedLanguages are intentionally not
-  // normalized in the cache key unless they produce runtime language hints.
-  const effectiveLanguageHint = languageHintedInput ?? languageHintedOutput;
+  const { createOptions: baseCreateOptions, effectiveLanguageHint } =
+    resolveBaseSessionConfig(options);
   const cache = resolveCache(options.cache, options.cacheTtl);
   const cacheKey =
     options.cacheKey ??
@@ -251,33 +372,6 @@ export const ask = async (options: AskOptions): Promise<AskResult> => {
     const cached = cache.get(cacheKey);
     if (cached) return { output: cached, cached: true };
   }
-
-  const initialPrompts: LanguageModelMessage[] = options.systemPrompt
-    ? [{ role: "system", content: options.systemPrompt }]
-    : [];
-
-  const baseCreateOptions: LanguageModelCreateOptions = {
-    ...(initialPrompts.length > 0 ? { initialPrompts } : {}),
-    ...(options.samplingMode !== undefined
-      ? { samplingMode: options.samplingMode }
-      : {}),
-    ...(options.temperature !== undefined
-      ? { temperature: options.temperature }
-      : {}),
-    ...(options.topK !== undefined ? { topK: options.topK } : {}),
-    ...(options.expectedInputs
-      ? { expectedInputs: options.expectedInputs }
-      : langHints.expectedInputs
-        ? { expectedInputs: langHints.expectedInputs }
-        : {}),
-    ...(options.expectedOutputs
-      ? { expectedOutputs: options.expectedOutputs }
-      : langHints.expectedOutputs
-        ? { expectedOutputs: langHints.expectedOutputs }
-        : {}),
-    ...(options.tools ? { tools: options.tools } : {}),
-    ...(options.monitor ? { monitor: options.monitor } : {}),
-  };
 
   const availability = await api
     .availability({
@@ -309,31 +403,35 @@ export const ask = async (options: AskOptions): Promise<AskResult> => {
     if (isLanguageModelCloneUnavailable(baseCreateOptions)) {
       session = await createOneShotLanguageModel(api, baseCreateOptions);
     } else {
-      const baseSessionPromise = getOrCreateLanguageModel(
-        api,
-        baseCreateOptions,
-      );
-
-      // Wrap session-create failures with context so consumers can branch on
-      // a single typed error instead of parsing browser-specific messages.
-      let baseSession: LanguageModelInstance;
+      // Pin the base entry while creating and cloning so a concurrent final
+      // lease release or clear cannot destroy it mid-use.
+      const acquired = acquireLanguageModel(api, baseCreateOptions);
       try {
-        baseSession = await baseSessionPromise;
-      } catch (err) {
-        if (err instanceof PromptAbortError) throw err;
-        throw wrapCreateError(err);
-      }
-      if (options.signal?.aborted) throw new PromptAbortError();
+        // Wrap session-create failures with context so consumers can branch
+        // on a single typed error instead of parsing browser-specific
+        // messages.
+        let baseSession: LanguageModelInstance;
+        try {
+          baseSession = await acquired.session;
+        } catch (err) {
+          if (err instanceof PromptAbortError) throw err;
+          throw wrapCreateError(err);
+        }
+        if (options.signal?.aborted) throw new PromptAbortError();
 
-      if (typeof baseSession.clone !== "function") {
-        markLanguageModelCloneUnavailable(baseCreateOptions);
-        dropCachedLanguageModel(baseCreateOptions);
-        destroyFallbackBaseOnce(baseSession);
-        session = await createOneShotLanguageModel(api, baseCreateOptions);
-      } else {
-        session = await baseSession.clone(
-          options.signal ? { signal: options.signal } : undefined,
-        );
+        if (typeof baseSession.clone !== "function") {
+          markLanguageModelCloneUnavailable(baseCreateOptions);
+          // Detach the no-clone base from the cache; the pin drain in the
+          // finally below destroys it exactly once.
+          dropCachedLanguageModel(baseCreateOptions);
+          session = await createOneShotLanguageModel(api, baseCreateOptions);
+        } else {
+          session = await baseSession.clone(
+            options.signal ? { signal: options.signal } : undefined,
+          );
+        }
+      } finally {
+        acquired.done();
       }
     }
     if (options.signal?.aborted) throw new PromptAbortError();

--- a/packages/prompt/src/index.ts
+++ b/packages/prompt/src/index.ts
@@ -181,6 +181,7 @@ const wrapCreateError = (err: unknown): PromptUnavailableError => {
  * Session-affecting subset of `AskOptions`. `prepareLanguageModel` and
  * `ask` derive the same native create options from these fields, so a
  * prepared base session is reused by the matching call.
+ * `monitor` observes creation only; it never affects the cache key.
  */
 export type PrepareLanguageModelOptions = Pick<
   AskOptions,
@@ -202,8 +203,9 @@ interface BaseSessionConfig {
 }
 
 /**
- * Single source of the option-to-base-session mapping. The session cache keys
- * by `createOptions`, so `ask` and `prepareLanguageModel` must both go
+ * Single source of the option-to-base-session mapping. The session cache key derives
+ * from the stable fields of `createOptions` (`monitor` never fragments
+ * reuse), so `ask` and `prepareLanguageModel` must both go
  * through this derivation.
  */
 const resolveBaseSessionConfig = (

--- a/packages/prompt/src/prepare.test.ts
+++ b/packages/prompt/src/prepare.test.ts
@@ -243,4 +243,17 @@ describe("prepareLanguageModel", () => {
     session.destroy();
     lease.release();
   });
+
+  it("re-trims the cache when the last in-flight pin drops", async () => {
+    const { api, bases } = installFakeApi();
+    configureLanguageModelCache({ max: 0 });
+
+    await ask({ input: "hello", systemPrompt: "sys" });
+    await tick();
+    expect(bases[0]?.destroy).toHaveBeenCalledTimes(1);
+
+    // Nothing stayed cached, so the same call creates a fresh session.
+    await ask({ input: "hello", systemPrompt: "sys" });
+    expect(api.create).toHaveBeenCalledTimes(2);
+  });
 });

--- a/packages/prompt/src/prepare.test.ts
+++ b/packages/prompt/src/prepare.test.ts
@@ -1,0 +1,246 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  __clearSessionCacheForTests,
+  configureLanguageModelCache,
+} from "./api.js";
+import {
+  ask,
+  clearLanguageModelSessions,
+  createSession,
+  PromptUnavailableError,
+  prepareLanguageModel,
+} from "./index.js";
+
+interface FakeClone {
+  prompt: ReturnType<typeof vi.fn>;
+  destroy: ReturnType<typeof vi.fn>;
+}
+
+interface FakeBase {
+  prompt: ReturnType<typeof vi.fn>;
+  clone: ReturnType<typeof vi.fn>;
+  destroy: ReturnType<typeof vi.fn>;
+}
+
+const makeClone = (): FakeClone => ({
+  prompt: vi.fn(async () => "reply"),
+  destroy: vi.fn(),
+});
+
+const makeBase = (): FakeBase => ({
+  prompt: vi.fn(async () => "reply"),
+  clone: vi.fn(async () => makeClone()),
+  destroy: vi.fn(),
+});
+
+const installFakeApi = () => {
+  const bases: FakeBase[] = [];
+  const api = {
+    availability: vi.fn(async () => "available" as const),
+    create: vi.fn(async () => {
+      const base = makeBase();
+      bases.push(base);
+      return base;
+    }),
+  };
+  (globalThis as { LanguageModel?: unknown }).LanguageModel = api;
+  return { api, bases };
+};
+
+const tick = () => new Promise<void>((resolve) => setTimeout(resolve, 0));
+
+beforeEach(() => {
+  __clearSessionCacheForTests();
+});
+
+afterEach(() => {
+  (globalThis as { LanguageModel?: unknown }).LanguageModel = undefined;
+});
+
+describe("prepareLanguageModel", () => {
+  it("starts creation immediately and the matching ask clones the warm base", async () => {
+    const { api, bases } = installFakeApi();
+    const lease = prepareLanguageModel({ systemPrompt: "sys" });
+    expect(api.create).toHaveBeenCalledTimes(1);
+    await lease.ready;
+
+    const result = await ask({ input: "hello", systemPrompt: "sys" });
+    expect(result.output).toBe("reply");
+    expect(api.create).toHaveBeenCalledTimes(1);
+    expect(bases[0]?.clone).toHaveBeenCalledTimes(1);
+    lease.release();
+  });
+
+  it("never throws when the API is missing; ready rejects instead", async () => {
+    const lease = prepareLanguageModel({ systemPrompt: "sys" });
+    await expect(lease.ready).rejects.toBeInstanceOf(PromptUnavailableError);
+    expect(() => lease.release()).not.toThrow();
+  });
+
+  it("rejects ready instead of throwing on invalid sampling options", async () => {
+    installFakeApi();
+    const lease = prepareLanguageModel({
+      samplingMode: "balanced",
+      temperature: 0.5,
+    });
+    await expect(lease.ready).rejects.toBeInstanceOf(Error);
+    expect(() => lease.release()).not.toThrow();
+  });
+
+  it("shares one base between concurrent leases and destroys exactly once", async () => {
+    const { api, bases } = installFakeApi();
+    const first = prepareLanguageModel({ systemPrompt: "sys" });
+    const second = prepareLanguageModel({ systemPrompt: "sys" });
+    expect(api.create).toHaveBeenCalledTimes(1);
+    await Promise.all([first.ready, second.ready]);
+
+    first.release();
+    first.release();
+    await tick();
+    expect(bases[0]?.destroy).not.toHaveBeenCalled();
+
+    second.release();
+    second.release();
+    await tick();
+    expect(bases[0]?.destroy).toHaveBeenCalledTimes(1);
+  });
+
+  it("release before creation settles destroys the base once created", async () => {
+    const { api } = installFakeApi();
+    let resolveCreate: (base: FakeBase) => void = () => {};
+    const base = makeBase();
+    api.create.mockImplementationOnce(
+      () =>
+        new Promise<FakeBase>((resolve) => {
+          resolveCreate = resolve;
+        }),
+    );
+
+    const lease = prepareLanguageModel({ systemPrompt: "sys" });
+    lease.release();
+    await tick();
+    expect(base.destroy).not.toHaveBeenCalled();
+
+    resolveCreate(base);
+    await tick();
+    expect(base.destroy).toHaveBeenCalledTimes(1);
+
+    // The released entry left the cache, so preparing again creates anew.
+    const retry = prepareLanguageModel({ systemPrompt: "sys" });
+    expect(api.create).toHaveBeenCalledTimes(2);
+    await retry.ready;
+    retry.release();
+  });
+
+  it("creation failure rejects ready, evicts the entry, and allows retry", async () => {
+    const { api } = installFakeApi();
+    api.create.mockRejectedValueOnce(new Error("no space"));
+
+    const failed = prepareLanguageModel({ systemPrompt: "sys" });
+    await expect(failed.ready).rejects.toBeInstanceOf(PromptUnavailableError);
+    failed.release();
+
+    const retry = prepareLanguageModel({ systemPrompt: "sys" });
+    expect(api.create).toHaveBeenCalledTimes(2);
+    await expect(retry.ready).resolves.toBeUndefined();
+    retry.release();
+  });
+
+  it("defers base destruction while ask is cloning from it", async () => {
+    const { bases } = installFakeApi();
+    const lease = prepareLanguageModel({ systemPrompt: "sys" });
+    await lease.ready;
+
+    const base = bases[0];
+    if (!base) throw new Error("expected a created base");
+    let resolveClone: (clone: FakeClone) => void = () => {};
+    base.clone.mockImplementationOnce(
+      () =>
+        new Promise<FakeClone>((resolve) => {
+          resolveClone = resolve;
+        }),
+    );
+
+    const running = ask({ input: "hello", systemPrompt: "sys" });
+    await tick();
+    lease.release();
+    await tick();
+    expect(base.destroy).not.toHaveBeenCalled();
+
+    resolveClone(makeClone());
+    await expect(running).resolves.toEqual({ output: "reply", cached: false });
+    await tick();
+    expect(base.destroy).toHaveBeenCalledTimes(1);
+  });
+
+  it("pins leased bases against LRU eviction", async () => {
+    const { bases } = installFakeApi();
+    configureLanguageModelCache({ max: 1 });
+
+    const lease = prepareLanguageModel({ systemPrompt: "keep" });
+    await lease.ready;
+    await ask({ input: "hello", systemPrompt: "evictable" });
+    await tick();
+
+    // Inserting a third entry trims to max; the leased base survives and the
+    // unpinned base is evicted.
+    const third = prepareLanguageModel({ systemPrompt: "third" });
+    await third.ready;
+    await tick();
+    expect(bases[0]?.destroy).not.toHaveBeenCalled();
+    expect(bases[1]?.destroy).toHaveBeenCalledTimes(1);
+
+    lease.release();
+    third.release();
+  });
+
+  it("isolates leases per option key", async () => {
+    const { api, bases } = installFakeApi();
+    const kept = prepareLanguageModel({ systemPrompt: "one" });
+    await kept.ready;
+
+    await ask({ input: "hello", systemPrompt: "two" });
+    expect(api.create).toHaveBeenCalledTimes(2);
+
+    kept.release();
+    await tick();
+    expect(bases[0]?.destroy).toHaveBeenCalledTimes(1);
+    expect(bases[1]?.destroy).not.toHaveBeenCalled();
+
+    // The other configuration stays cached and reusable.
+    await ask({ input: "again", systemPrompt: "two" });
+    expect(api.create).toHaveBeenCalledTimes(2);
+  });
+
+  it("clear detaches leased bases and destroys them on final release", async () => {
+    const { api, bases } = installFakeApi();
+    const lease = prepareLanguageModel({ systemPrompt: "sys" });
+    await lease.ready;
+
+    clearLanguageModelSessions();
+    await tick();
+    expect(bases[0]?.destroy).not.toHaveBeenCalled();
+
+    // The detached base no longer serves new calls.
+    await ask({ input: "hello", systemPrompt: "sys" });
+    expect(api.create).toHaveBeenCalledTimes(2);
+
+    lease.release();
+    await tick();
+    expect(bases[0]?.destroy).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not affect createSession, which stays caller-owned", async () => {
+    const { api } = installFakeApi();
+    const lease = prepareLanguageModel({});
+    await lease.ready;
+
+    // createSession bypasses the warm cache by design.
+    const session = createSession();
+    await session.send("hello");
+    expect(api.create).toHaveBeenCalledTimes(2);
+
+    session.destroy();
+    lease.release();
+  });
+});

--- a/packages/proofreader/README.md
+++ b/packages/proofreader/README.md
@@ -143,7 +143,7 @@ proofreaderModel.release();
 - Failed creation evicts the entry, so a later prepare retries.
 - Sessions with active leases never evict from the LRU cache.
 
-Reuse requires the same session-affecting options as the `proofread` call. `PrepareProofreaderOptions` covers `expectedInputLanguages` and `monitor`.
+Reuse requires the same session-affecting options as the `proofread` call. `PrepareProofreaderOptions` covers `expectedInputLanguages`. `monitor` observes creation only and never affects reuse.
 
 ## Result caching
 

--- a/packages/proofreader/README.md
+++ b/packages/proofreader/README.md
@@ -108,7 +108,42 @@ Drop every cached proofreader session. Sessions live for the tab lifetime by def
 
 ### Session cache controls
 
-`configureProofreaderCache({ max })` bounds the internal warm `Proofreader` session cache (default `8`). `clearProofreaderSessions()` drops every warm session, and `clearProofreaderSession({ expectedInputLanguages })` drops one matching proofreader configuration.
+`configureProofreaderCache({ max })` bounds the internal warm `Proofreader` session cache (default `8`). `clearProofreaderSessions()` drops every warm session, and `clearProofreaderSession({ expectedInputLanguages })` drops one matching proofreader configuration. Clearing detaches sessions pinned by a lease or an in-flight call and destroys them when the last pin drops.
+
+### Prepare and release
+
+`prepareProofreader(options?)` starts native session creation when user intent is clear, before the input exists. It returns a `ProofreaderLease`:
+
+```ts
+interface ProofreaderLease {
+  ready: Promise<void>; // settles when native creation settles
+  release(): void;      // idempotent
+}
+```
+
+```ts
+import { prepareProofreader, proofread } from "@web-ai-sdk/proofreader";
+
+// User focused the editor; warm the session now.
+const proofreaderModel = prepareProofreader({ expectedInputLanguages: ["en"] });
+
+// The matching call reuses the prepared session with no second create.
+const result = await proofread({
+  input: "I seen him yesterday at the store.",
+  expectedInputLanguages: ["en"],
+});
+
+// User left the editor.
+proofreaderModel.release();
+```
+
+- `prepareProofreader` never throws synchronously. Unavailability and creation failure reject `ready` with `ProofreaderUnavailableError`.
+- `release()` is idempotent. The final release destroys the session once no other lease or in-flight call uses it.
+- Releasing before creation settles destroys the session after creation succeeds.
+- Failed creation evicts the entry, so a later prepare retries.
+- Sessions with active leases never evict from the LRU cache.
+
+Reuse requires the same session-affecting options as the `proofread` call. `PrepareProofreaderOptions` covers `expectedInputLanguages` and `monitor`.
 
 ## Result caching
 

--- a/packages/proofreader/src/api.ts
+++ b/packages/proofreader/src/api.ts
@@ -103,10 +103,26 @@ interface CacheConfig {
 
 const cacheConfig: CacheConfig = { max: DEFAULT_MAX_CACHED_SESSIONS };
 
+interface SessionEntry {
+  key: string;
+  session: Promise<ProofreaderInstance>;
+  /** Active prepare leases. Leased entries never evict. */
+  leaseCount: number;
+  /** Operations currently running inference on this session. */
+  inFlightCount: number;
+  /** Still reachable through `sessionCache`. */
+  inMap: boolean;
+  /** Destruction already scheduled; guards double-destroy. */
+  destroyed: boolean;
+}
+
 // Map iteration order is insertion order, which lets us use it as an LRU:
 // on hit we re-insert to bump recency, and on overflow we evict the
 // oldest (first) entry.
-const sessionCache = new Map<string, Promise<ProofreaderInstance>>();
+const sessionCache = new Map<string, SessionEntry>();
+
+const isPinned = (entry: SessionEntry): boolean =>
+  entry.leaseCount > 0 || entry.inFlightCount > 0;
 
 const normalizeCacheMax = (max: number): number =>
   Number.isFinite(max) ? Math.max(0, Math.floor(max)) : 0;
@@ -130,27 +146,45 @@ export const configureProofreaderCache = (
   trim();
 };
 
-const destroySession = (entry: Promise<ProofreaderInstance>): void => {
-  entry
-    .then((session) => {
+const destroySession = (session: Promise<ProofreaderInstance>): void => {
+  session
+    .then((instance) => {
       try {
-        session.destroy?.();
+        instance.destroy?.();
       } catch {
         // best-effort; the spec doesn't require destroy to be infallible.
       }
     })
     .catch(() => {
-      // session never resolved; nothing to destroy.
+      // session never resolved (e.g. create() rejected); nothing to destroy.
     });
 };
 
+const detachEntry = (entry: SessionEntry): void => {
+  if (!entry.inMap) return;
+  entry.inMap = false;
+  sessionCache.delete(entry.key);
+};
+
+/**
+ * Destroy a detached entry once nothing pins it. Pinned entries are settled
+ * again when their last lease releases or their last in-flight call ends.
+ */
+const settleEntry = (entry: SessionEntry): void => {
+  if (entry.inMap || entry.destroyed || isPinned(entry)) return;
+  entry.destroyed = true;
+  destroySession(entry.session);
+};
+
 const trim = (): void => {
-  while (sessionCache.size > cacheConfig.max) {
-    const oldestKey = sessionCache.keys().next().value;
-    if (oldestKey === undefined) return;
-    const evicted = sessionCache.get(oldestKey);
-    sessionCache.delete(oldestKey);
-    if (evicted) destroySession(evicted);
+  if (sessionCache.size <= cacheConfig.max) return;
+  for (const entry of [...sessionCache.values()]) {
+    if (sessionCache.size <= cacheConfig.max) return;
+    // Leased or in-flight entries never evict, so the cache may temporarily
+    // exceed `max` while they stay pinned.
+    if (isPinned(entry)) continue;
+    detachEntry(entry);
+    settleEntry(entry);
   }
 };
 
@@ -166,50 +200,141 @@ const cacheKeyFor = (options: ProofreaderAvailabilityOptions): string =>
   });
 
 /**
- * Get or create a `Proofreader` session for the given options. Sessions live
- * for the tab lifetime so consecutive same-config calls skip the cold start.
- * On `create()` failure the cache slot is purged so the next call retries
- * instead of returning a poisoned promise.
+ * Drop every cached proofreader session. Sessions live for the tab lifetime
+ * by default; call this to free them eagerly when navigating away from a
+ * feature that won't be revisited. Sessions pinned by a lease or an in-flight
+ * call leave the cache now and are destroyed once the last pin drops.
  */
-export const getOrCreateProofreader = (
-  api: ProofreaderApi,
-  options: ProofreaderCreateOptions,
-): Promise<ProofreaderInstance> => {
-  // Drop `signal` and `monitor` from the cache key; they're per-call
-  // ephemera that shouldn't fragment session reuse.
-  const key = cacheKeyFor(options);
-  let session = sessionCache.get(key);
-  if (session) {
-    sessionCache.delete(key);
-    sessionCache.set(key, session);
-    return session;
-  }
-  session = api.create(options).catch((err) => {
-    sessionCache.delete(key);
-    throw err;
-  });
-  sessionCache.set(key, session);
-  trim();
-  return session;
-};
-
-/** Drop every cached proofreader session. */
 export const clearProofreaderSessions = (): void => {
-  for (const entry of sessionCache.values()) {
-    destroySession(entry);
+  for (const entry of [...sessionCache.values()]) {
+    detachEntry(entry);
+    settleEntry(entry);
   }
-  sessionCache.clear();
 };
 
-/** Drop the cached proofreader session whose create-options match `options`. */
+/**
+ * Drop the cached proofreader session whose create-options match `options`.
+ * A session pinned by a lease or an in-flight call leaves the cache now and
+ * is destroyed once the last pin drops.
+ */
 export const clearProofreaderSession = (
   options: ProofreaderAvailabilityOptions,
 ): void => {
-  const key = cacheKeyFor(options);
-  const entry = sessionCache.get(key);
+  const entry = sessionCache.get(cacheKeyFor(options));
   if (!entry) return;
-  sessionCache.delete(key);
-  destroySession(entry);
+  detachEntry(entry);
+  settleEntry(entry);
+};
+
+/**
+ * Get or create the cache entry for the given options. Sessions live for the
+ * tab lifetime so consecutive same-config calls skip the cold start. The key
+ * drops `signal` and `monitor`; they're per-call ephemera that shouldn't
+ * fragment session reuse. On `create()` failure the cache slot is purged so
+ * the next call retries instead of returning a poisoned promise.
+ */
+const getOrCreateEntry = (
+  api: ProofreaderApi,
+  options: ProofreaderCreateOptions,
+): SessionEntry => {
+  const key = cacheKeyFor(options);
+  const existing = sessionCache.get(key);
+  if (existing) {
+    // Bump recency: delete + reinsert so this entry moves to the end of the
+    // LRU order.
+    sessionCache.delete(key);
+    sessionCache.set(key, existing);
+    return existing;
+  }
+  const entry: SessionEntry = {
+    key,
+    session: api.create(options).catch((err) => {
+      detachEntry(entry);
+      throw err;
+    }),
+    leaseCount: 0,
+    inFlightCount: 0,
+    inMap: true,
+    destroyed: false,
+  };
+  // A prepare-only caller may never observe the session promise; keep the
+  // stored branch handled so failed creation cannot surface as an unhandled
+  // rejection.
+  entry.session.catch(() => {});
+  sessionCache.set(key, entry);
+  return entry;
+};
+
+export interface AcquiredProofreader {
+  session: Promise<ProofreaderInstance>;
+  /** Release the in-flight pin. Idempotent. */
+  done(): void;
+}
+
+/**
+ * Get or create a `Proofreader` session and pin it for one operation. The pin
+ * defers destruction (final lease release, clear, eviction) until `done()`
+ * runs, so in-flight inference can never lose its session.
+ */
+export const acquireProofreader = (
+  api: ProofreaderApi,
+  options: ProofreaderCreateOptions,
+): AcquiredProofreader => {
+  const entry = getOrCreateEntry(api, options);
+  // Pin before trimming so a fresh entry can never evict itself when every
+  // other entry is pinned.
+  entry.inFlightCount += 1;
+  trim();
+  let released = false;
+  return {
+    session: entry.session,
+    done: () => {
+      if (released) return;
+      released = true;
+      entry.inFlightCount -= 1;
+      settleEntry(entry);
+    },
+  };
+};
+
+export interface ProofreaderSessionLease {
+  /** Settles with the underlying `create()` outcome. */
+  ready: Promise<void>;
+  /** Idempotent. The final release detaches and destroys once safe. */
+  release(): void;
+}
+
+/**
+ * Start (or join) session creation for the given options and hold a lease on
+ * the entry. Leases pin the entry against LRU eviction. The final release
+ * removes the entry from the cache and destroys the session as soon as no
+ * in-flight call uses it; released-before-ready sessions are destroyed when
+ * creation later succeeds.
+ */
+export const leaseProofreader = (
+  api: ProofreaderApi,
+  options: ProofreaderCreateOptions,
+): ProofreaderSessionLease => {
+  const entry = getOrCreateEntry(api, options);
+  // Pin before trimming so a fresh entry can never evict itself when every
+  // other entry is pinned.
+  entry.leaseCount += 1;
+  trim();
+  let released = false;
+  const ready = entry.session.then(() => undefined);
+  // Keep unobserved leases from surfacing unhandled rejections.
+  ready.catch(() => {});
+  return {
+    ready,
+    release: () => {
+      if (released) return;
+      released = true;
+      entry.leaseCount -= 1;
+      if (entry.leaseCount > 0) return;
+      detachEntry(entry);
+      settleEntry(entry);
+    },
+  };
 };
 
 /** Test-only escape hatch; drop every cached session. */

--- a/packages/proofreader/src/api.ts
+++ b/packages/proofreader/src/api.ts
@@ -293,6 +293,9 @@ export const acquireProofreader = (
       released = true;
       entry.inFlightCount -= 1;
       settleEntry(entry);
+      // The dropped pin may leave the cache over its cap; re-trim now
+      // instead of waiting for the next create or configure call.
+      trim();
     },
   };
 };

--- a/packages/proofreader/src/index.ts
+++ b/packages/proofreader/src/index.ts
@@ -111,6 +111,7 @@ class ProofreaderAbortError extends Error {
  * Session-affecting subset of `ProofreadOptions`. `prepareProofreader` and
  * `proofread` derive the same native create options from these fields, so a
  * prepared session is reused by the matching call.
+ * `monitor` observes creation only; it never affects the cache key.
  */
 export type PrepareProofreaderOptions = Pick<
   ProofreadOptions,
@@ -123,8 +124,9 @@ interface SessionConfig {
 }
 
 /**
- * Single source of the option-to-session mapping. The session cache keys by
- * `createOptions`, so `proofread` and `prepareProofreader` must both go
+ * Single source of the option-to-session mapping. The session cache key derives from
+ * the stable fields of `createOptions` (`monitor` never fragments reuse),
+ * so `proofread` and `prepareProofreader` must both go
  * through this derivation.
  */
 const resolveSessionConfig = (

--- a/packages/proofreader/src/index.ts
+++ b/packages/proofreader/src/index.ts
@@ -9,10 +9,11 @@
  */
 
 import {
+  acquireProofreader,
   type ConfigureProofreaderCacheOptions,
   type CreateMonitor,
-  getOrCreateProofreader,
   getProofreaderApi,
+  leaseProofreader,
   type ProofreadCorrection,
   type ProofreaderApi,
   type ProofreaderAvailability,
@@ -33,16 +34,10 @@ export {
   clearProofreaderSession,
   clearProofreaderSessions,
   configureProofreaderCache,
-  getOrCreateProofreader,
-  getProofreaderApi,
   isAvailable,
 } from "./api.js";
 
-export {
-  DEFAULT_CACHE_TTL_MS,
-  defaultCacheKey,
-  resolveCache,
-} from "./cache.js";
+export { DEFAULT_CACHE_TTL_MS } from "./cache.js";
 
 export type {
   CacheOption,
@@ -113,6 +108,85 @@ class ProofreaderAbortError extends Error {
 }
 
 /**
+ * Session-affecting subset of `ProofreadOptions`. `prepareProofreader` and
+ * `proofread` derive the same native create options from these fields, so a
+ * prepared session is reused by the matching call.
+ */
+export type PrepareProofreaderOptions = Pick<
+  ProofreadOptions,
+  "expectedInputLanguages" | "monitor"
+>;
+
+interface SessionConfig {
+  expectedInputLanguages: string[] | undefined;
+  createOptions: ProofreaderCreateOptions;
+}
+
+/**
+ * Single source of the option-to-session mapping. The session cache keys by
+ * `createOptions`, so `proofread` and `prepareProofreader` must both go
+ * through this derivation.
+ */
+const resolveSessionConfig = (
+  options: PrepareProofreaderOptions,
+): SessionConfig => {
+  const expectedInputLanguages = options.expectedInputLanguages
+    ? [...options.expectedInputLanguages]
+    : undefined;
+  const createOptions: ProofreaderCreateOptions = {
+    ...(expectedInputLanguages ? { expectedInputLanguages } : {}),
+    ...(options.monitor ? { monitor: options.monitor } : {}),
+  };
+  return { expectedInputLanguages, createOptions };
+};
+
+export interface ProofreaderLease {
+  /**
+   * Resolves when the native session is created. Rejects with
+   * `ProofreaderUnavailableError` when the API is missing or creation fails.
+   */
+  ready: Promise<void>;
+  /**
+   * Idempotent. The final release destroys the session once no other lease
+   * or in-flight call uses it.
+   */
+  release(): void;
+}
+
+/**
+ * Start native session creation as soon as user intent is clear, before the
+ * input exists. The matching `proofread` call reuses the prepared session
+ * without a second create. Never throws synchronously; unavailability and
+ * creation failures reject `ready`. Failed preparations leave the cache so a
+ * later call can retry.
+ */
+export const prepareProofreader = (
+  options: PrepareProofreaderOptions = {},
+): ProofreaderLease => {
+  const api = getProofreaderApi();
+  if (!api?.create) {
+    const ready = Promise.reject(
+      new ProofreaderUnavailableError(
+        "Proofreader API is not available in this environment.",
+      ),
+    );
+    // Keep unobserved leases from surfacing unhandled rejections.
+    ready.catch(() => {});
+    return { ready, release: () => {} };
+  }
+  const { createOptions } = resolveSessionConfig(options);
+  const lease = leaseProofreader(api, createOptions);
+  const ready = lease.ready.catch((err) => {
+    const message = (err as Error)?.message ?? String(err);
+    throw new ProofreaderUnavailableError(
+      `Proofreader.create() failed: ${message}`,
+    );
+  });
+  ready.catch(() => {});
+  return { ready, release: lease.release };
+};
+
+/**
  * Proofread a string for grammar, spelling, and punctuation. Returns the
  * corrected text plus the list of per-issue corrections. Returns
  * `{ output: null, ... }` for empty input. Throws
@@ -132,9 +206,8 @@ export const proofread = async (
   const text = options.input.trim();
   if (!text) return { output: null, cached: false };
 
-  const expectedInputLanguages = options.expectedInputLanguages
-    ? [...options.expectedInputLanguages]
-    : undefined;
+  const { expectedInputLanguages, createOptions } =
+    resolveSessionConfig(options);
 
   const cache = resolveCache(options.cache, options.cacheTtl);
   const cacheKey =
@@ -150,11 +223,6 @@ export const proofread = async (
     }
   }
 
-  const baseCreateOptions: ProofreaderCreateOptions = {
-    ...(expectedInputLanguages ? { expectedInputLanguages } : {}),
-    ...(options.monitor ? { monitor: options.monitor } : {}),
-  };
-
   const availability = await api
     .availability(
       expectedInputLanguages ? { expectedInputLanguages } : undefined,
@@ -165,30 +233,35 @@ export const proofread = async (
   }
   if (options.signal?.aborted) throw new ProofreaderAbortError();
 
-  const sessionPromise = getOrCreateProofreader(api, baseCreateOptions);
-
-  // Wrap session-create failures with context so consumers can branch on a
-  // single typed error instead of parsing browser-specific messages.
-  let proofreader: ProofreaderInstance;
+  // The pin defers destruction (lease release, clear, eviction) until this
+  // call finishes.
+  const acquired = acquireProofreader(api, createOptions);
   try {
-    proofreader = await sessionPromise;
-  } catch (err) {
-    if (err instanceof ProofreaderAbortError) throw err;
-    const message = (err as Error)?.message ?? String(err);
-    throw new ProofreaderUnavailableError(
-      `Proofreader.create() failed: ${message}`,
-    );
+    // Wrap session-create failures with context so consumers can branch on a
+    // single typed error instead of parsing browser-specific messages.
+    let proofreader: ProofreaderInstance;
+    try {
+      proofreader = await acquired.session;
+    } catch (err) {
+      if (err instanceof ProofreaderAbortError) throw err;
+      const message = (err as Error)?.message ?? String(err);
+      throw new ProofreaderUnavailableError(
+        `Proofreader.create() failed: ${message}`,
+      );
+    }
+    if (options.signal?.aborted) throw new ProofreaderAbortError();
+
+    const raw = await proofreader.proofread(text);
+    if (options.signal?.aborted) throw new ProofreaderAbortError();
+
+    const output: ProofreadOutput = {
+      correctedInput: raw.correctedInput ?? text,
+      corrections: Array.isArray(raw.corrections) ? raw.corrections : [],
+    };
+
+    if (cache) cache.set(cacheKey, JSON.stringify(output));
+    return { output, cached: false };
+  } finally {
+    acquired.done();
   }
-  if (options.signal?.aborted) throw new ProofreaderAbortError();
-
-  const raw = await proofreader.proofread(text);
-  if (options.signal?.aborted) throw new ProofreaderAbortError();
-
-  const output: ProofreadOutput = {
-    correctedInput: raw.correctedInput ?? text,
-    corrections: Array.isArray(raw.corrections) ? raw.corrections : [],
-  };
-
-  if (cache) cache.set(cacheKey, JSON.stringify(output));
-  return { output, cached: false };
 };

--- a/packages/proofreader/src/prepare.test.ts
+++ b/packages/proofreader/src/prepare.test.ts
@@ -1,0 +1,227 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  __clearSessionCacheForTests,
+  configureProofreaderCache,
+} from "./api.js";
+import {
+  clearProofreaderSessions,
+  ProofreaderUnavailableError,
+  prepareProofreader,
+  proofread,
+} from "./index.js";
+
+interface FakeProofreader {
+  proofread: ReturnType<typeof vi.fn>;
+  destroy: ReturnType<typeof vi.fn>;
+}
+
+const makeInstance = (): FakeProofreader => ({
+  proofread: vi.fn(async () => ({
+    correctedInput: "Fixed.",
+    corrections: [],
+  })),
+  destroy: vi.fn(),
+});
+
+const installFakeApi = () => {
+  const instances: FakeProofreader[] = [];
+  const api = {
+    availability: vi.fn(async () => "available" as const),
+    create: vi.fn(async () => {
+      const instance = makeInstance();
+      instances.push(instance);
+      return instance;
+    }),
+  };
+  (globalThis as { Proofreader?: unknown }).Proofreader = api;
+  return { api, instances };
+};
+
+const tick = () => new Promise<void>((resolve) => setTimeout(resolve, 0));
+
+beforeEach(() => {
+  __clearSessionCacheForTests();
+});
+
+afterEach(() => {
+  (globalThis as { Proofreader?: unknown }).Proofreader = undefined;
+});
+
+describe("prepareProofreader", () => {
+  it("starts creation immediately and the matching proofread reuses it", async () => {
+    const { api } = installFakeApi();
+    const lease = prepareProofreader({ expectedInputLanguages: ["en"] });
+    expect(api.create).toHaveBeenCalledTimes(1);
+    await lease.ready;
+
+    const result = await proofread({
+      input: "I has cat.",
+      expectedInputLanguages: ["en"],
+    });
+    expect(result.output?.correctedInput).toBe("Fixed.");
+    expect(api.create).toHaveBeenCalledTimes(1);
+    lease.release();
+  });
+
+  it("never throws when the API is missing; ready rejects instead", async () => {
+    const lease = prepareProofreader({ expectedInputLanguages: ["en"] });
+    await expect(lease.ready).rejects.toBeInstanceOf(
+      ProofreaderUnavailableError,
+    );
+    expect(() => lease.release()).not.toThrow();
+  });
+
+  it("shares one session between concurrent leases and destroys exactly once", async () => {
+    const { api, instances } = installFakeApi();
+    const first = prepareProofreader({ expectedInputLanguages: ["en"] });
+    const second = prepareProofreader({ expectedInputLanguages: ["en"] });
+    expect(api.create).toHaveBeenCalledTimes(1);
+    await Promise.all([first.ready, second.ready]);
+
+    first.release();
+    first.release();
+    await tick();
+    expect(instances[0]?.destroy).not.toHaveBeenCalled();
+
+    second.release();
+    second.release();
+    await tick();
+    expect(instances[0]?.destroy).toHaveBeenCalledTimes(1);
+  });
+
+  it("release before creation settles destroys the session once created", async () => {
+    const { api } = installFakeApi();
+    let resolveCreate: (instance: FakeProofreader) => void = () => {};
+    const instance = makeInstance();
+    api.create.mockImplementationOnce(
+      () =>
+        new Promise<FakeProofreader>((resolve) => {
+          resolveCreate = resolve;
+        }),
+    );
+
+    const lease = prepareProofreader({ expectedInputLanguages: ["en"] });
+    lease.release();
+    await tick();
+    expect(instance.destroy).not.toHaveBeenCalled();
+
+    resolveCreate(instance);
+    await tick();
+    expect(instance.destroy).toHaveBeenCalledTimes(1);
+
+    // The released entry left the cache, so preparing again creates anew.
+    const retry = prepareProofreader({ expectedInputLanguages: ["en"] });
+    expect(api.create).toHaveBeenCalledTimes(2);
+    await retry.ready;
+    retry.release();
+  });
+
+  it("creation failure rejects ready, evicts the entry, and allows retry", async () => {
+    const { api } = installFakeApi();
+    api.create.mockRejectedValueOnce(new Error("no space"));
+
+    const failed = prepareProofreader({ expectedInputLanguages: ["en"] });
+    await expect(failed.ready).rejects.toBeInstanceOf(
+      ProofreaderUnavailableError,
+    );
+    failed.release();
+
+    const retry = prepareProofreader({ expectedInputLanguages: ["en"] });
+    expect(api.create).toHaveBeenCalledTimes(2);
+    await expect(retry.ready).resolves.toBeUndefined();
+    retry.release();
+  });
+
+  it("defers destruction while inference is in flight", async () => {
+    const { instances } = installFakeApi();
+    const lease = prepareProofreader({ expectedInputLanguages: ["en"] });
+    await lease.ready;
+
+    const instance = instances[0];
+    if (!instance) throw new Error("expected a created instance");
+    let resolveProofread: (output: {
+      correctedInput: string;
+      corrections: never[];
+    }) => void = () => {};
+    instance.proofread.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveProofread = resolve;
+        }),
+    );
+
+    const running = proofread({
+      input: "I has cat.",
+      expectedInputLanguages: ["en"],
+    });
+    await tick();
+    lease.release();
+    await tick();
+    expect(instance.destroy).not.toHaveBeenCalled();
+
+    resolveProofread({ correctedInput: "Fixed.", corrections: [] });
+    await expect(running).resolves.toEqual({
+      output: { correctedInput: "Fixed.", corrections: [] },
+      cached: false,
+    });
+    await tick();
+    expect(instance.destroy).toHaveBeenCalledTimes(1);
+  });
+
+  it("pins leased entries against LRU eviction", async () => {
+    const { instances } = installFakeApi();
+    configureProofreaderCache({ max: 1 });
+
+    const lease = prepareProofreader({ expectedInputLanguages: ["en"] });
+    await lease.ready;
+    await proofread({ input: "Tengo gato.", expectedInputLanguages: ["es"] });
+    await tick();
+
+    // Inserting a third entry trims to max; the leased "en" session survives
+    // and the unpinned "es" session is evicted.
+    const third = prepareProofreader({ expectedInputLanguages: ["ja"] });
+    await third.ready;
+    await tick();
+    expect(instances[0]?.destroy).not.toHaveBeenCalled();
+    expect(instances[1]?.destroy).toHaveBeenCalledTimes(1);
+
+    lease.release();
+    third.release();
+  });
+
+  it("isolates leases per option key", async () => {
+    const { api, instances } = installFakeApi();
+    const english = prepareProofreader({ expectedInputLanguages: ["en"] });
+    await english.ready;
+
+    await proofread({ input: "Tengo gato.", expectedInputLanguages: ["es"] });
+    expect(api.create).toHaveBeenCalledTimes(2);
+
+    english.release();
+    await tick();
+    expect(instances[0]?.destroy).toHaveBeenCalledTimes(1);
+    expect(instances[1]?.destroy).not.toHaveBeenCalled();
+
+    // The other configuration stays cached and reusable.
+    await proofread({ input: "Tengo gato.", expectedInputLanguages: ["es"] });
+    expect(api.create).toHaveBeenCalledTimes(2);
+  });
+
+  it("clear detaches leased sessions and destroys them on final release", async () => {
+    const { api, instances } = installFakeApi();
+    const lease = prepareProofreader({ expectedInputLanguages: ["en"] });
+    await lease.ready;
+
+    clearProofreaderSessions();
+    await tick();
+    expect(instances[0]?.destroy).not.toHaveBeenCalled();
+
+    // The detached session no longer serves new calls.
+    await proofread({ input: "I has cat.", expectedInputLanguages: ["en"] });
+    expect(api.create).toHaveBeenCalledTimes(2);
+
+    lease.release();
+    await tick();
+    expect(instances[0]?.destroy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/proofreader/src/prepare.test.ts
+++ b/packages/proofreader/src/prepare.test.ts
@@ -224,4 +224,17 @@ describe("prepareProofreader", () => {
     await tick();
     expect(instances[0]?.destroy).toHaveBeenCalledTimes(1);
   });
+
+  it("re-trims the cache when the last in-flight pin drops", async () => {
+    const { api, instances } = installFakeApi();
+    configureProofreaderCache({ max: 0 });
+
+    await proofread({ input: "Tengo gato.", expectedInputLanguages: ["es"] });
+    await tick();
+    expect(instances[0]?.destroy).toHaveBeenCalledTimes(1);
+
+    // Nothing stayed cached, so the same call creates a fresh session.
+    await proofread({ input: "Tengo gato.", expectedInputLanguages: ["es"] });
+    expect(api.create).toHaveBeenCalledTimes(2);
+  });
 });

--- a/packages/rewriter/README.md
+++ b/packages/rewriter/README.md
@@ -101,7 +101,42 @@ import {
 } from "@web-ai-sdk/rewriter";
 ```
 
-The internal session cache is LRU-bounded (default 8). Evicted sessions have their `destroy()` invoked when present.
+The internal session cache is LRU-bounded (default 8). Evicted sessions have their `destroy()` invoked when present. Clearing detaches sessions pinned by a lease or an in-flight call and destroys them when the last pin drops.
+
+### Prepare and release
+
+`prepareRewriter(options)` starts native session creation when user intent is clear, before the input exists. It returns a `RewriterLease`:
+
+```ts
+interface RewriterLease {
+  ready: Promise<void>; // settles when native creation settles
+  release(): void;      // idempotent
+}
+```
+
+```ts
+import { prepareRewriter, rewrite } from "@web-ai-sdk/rewriter";
+
+// User opened the polish panel; warm the session now.
+const rewriterModel = prepareRewriter({ tone: "more-formal" });
+
+// The matching call reuses the prepared session with no second create.
+const result = await rewrite({
+  input: "hey, can u send me that doc when u get a sec? thx",
+  tone: "more-formal",
+});
+
+// User dismissed the panel.
+rewriterModel.release();
+```
+
+- `prepareRewriter` never throws synchronously. Unavailability and creation failure reject `ready` with `RewriterUnavailableError`.
+- `release()` is idempotent. The final release destroys the session once no other lease or in-flight call uses it.
+- Releasing before creation settles destroys the session after creation succeeds.
+- Failed creation evicts the entry, so a later prepare retries.
+- Sessions with active leases never evict from the LRU cache.
+
+Reuse requires the same session-affecting options as the `rewrite` call. `PrepareRewriterOptions` covers `language`, `supportedLanguages`, `tone`, `format`, `length`, `sharedContext`, and `monitor`.
 
 ## Result caching
 

--- a/packages/rewriter/README.md
+++ b/packages/rewriter/README.md
@@ -136,7 +136,7 @@ rewriterModel.release();
 - Failed creation evicts the entry, so a later prepare retries.
 - Sessions with active leases never evict from the LRU cache.
 
-Reuse requires the same session-affecting options as the `rewrite` call. `PrepareRewriterOptions` covers `language`, `supportedLanguages`, `tone`, `format`, `length`, `sharedContext`, and `monitor`.
+Reuse requires the same session-affecting options as the `rewrite` call. `PrepareRewriterOptions` covers `language`, `supportedLanguages`, `tone`, `format`, `length`, and `sharedContext`. `monitor` observes creation only and never affects reuse.
 
 ## Result caching
 

--- a/packages/rewriter/src/api.ts
+++ b/packages/rewriter/src/api.ts
@@ -297,6 +297,9 @@ export const acquireRewriter = (
       released = true;
       entry.inFlightCount -= 1;
       settleEntry(entry);
+      // The dropped pin may leave the cache over its cap; re-trim now
+      // instead of waiting for the next create or configure call.
+      trim();
     },
   };
 };

--- a/packages/rewriter/src/api.ts
+++ b/packages/rewriter/src/api.ts
@@ -110,10 +110,26 @@ interface CacheConfig {
 
 const cacheConfig: CacheConfig = { max: DEFAULT_MAX_CACHED_SESSIONS };
 
+interface SessionEntry {
+  key: string;
+  session: Promise<RewriterInstance>;
+  /** Active prepare leases. Leased entries never evict. */
+  leaseCount: number;
+  /** Operations currently running inference on this session. */
+  inFlightCount: number;
+  /** Still reachable through `sessionCache`. */
+  inMap: boolean;
+  /** Destruction already scheduled; guards double-destroy. */
+  destroyed: boolean;
+}
+
 // Map iteration order is insertion order, which lets us use it as an LRU:
 // on hit we re-insert to bump recency, and on overflow we evict the
 // oldest (first) entry.
-const sessionCache = new Map<string, Promise<RewriterInstance>>();
+const sessionCache = new Map<string, SessionEntry>();
+
+const isPinned = (entry: SessionEntry): boolean =>
+  entry.leaseCount > 0 || entry.inFlightCount > 0;
 
 const normalizeCacheMax = (max: number): number =>
   Number.isFinite(max) ? Math.max(0, Math.floor(max)) : 0;
@@ -137,11 +153,11 @@ export const configureRewriterCache = (
   trim();
 };
 
-const destroySession = (entry: Promise<RewriterInstance>): void => {
-  entry
-    .then((session) => {
+const destroySession = (session: Promise<RewriterInstance>): void => {
+  session
+    .then((instance) => {
       try {
-        session.destroy?.();
+        instance.destroy?.();
       } catch {
         // best-effort; the spec doesn't require destroy to be infallible.
       }
@@ -151,26 +167,45 @@ const destroySession = (entry: Promise<RewriterInstance>): void => {
     });
 };
 
+const detachEntry = (entry: SessionEntry): void => {
+  if (!entry.inMap) return;
+  entry.inMap = false;
+  sessionCache.delete(entry.key);
+};
+
+/**
+ * Destroy a detached entry once nothing pins it. Pinned entries are settled
+ * again when their last lease releases or their last in-flight call ends.
+ */
+const settleEntry = (entry: SessionEntry): void => {
+  if (entry.inMap || entry.destroyed || isPinned(entry)) return;
+  entry.destroyed = true;
+  destroySession(entry.session);
+};
+
 const trim = (): void => {
-  while (sessionCache.size > cacheConfig.max) {
-    const oldestKey = sessionCache.keys().next().value;
-    if (oldestKey === undefined) return;
-    const evicted = sessionCache.get(oldestKey);
-    sessionCache.delete(oldestKey);
-    if (evicted) destroySession(evicted);
+  if (sessionCache.size <= cacheConfig.max) return;
+  for (const entry of [...sessionCache.values()]) {
+    if (sessionCache.size <= cacheConfig.max) return;
+    // Leased or in-flight entries never evict, so the cache may temporarily
+    // exceed `max` while they stay pinned.
+    if (isPinned(entry)) continue;
+    detachEntry(entry);
+    settleEntry(entry);
   }
 };
 
 /**
  * Drop every cached rewriter session. Sessions live for the tab lifetime by
  * default; call this to free them eagerly when navigating away from a feature
- * that won't be revisited.
+ * that won't be revisited. Sessions pinned by a lease or an in-flight call
+ * leave the cache now and are destroyed once the last pin drops.
  */
 export const clearRewriterSessions = (): void => {
-  for (const entry of sessionCache.values()) {
-    destroySession(entry);
+  for (const entry of [...sessionCache.values()]) {
+    detachEntry(entry);
+    settleEntry(entry);
   }
-  sessionCache.clear();
 };
 
 // `signal` and `monitor` are per-call ephemera; drop them from the key so
@@ -190,37 +225,120 @@ const cacheKeyFor = (options: RewriterCreateOptions): string =>
  * Drop the cached rewriter whose create-options match `options`.
  */
 export const clearRewriterSession = (options: RewriterCreateOptions): void => {
-  const key = cacheKeyFor(options);
-  const entry = sessionCache.get(key);
+  const entry = sessionCache.get(cacheKeyFor(options));
   if (!entry) return;
-  sessionCache.delete(key);
-  destroySession(entry);
+  detachEntry(entry);
+  settleEntry(entry);
 };
 
 /**
- * Get or create a `Rewriter` session for the given options. Sessions live for
- * the tab lifetime so consecutive same-config calls skip the cold start. On
+ * Get or create the cache entry for the given options. Sessions live for the
+ * tab lifetime so consecutive same-config calls skip the cold start. On
  * `create()` failure the cache slot is purged so the next call retries
  * instead of returning a poisoned promise.
  */
-export const getOrCreateRewriter = (
+const getOrCreateEntry = (
   api: RewriterApi,
   options: RewriterCreateOptions,
-): Promise<RewriterInstance> => {
+): SessionEntry => {
   const key = cacheKeyFor(options);
-  let session = sessionCache.get(key);
-  if (session) {
+  const existing = sessionCache.get(key);
+  if (existing) {
+    // Bump recency: delete + reinsert so this entry moves to the end of the
+    // LRU order.
     sessionCache.delete(key);
-    sessionCache.set(key, session);
-    return session;
+    sessionCache.set(key, existing);
+    return existing;
   }
-  session = api.create(options).catch((err) => {
-    sessionCache.delete(key);
-    throw err;
-  });
-  sessionCache.set(key, session);
+  const entry: SessionEntry = {
+    key,
+    session: api.create(options).catch((err) => {
+      detachEntry(entry);
+      throw err;
+    }),
+    leaseCount: 0,
+    inFlightCount: 0,
+    inMap: true,
+    destroyed: false,
+  };
+  // A prepare-only caller may never observe the session promise; keep the
+  // stored branch handled so failed creation cannot surface as an unhandled
+  // rejection.
+  entry.session.catch(() => {});
+  sessionCache.set(key, entry);
+  return entry;
+};
+
+export interface AcquiredRewriter {
+  session: Promise<RewriterInstance>;
+  /** Release the in-flight pin. Idempotent. */
+  done(): void;
+}
+
+/**
+ * Get or create a `Rewriter` session and pin it for one operation. The pin
+ * defers destruction (final lease release, clear, eviction) until `done()`
+ * runs, so in-flight inference can never lose its session.
+ */
+export const acquireRewriter = (
+  api: RewriterApi,
+  options: RewriterCreateOptions,
+): AcquiredRewriter => {
+  const entry = getOrCreateEntry(api, options);
+  // Pin before trimming so a fresh entry can never evict itself when every
+  // other entry is pinned.
+  entry.inFlightCount += 1;
   trim();
-  return session;
+  let released = false;
+  return {
+    session: entry.session,
+    done: () => {
+      if (released) return;
+      released = true;
+      entry.inFlightCount -= 1;
+      settleEntry(entry);
+    },
+  };
+};
+
+export interface RewriterSessionLease {
+  /** Settles with the underlying `create()` outcome. */
+  ready: Promise<void>;
+  /** Idempotent. The final release detaches and destroys once safe. */
+  release(): void;
+}
+
+/**
+ * Start (or join) session creation for the given options and hold a lease on
+ * the entry. Leases pin the entry against LRU eviction. The final release
+ * removes the entry from the cache and destroys the session as soon as no
+ * in-flight call uses it; released-before-ready sessions are destroyed when
+ * creation later succeeds.
+ */
+export const leaseRewriter = (
+  api: RewriterApi,
+  options: RewriterCreateOptions,
+): RewriterSessionLease => {
+  const entry = getOrCreateEntry(api, options);
+  // Pin before trimming so a fresh entry can never evict itself when every
+  // other entry is pinned.
+  entry.leaseCount += 1;
+  trim();
+  let released = false;
+  const ready = entry.session.then(() => undefined);
+  // Keep unobserved leases from surfacing unhandled rejections.
+  ready.catch(() => {});
+  return {
+    ready,
+    release: () => {
+      if (released) return;
+      released = true;
+      entry.leaseCount -= 1;
+      if (entry.leaseCount > 0) return;
+      detachEntry(entry);
+      settleEntry(entry);
+    },
+  };
 };
 
 /** Test-only escape hatch; drop every cached session. */

--- a/packages/rewriter/src/index.ts
+++ b/packages/rewriter/src/index.ts
@@ -8,9 +8,11 @@
  */
 
 import {
+  acquireRewriter,
+  type ConfigureRewriterCacheOptions,
   type CreateMonitor,
-  getOrCreateRewriter,
   getRewriterApi,
+  leaseRewriter,
   type RewriterApi,
   type RewriterAvailability,
   type RewriterAvailabilityOptions,
@@ -29,19 +31,14 @@ export {
   clearRewriterSession,
   clearRewriterSessions,
   configureRewriterCache,
-  getOrCreateRewriter,
-  getRewriterApi,
   isAvailable,
 } from "./api.js";
 
-export {
-  DEFAULT_CACHE_TTL_MS,
-  defaultCacheKey,
-  resolveCache,
-} from "./cache.js";
+export { DEFAULT_CACHE_TTL_MS } from "./cache.js";
 
 export type {
   CacheOption,
+  ConfigureRewriterCacheOptions,
   CreateMonitor,
   RewriteCache,
   RewriterApi,
@@ -124,6 +121,112 @@ class RewriterAbortError extends Error {
 }
 
 /**
+ * Session-affecting subset of `RewriteOptions`. `prepareRewriter` and
+ * `rewrite` derive the same native create options from these fields, so a
+ * prepared session is reused by the matching call.
+ */
+export type PrepareRewriterOptions = Pick<
+  RewriteOptions,
+  | "language"
+  | "supportedLanguages"
+  | "tone"
+  | "format"
+  | "length"
+  | "sharedContext"
+  | "monitor"
+>;
+
+interface SessionConfig {
+  lang: string | undefined;
+  languageHints: boolean;
+  createOptions: RewriterCreateOptions;
+}
+
+/**
+ * Single source of the option-to-session mapping. The session cache keys by
+ * `createOptions`, so `rewrite` and `prepareRewriter` must both go through
+ * this derivation.
+ */
+const resolveSessionConfig = (
+  options: PrepareRewriterOptions,
+): SessionConfig => {
+  const lang = options.language ? NORMALIZE_LANG(options.language) : undefined;
+  const supported = new Set(
+    (options.supportedLanguages ?? DEFAULT_SUPPORTED_LANGUAGES).map(
+      NORMALIZE_LANG,
+    ),
+  );
+  const languageHints = lang ? supported.has(lang) : false;
+
+  const langOptions: Pick<
+    RewriterCreateOptions,
+    "expectedInputLanguages" | "expectedContextLanguages" | "outputLanguage"
+  > =
+    lang && languageHints
+      ? {
+          expectedInputLanguages: [lang],
+          expectedContextLanguages: [lang],
+          outputLanguage: lang,
+        }
+      : {};
+
+  const createOptions: RewriterCreateOptions = {
+    tone: options.tone ?? "as-is",
+    format: options.format ?? "as-is",
+    length: options.length ?? "as-is",
+    sharedContext: options.sharedContext ?? "",
+    ...langOptions,
+    ...(options.monitor ? { monitor: options.monitor } : {}),
+  };
+
+  return { lang, languageHints, createOptions };
+};
+
+export interface RewriterLease {
+  /**
+   * Resolves when the native session is created. Rejects with
+   * `RewriterUnavailableError` when the API is missing or creation fails.
+   */
+  ready: Promise<void>;
+  /**
+   * Idempotent. The final release destroys the session once no other lease
+   * or in-flight call uses it.
+   */
+  release(): void;
+}
+
+/**
+ * Start native session creation as soon as user intent is clear, before the
+ * input exists. The matching `rewrite` call reuses the prepared session
+ * without a second create. Never throws synchronously; unavailability and
+ * creation failures reject `ready`. Failed preparations leave the cache so a
+ * later call can retry.
+ */
+export const prepareRewriter = (
+  options: PrepareRewriterOptions = {},
+): RewriterLease => {
+  const api = getRewriterApi();
+  if (!api?.create) {
+    const ready = Promise.reject(
+      new RewriterUnavailableError(
+        "Rewriter API is not available in this environment.",
+      ),
+    );
+    // Keep unobserved leases from surfacing unhandled rejections.
+    ready.catch(() => {});
+    return { ready, release: () => {} };
+  }
+  const { createOptions } = resolveSessionConfig(options);
+  const lease = leaseRewriter(api, createOptions);
+  const ready = lease.ready.catch((err) => {
+    const message = (err as Error)?.message ?? String(err);
+    throw new RewriterUnavailableError(`Rewriter.create() failed: ${message}`);
+  });
+  ready.catch(() => {});
+  return { ready, release: lease.release };
+};
+
+/**
  * Rewrite existing text under tone / format / length adjustments. Uses
  * streaming when the underlying instance supports it, one-shot otherwise.
  * Returns `{ output: null }` for empty input. Throws
@@ -145,12 +248,7 @@ export const rewrite = async (
   const text = options.input.trim();
   if (!text) return { output: null, cached: false };
 
-  const lang = options.language ? NORMALIZE_LANG(options.language) : undefined;
-  const supportedLanguages = (
-    options.supportedLanguages ?? DEFAULT_SUPPORTED_LANGUAGES
-  ).map(NORMALIZE_LANG);
-  const supported = new Set(supportedLanguages);
-  const languageHints = lang ? supported.has(lang) : false;
+  const { lang, languageHints, createOptions } = resolveSessionConfig(options);
   const cache = resolveCache(options.cache, options.cacheTtl);
   const cacheKey =
     options.cacheKey ??
@@ -169,45 +267,23 @@ export const rewrite = async (
     if (cached) return { output: cached, cached: true };
   }
 
-  const langOptions: Pick<
-    RewriterCreateOptions,
-    "expectedInputLanguages" | "expectedContextLanguages" | "outputLanguage"
-  > =
-    lang && languageHints
-      ? {
-          expectedInputLanguages: [lang],
-          expectedContextLanguages: [lang],
-          outputLanguage: lang,
-        }
-      : {};
-
-  const baseCreateOptions: RewriterCreateOptions = {
-    tone: options.tone ?? "as-is",
-    format: options.format ?? "as-is",
-    length: options.length ?? "as-is",
-    sharedContext: options.sharedContext ?? "",
-    ...langOptions,
-    ...(options.monitor ? { monitor: options.monitor } : {}),
-  };
-
   // Pass the same shape to availability() as we do to create() so engines
   // that warn on mismatch stay quiet.
   const availability = await api
     .availability({
-      ...(baseCreateOptions.tone ? { tone: baseCreateOptions.tone } : {}),
-      ...(baseCreateOptions.format ? { format: baseCreateOptions.format } : {}),
-      ...(baseCreateOptions.length ? { length: baseCreateOptions.length } : {}),
-      ...(baseCreateOptions.expectedInputLanguages
-        ? { expectedInputLanguages: baseCreateOptions.expectedInputLanguages }
+      ...(createOptions.tone ? { tone: createOptions.tone } : {}),
+      ...(createOptions.format ? { format: createOptions.format } : {}),
+      ...(createOptions.length ? { length: createOptions.length } : {}),
+      ...(createOptions.expectedInputLanguages
+        ? { expectedInputLanguages: createOptions.expectedInputLanguages }
         : {}),
-      ...(baseCreateOptions.expectedContextLanguages
+      ...(createOptions.expectedContextLanguages
         ? {
-            expectedContextLanguages:
-              baseCreateOptions.expectedContextLanguages,
+            expectedContextLanguages: createOptions.expectedContextLanguages,
           }
         : {}),
-      ...(baseCreateOptions.outputLanguage
-        ? { outputLanguage: baseCreateOptions.outputLanguage }
+      ...(createOptions.outputLanguage
+        ? { outputLanguage: createOptions.outputLanguage }
         : {}),
     })
     .catch(() => "unavailable" as const);
@@ -216,45 +292,52 @@ export const rewrite = async (
   }
   if (options.signal?.aborted) throw new RewriterAbortError();
 
-  const sessionPromise = getOrCreateRewriter(api, baseCreateOptions);
-
-  // Wrap session-create failures with context so consumers can branch on a
-  // single typed error instead of parsing browser-specific messages.
-  let rewriter: RewriterInstance;
+  // The pin defers destruction (lease release, clear, eviction) until this
+  // call finishes.
+  const acquired = acquireRewriter(api, createOptions);
   try {
-    rewriter = await sessionPromise;
-  } catch (err) {
-    if (err instanceof RewriterAbortError) throw err;
-    const message = (err as Error)?.message ?? String(err);
-    throw new RewriterUnavailableError(`Rewriter.create() failed: ${message}`);
-  }
-  if (options.signal?.aborted) throw new RewriterAbortError();
-
-  const taskOptions = {
-    ...(options.context !== undefined ? { context: options.context } : {}),
-    ...(options.signal ? { signal: options.signal } : {}),
-  };
-
-  // Browser implementations may emit delta or cumulative chunks. Detect the
-  // shape per chunk and merge accordingly.
-  const mergeChunk = (buffer: string, chunk: string): string =>
-    chunk.startsWith(buffer) ? chunk : buffer + chunk;
-
-  let finalText: string;
-  if (typeof rewriter.rewriteStreaming === "function") {
-    let buffer = "";
-    for await (const chunk of rewriter.rewriteStreaming(text, taskOptions)) {
-      if (options.signal?.aborted) throw new RewriterAbortError();
-      buffer = mergeChunk(buffer, chunk);
-      options.onUpdate?.(buffer);
+    // Wrap session-create failures with context so consumers can branch on a
+    // single typed error instead of parsing browser-specific messages.
+    let rewriter: RewriterInstance;
+    try {
+      rewriter = await acquired.session;
+    } catch (err) {
+      if (err instanceof RewriterAbortError) throw err;
+      const message = (err as Error)?.message ?? String(err);
+      throw new RewriterUnavailableError(
+        `Rewriter.create() failed: ${message}`,
+      );
     }
-    finalText = buffer.trim();
-  } else {
-    const raw = await rewriter.rewrite(text, taskOptions);
     if (options.signal?.aborted) throw new RewriterAbortError();
-    finalText = raw.trim();
-  }
 
-  if (finalText && cache) cache.set(cacheKey, finalText);
-  return { output: finalText || null, cached: false };
+    const taskOptions = {
+      ...(options.context !== undefined ? { context: options.context } : {}),
+      ...(options.signal ? { signal: options.signal } : {}),
+    };
+
+    // Browser implementations may emit delta or cumulative chunks. Detect the
+    // shape per chunk and merge accordingly.
+    const mergeChunk = (buffer: string, chunk: string): string =>
+      chunk.startsWith(buffer) ? chunk : buffer + chunk;
+
+    let finalText: string;
+    if (typeof rewriter.rewriteStreaming === "function") {
+      let buffer = "";
+      for await (const chunk of rewriter.rewriteStreaming(text, taskOptions)) {
+        if (options.signal?.aborted) throw new RewriterAbortError();
+        buffer = mergeChunk(buffer, chunk);
+        options.onUpdate?.(buffer);
+      }
+      finalText = buffer.trim();
+    } else {
+      const raw = await rewriter.rewrite(text, taskOptions);
+      if (options.signal?.aborted) throw new RewriterAbortError();
+      finalText = raw.trim();
+    }
+
+    if (finalText && cache) cache.set(cacheKey, finalText);
+    return { output: finalText || null, cached: false };
+  } finally {
+    acquired.done();
+  }
 };

--- a/packages/rewriter/src/index.ts
+++ b/packages/rewriter/src/index.ts
@@ -124,6 +124,7 @@ class RewriterAbortError extends Error {
  * Session-affecting subset of `RewriteOptions`. `prepareRewriter` and
  * `rewrite` derive the same native create options from these fields, so a
  * prepared session is reused by the matching call.
+ * `monitor` observes creation only; it never affects the cache key.
  */
 export type PrepareRewriterOptions = Pick<
   RewriteOptions,
@@ -143,8 +144,9 @@ interface SessionConfig {
 }
 
 /**
- * Single source of the option-to-session mapping. The session cache keys by
- * `createOptions`, so `rewrite` and `prepareRewriter` must both go through
+ * Single source of the option-to-session mapping. The session cache key derives from
+ * the stable fields of `createOptions` (`monitor` never fragments reuse),
+ * so `rewrite` and `prepareRewriter` must both go through
  * this derivation.
  */
 const resolveSessionConfig = (

--- a/packages/rewriter/src/prepare.test.ts
+++ b/packages/rewriter/src/prepare.test.ts
@@ -205,4 +205,17 @@ describe("prepareRewriter", () => {
     await tick();
     expect(instances[0]?.destroy).toHaveBeenCalledTimes(1);
   });
+
+  it("re-trims the cache when the last in-flight pin drops", async () => {
+    const { api, instances } = installFakeApi();
+    configureRewriterCache({ max: 0 });
+
+    await rewrite({ input: "Make this clearer." });
+    await tick();
+    expect(instances[0]?.destroy).toHaveBeenCalledTimes(1);
+
+    // Nothing stayed cached, so the same call creates a fresh session.
+    await rewrite({ input: "Make this clearer." });
+    expect(api.create).toHaveBeenCalledTimes(2);
+  });
 });

--- a/packages/rewriter/src/prepare.test.ts
+++ b/packages/rewriter/src/prepare.test.ts
@@ -1,0 +1,208 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { __clearSessionCacheForTests, configureRewriterCache } from "./api.js";
+import {
+  clearRewriterSessions,
+  prepareRewriter,
+  RewriterUnavailableError,
+  rewrite,
+} from "./index.js";
+
+interface FakeRewriter {
+  rewrite: ReturnType<typeof vi.fn>;
+  destroy: ReturnType<typeof vi.fn>;
+}
+
+const makeInstance = (): FakeRewriter => ({
+  rewrite: vi.fn(async () => "Rewritten."),
+  destroy: vi.fn(),
+});
+
+const installFakeApi = () => {
+  const instances: FakeRewriter[] = [];
+  const api = {
+    availability: vi.fn(async () => "available" as const),
+    create: vi.fn(async () => {
+      const instance = makeInstance();
+      instances.push(instance);
+      return instance;
+    }),
+  };
+  (globalThis as { Rewriter?: unknown }).Rewriter = api;
+  return { api, instances };
+};
+
+const tick = () => new Promise<void>((resolve) => setTimeout(resolve, 0));
+
+beforeEach(() => {
+  __clearSessionCacheForTests();
+});
+
+afterEach(() => {
+  (globalThis as { Rewriter?: unknown }).Rewriter = undefined;
+});
+
+describe("prepareRewriter", () => {
+  it("starts creation immediately and the matching rewrite reuses it", async () => {
+    const { api } = installFakeApi();
+    const lease = prepareRewriter();
+    expect(api.create).toHaveBeenCalledTimes(1);
+    await lease.ready;
+
+    const result = await rewrite({ input: "Make this clearer." });
+    expect(result.output).toBe("Rewritten.");
+    expect(api.create).toHaveBeenCalledTimes(1);
+    lease.release();
+  });
+
+  it("never throws when the API is missing; ready rejects instead", async () => {
+    const lease = prepareRewriter();
+    await expect(lease.ready).rejects.toBeInstanceOf(RewriterUnavailableError);
+    expect(() => lease.release()).not.toThrow();
+  });
+
+  it("shares one session between concurrent leases and destroys exactly once", async () => {
+    const { api, instances } = installFakeApi();
+    const first = prepareRewriter();
+    const second = prepareRewriter();
+    expect(api.create).toHaveBeenCalledTimes(1);
+    await Promise.all([first.ready, second.ready]);
+
+    first.release();
+    first.release();
+    await tick();
+    expect(instances[0]?.destroy).not.toHaveBeenCalled();
+
+    second.release();
+    second.release();
+    await tick();
+    expect(instances[0]?.destroy).toHaveBeenCalledTimes(1);
+  });
+
+  it("release before creation settles destroys the session once created", async () => {
+    const { api } = installFakeApi();
+    let resolveCreate: (instance: FakeRewriter) => void = () => {};
+    const instance = makeInstance();
+    api.create.mockImplementationOnce(
+      () =>
+        new Promise<FakeRewriter>((resolve) => {
+          resolveCreate = resolve;
+        }),
+    );
+
+    const lease = prepareRewriter();
+    lease.release();
+    await tick();
+    expect(instance.destroy).not.toHaveBeenCalled();
+
+    resolveCreate(instance);
+    await tick();
+    expect(instance.destroy).toHaveBeenCalledTimes(1);
+
+    // The released entry left the cache, so preparing again creates anew.
+    const retry = prepareRewriter();
+    expect(api.create).toHaveBeenCalledTimes(2);
+    await retry.ready;
+    retry.release();
+  });
+
+  it("creation failure rejects ready, evicts the entry, and allows retry", async () => {
+    const { api } = installFakeApi();
+    api.create.mockRejectedValueOnce(new Error("no space"));
+
+    const failed = prepareRewriter();
+    await expect(failed.ready).rejects.toBeInstanceOf(RewriterUnavailableError);
+    failed.release();
+
+    const retry = prepareRewriter();
+    expect(api.create).toHaveBeenCalledTimes(2);
+    await expect(retry.ready).resolves.toBeUndefined();
+    retry.release();
+  });
+
+  it("defers destruction while inference is in flight", async () => {
+    const { instances } = installFakeApi();
+    const lease = prepareRewriter();
+    await lease.ready;
+
+    const instance = instances[0];
+    if (!instance) throw new Error("expected a created instance");
+    let resolveRewrite: (text: string) => void = () => {};
+    instance.rewrite.mockImplementationOnce(
+      () =>
+        new Promise<string>((resolve) => {
+          resolveRewrite = resolve;
+        }),
+    );
+
+    const running = rewrite({ input: "Make this clearer." });
+    await tick();
+    lease.release();
+    await tick();
+    expect(instance.destroy).not.toHaveBeenCalled();
+
+    resolveRewrite("Rewritten.");
+    await expect(running).resolves.toEqual({
+      output: "Rewritten.",
+      cached: false,
+    });
+    await tick();
+    expect(instance.destroy).toHaveBeenCalledTimes(1);
+  });
+
+  it("pins leased entries against LRU eviction", async () => {
+    const { instances } = installFakeApi();
+    configureRewriterCache({ max: 1 });
+
+    const lease = prepareRewriter({ tone: "more-formal" });
+    await lease.ready;
+    await rewrite({ input: "Loosen this up.", tone: "more-casual" });
+    await tick();
+
+    // Inserting a third entry trims to max; the leased "more-formal" session
+    // survives and the unpinned "more-casual" session is evicted.
+    const third = prepareRewriter({ length: "shorter" });
+    await third.ready;
+    await tick();
+    expect(instances[0]?.destroy).not.toHaveBeenCalled();
+    expect(instances[1]?.destroy).toHaveBeenCalledTimes(1);
+
+    lease.release();
+    third.release();
+  });
+
+  it("isolates leases per option key", async () => {
+    const { api, instances } = installFakeApi();
+    const formal = prepareRewriter({ tone: "more-formal" });
+    await formal.ready;
+
+    await rewrite({ input: "Loosen this up.", tone: "more-casual" });
+    expect(api.create).toHaveBeenCalledTimes(2);
+
+    formal.release();
+    await tick();
+    expect(instances[0]?.destroy).toHaveBeenCalledTimes(1);
+    expect(instances[1]?.destroy).not.toHaveBeenCalled();
+
+    // The other configuration stays cached and reusable.
+    await rewrite({ input: "Loosen this up.", tone: "more-casual" });
+    expect(api.create).toHaveBeenCalledTimes(2);
+  });
+
+  it("clear detaches leased sessions and destroys them on final release", async () => {
+    const { api, instances } = installFakeApi();
+    const lease = prepareRewriter();
+    await lease.ready;
+
+    clearRewriterSessions();
+    await tick();
+    expect(instances[0]?.destroy).not.toHaveBeenCalled();
+
+    // The detached session no longer serves new calls.
+    await rewrite({ input: "Make this clearer." });
+    expect(api.create).toHaveBeenCalledTimes(2);
+
+    lease.release();
+    await tick();
+    expect(instances[0]?.destroy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -58,7 +58,7 @@ await summarizer.summarize({ language: "en", input: document.body.innerText });
 const tools = await webmcp.getTools();
 ```
 
-The root entry namespaces each scoped package because several exports (e.g. `checkAvailability`, `isAvailable`, `defaultCacheKey`) appear in more than one package and would collide on a flat re-export.
+The root entry namespaces each scoped package because several exports (e.g. `checkAvailability`, `isAvailable`, `DEFAULT_CACHE_TTL_MS`) appear in more than one package and would collide on a flat re-export.
 
 ## Why a meta-package?
 

--- a/packages/sdk/src/index.test.ts
+++ b/packages/sdk/src/index.test.ts
@@ -40,6 +40,30 @@ const _cacheOptionTripwire: [
   : never = true;
 void _cacheOptionTripwire;
 
+// Compile-time tripwire: every task package exposes the same lease shape from
+// its prepare function.
+type LeaseShape = { ready: Promise<void>; release(): void };
+const _prepareLeaseTripwire: [
+  ReturnType<typeof sdk.prompt.prepareLanguageModel>,
+  ReturnType<typeof sdk.summarizer.prepareSummarizer>,
+  ReturnType<typeof sdk.translator.prepareTranslator>,
+  ReturnType<typeof sdk.detector.prepareLanguageDetector>,
+  ReturnType<typeof sdk.writer.prepareWriter>,
+  ReturnType<typeof sdk.rewriter.prepareRewriter>,
+  ReturnType<typeof sdk.proofreader.prepareProofreader>,
+] extends [
+  LeaseShape,
+  LeaseShape,
+  LeaseShape,
+  LeaseShape,
+  LeaseShape,
+  LeaseShape,
+  LeaseShape,
+]
+  ? true
+  : never = true;
+void _prepareLeaseTripwire;
+
 describe("web-ai-sdk root namespace", () => {
   it("exposes every scoped package", () => {
     expect(typeof sdk.prompt.ask).toBe("function");
@@ -54,6 +78,23 @@ describe("web-ai-sdk root namespace", () => {
     expect(typeof sdk.writer.write).toBe("function");
     expect(typeof sdk.rewriter.rewrite).toBe("function");
     expect(typeof sdk.proofreader.proofread).toBe("function");
+  });
+
+  it("exposes the prepare lifecycle on every task package", () => {
+    expect(typeof sdk.prompt.prepareLanguageModel).toBe("function");
+    expect(typeof sdk.summarizer.prepareSummarizer).toBe("function");
+    expect(typeof sdk.translator.prepareTranslator).toBe("function");
+    expect(typeof sdk.detector.prepareLanguageDetector).toBe("function");
+    expect(typeof sdk.writer.prepareWriter).toBe("function");
+    expect(typeof sdk.rewriter.prepareRewriter).toBe("function");
+    expect(typeof sdk.proofreader.prepareProofreader).toBe("function");
+    expect(typeof sdk.prompt.clearLanguageModelSessions).toBe("function");
+    expect(typeof sdk.summarizer.clearSummarizerSessions).toBe("function");
+    expect(typeof sdk.translator.clearTranslatorSessions).toBe("function");
+    expect(typeof sdk.detector.clearLanguageDetectorSessions).toBe("function");
+    expect(typeof sdk.writer.clearWriterSessions).toBe("function");
+    expect(typeof sdk.rewriter.clearRewriterSessions).toBe("function");
+    expect(typeof sdk.proofreader.clearProofreaderSessions).toBe("function");
   });
 
   it("exposes the shared cache TTL default on result-producing packages", () => {

--- a/packages/summarizer/README.md
+++ b/packages/summarizer/README.md
@@ -101,6 +101,39 @@ Feature-detect helper.
 
 Forwards to the spec's `availability()` call. Returns `null` if the global is missing or the call throws.
 
+### Prepare and release
+
+`prepareSummarizer(options)` starts native session creation when user intent is clear, before the input exists. It returns a `SummarizerLease`: `{ ready: Promise<void>; release(): void }`.
+
+```ts
+import { prepareSummarizer, summarize } from "@web-ai-sdk/summarizer";
+
+// User hovers the "Summarize" button: warm the session now.
+const summarizerModel = prepareSummarizer({ language: "en", type: "key-points" });
+
+// The matching call reuses the prepared session; no second create.
+const result = await summarize({
+  input: articleText,
+  language: "en",
+  type: "key-points",
+});
+
+// User dismisses the feature: let the session go.
+summarizerModel.release();
+```
+
+- `prepareSummarizer` never throws synchronously. Unavailability and creation failure reject `ready` with `SummarizerUnavailableError`.
+- `release()` is idempotent. The final release destroys the session once no other lease or in-flight call uses it.
+- Releasing before creation settles destroys the session after creation succeeds.
+- Failed creation evicts the entry, so a later prepare retries.
+- Sessions with active leases never evict from the LRU cache.
+
+Reuse requires the same session-affecting options as the `summarize` call. For this package those are `language`, `supportedLanguages`, `type`, `length`, `format`, `preference`, `sharedContext`, and `monitor` (`PrepareSummarizerOptions`).
+
+### Session cache controls
+
+`configureSummarizerCache({ max })` bounds the internal warm `Summarizer` session cache (default `8`). `clearSummarizerSessions()` drops every warm session, and `clearSummarizerSession(createOptions)` drops one matching configuration. Clearing detaches sessions pinned by a lease or an in-flight call and destroys them when the last pin drops.
+
 ## Performance preference
 
 `preference` is a hint about the speed/quality tradeoff the browser makes when picking the underlying model:
@@ -142,7 +175,7 @@ summarize({ language: "en", input: text, cache: "local", cacheTtl: 5 * 60 * 1000
 summarize({ language: "en", input: text, cache: "local", cacheRefresh: true });
 ```
 
-The internal session cache (warm `Summarizer` instances) is separate and always on, so same-config calls skip the ~1-3s cold start within a tab.
+The internal session cache (warm `Summarizer` instances) is separate and always on, so same-config calls skip the ~1-3s cold start within a tab. Bound or clear it via the Session cache controls above.
 
 ## Output normalization
 

--- a/packages/summarizer/README.md
+++ b/packages/summarizer/README.md
@@ -128,7 +128,7 @@ summarizerModel.release();
 - Failed creation evicts the entry, so a later prepare retries.
 - Sessions with active leases never evict from the LRU cache.
 
-Reuse requires the same session-affecting options as the `summarize` call. For this package those are `language`, `supportedLanguages`, `type`, `length`, `format`, `preference`, `sharedContext`, and `monitor` (`PrepareSummarizerOptions`).
+Reuse requires the same session-affecting options as the `summarize` call. For this package those are `language`, `supportedLanguages`, `type`, `length`, `format`, `preference`, and `sharedContext` (`PrepareSummarizerOptions`). `monitor` observes creation only and never affects reuse.
 
 ### Session cache controls
 

--- a/packages/summarizer/src/api.ts
+++ b/packages/summarizer/src/api.ts
@@ -270,6 +270,9 @@ export const acquireSummarizer = (
       released = true;
       entry.inFlightCount -= 1;
       settleEntry(entry);
+      // The dropped pin may leave the cache over its cap; re-trim now
+      // instead of waiting for the next create or configure call.
+      trim();
     },
   };
 };

--- a/packages/summarizer/src/api.ts
+++ b/packages/summarizer/src/api.ts
@@ -94,10 +94,26 @@ interface CacheConfig {
 
 const cacheConfig: CacheConfig = { max: DEFAULT_MAX_CACHED_SESSIONS };
 
+interface SessionEntry {
+  key: string;
+  session: Promise<SummarizerInstance>;
+  /** Active prepare leases. Leased entries never evict. */
+  leaseCount: number;
+  /** Operations currently running inference on this session. */
+  inFlightCount: number;
+  /** Still reachable through `sessionCache`. */
+  inMap: boolean;
+  /** Destruction already scheduled; guards double-destroy. */
+  destroyed: boolean;
+}
+
 // Map iteration order is insertion order, which lets us use it as an LRU:
 // on hit we re-insert to bump recency, and on overflow we evict the
 // oldest (first) entry.
-const sessionCache = new Map<string, Promise<SummarizerInstance>>();
+const sessionCache = new Map<string, SessionEntry>();
+
+const isPinned = (entry: SessionEntry): boolean =>
+  entry.leaseCount > 0 || entry.inFlightCount > 0;
 
 const normalizeCacheMax = (max: number): number =>
   Number.isFinite(max) ? Math.max(0, Math.floor(max)) : 0;
@@ -121,11 +137,11 @@ export const configureSummarizerCache = (
   trim();
 };
 
-const destroySession = (entry: Promise<SummarizerInstance>): void => {
-  entry
-    .then((session) => {
+const destroySession = (session: Promise<SummarizerInstance>): void => {
+  session
+    .then((instance) => {
       try {
-        session.destroy?.();
+        instance.destroy?.();
       } catch {
         // best-effort; the spec doesn't require destroy to be infallible.
       }
@@ -135,26 +151,45 @@ const destroySession = (entry: Promise<SummarizerInstance>): void => {
     });
 };
 
+const detachEntry = (entry: SessionEntry): void => {
+  if (!entry.inMap) return;
+  entry.inMap = false;
+  sessionCache.delete(entry.key);
+};
+
+/**
+ * Destroy a detached entry once nothing pins it. Pinned entries are settled
+ * again when their last lease releases or their last in-flight call ends.
+ */
+const settleEntry = (entry: SessionEntry): void => {
+  if (entry.inMap || entry.destroyed || isPinned(entry)) return;
+  entry.destroyed = true;
+  destroySession(entry.session);
+};
+
 const trim = (): void => {
-  while (sessionCache.size > cacheConfig.max) {
-    const oldestKey = sessionCache.keys().next().value;
-    if (oldestKey === undefined) return;
-    const evicted = sessionCache.get(oldestKey);
-    sessionCache.delete(oldestKey);
-    if (evicted) destroySession(evicted);
+  if (sessionCache.size <= cacheConfig.max) return;
+  for (const entry of [...sessionCache.values()]) {
+    if (sessionCache.size <= cacheConfig.max) return;
+    // Leased or in-flight entries never evict, so the cache may temporarily
+    // exceed `max` while they stay pinned.
+    if (isPinned(entry)) continue;
+    detachEntry(entry);
+    settleEntry(entry);
   }
 };
 
 /**
  * Drop every cached summarizer session. Sessions live for the tab lifetime by
  * default; call this to free them eagerly when navigating away from a feature
- * that won't be revisited.
+ * that won't be revisited. Sessions pinned by a lease or an in-flight call
+ * leave the cache now and are destroyed once the last pin drops.
  */
 export const clearSummarizerSessions = (): void => {
-  for (const entry of sessionCache.values()) {
-    destroySession(entry);
+  for (const entry of [...sessionCache.values()]) {
+    detachEntry(entry);
+    settleEntry(entry);
   }
-  sessionCache.clear();
 };
 
 /**
@@ -163,39 +198,120 @@ export const clearSummarizerSessions = (): void => {
 export const clearSummarizerSession = (
   options: SummarizerCreateOptions,
 ): void => {
-  const key = JSON.stringify(options);
-  const entry = sessionCache.get(key);
+  const entry = sessionCache.get(JSON.stringify(options));
   if (!entry) return;
-  sessionCache.delete(key);
-  destroySession(entry);
+  detachEntry(entry);
+  settleEntry(entry);
 };
 
 /**
- * Get or create a `Summarizer` session for the given options. Sessions live
- * for the tab lifetime so navigating between same-config pages skips the
- * ~1-3s cold start. On `create()` failure the cache slot is purged so the
- * next call retries instead of returning a poisoned promise.
+ * Get or create the cache entry for the given options. Sessions live for the
+ * tab lifetime so navigating between same-config pages skips the ~1-3s cold
+ * start. On `create()` failure the cache slot is purged so the next call
+ * retries instead of returning a poisoned promise.
  */
-export const getOrCreateSummarizer = (
+const getOrCreateEntry = (
   api: SummarizerApi,
   options: SummarizerCreateOptions,
-): Promise<SummarizerInstance> => {
+): SessionEntry => {
   const key = JSON.stringify(options);
-  let session = sessionCache.get(key);
-  if (session) {
+  const existing = sessionCache.get(key);
+  if (existing) {
     // Bump recency: delete + reinsert so this entry moves to the end of the
     // LRU order.
     sessionCache.delete(key);
-    sessionCache.set(key, session);
-    return session;
+    sessionCache.set(key, existing);
+    return existing;
   }
-  session = api.create(options).catch((err) => {
-    sessionCache.delete(key);
-    throw err;
-  });
-  sessionCache.set(key, session);
+  const entry: SessionEntry = {
+    key,
+    session: api.create(options).catch((err) => {
+      detachEntry(entry);
+      throw err;
+    }),
+    leaseCount: 0,
+    inFlightCount: 0,
+    inMap: true,
+    destroyed: false,
+  };
+  // A prepare-only caller may never observe the session promise; keep the
+  // stored branch handled so failed creation cannot surface as an unhandled
+  // rejection.
+  entry.session.catch(() => {});
+  sessionCache.set(key, entry);
+  return entry;
+};
+
+export interface AcquiredSummarizer {
+  session: Promise<SummarizerInstance>;
+  /** Release the in-flight pin. Idempotent. */
+  done(): void;
+}
+
+/**
+ * Get or create a `Summarizer` session and pin it for one operation. The pin
+ * defers destruction (final lease release, clear, eviction) until `done()`
+ * runs, so in-flight inference can never lose its session.
+ */
+export const acquireSummarizer = (
+  api: SummarizerApi,
+  options: SummarizerCreateOptions,
+): AcquiredSummarizer => {
+  const entry = getOrCreateEntry(api, options);
+  // Pin before trimming so a fresh entry can never evict itself when every
+  // other entry is pinned.
+  entry.inFlightCount += 1;
   trim();
-  return session;
+  let released = false;
+  return {
+    session: entry.session,
+    done: () => {
+      if (released) return;
+      released = true;
+      entry.inFlightCount -= 1;
+      settleEntry(entry);
+    },
+  };
+};
+
+export interface SummarizerSessionLease {
+  /** Settles with the underlying `create()` outcome. */
+  ready: Promise<void>;
+  /** Idempotent. The final release detaches and destroys once safe. */
+  release(): void;
+}
+
+/**
+ * Start (or join) session creation for the given options and hold a lease on
+ * the entry. Leases pin the entry against LRU eviction. The final release
+ * removes the entry from the cache and destroys the session as soon as no
+ * in-flight call uses it; released-before-ready sessions are destroyed when
+ * creation later succeeds.
+ */
+export const leaseSummarizer = (
+  api: SummarizerApi,
+  options: SummarizerCreateOptions,
+): SummarizerSessionLease => {
+  const entry = getOrCreateEntry(api, options);
+  // Pin before trimming so a fresh entry can never evict itself when every
+  // other entry is pinned.
+  entry.leaseCount += 1;
+  trim();
+  let released = false;
+  const ready = entry.session.then(() => undefined);
+  // Keep unobserved leases from surfacing unhandled rejections.
+  ready.catch(() => {});
+  return {
+    ready,
+    release: () => {
+      if (released) return;
+      released = true;
+      entry.leaseCount -= 1;
+      if (entry.leaseCount > 0) return;
+      detachEntry(entry);
+      settleEntry(entry);
+    },
+  };
 };
 
 /** Test-only escape hatch; drop every cached session. */

--- a/packages/summarizer/src/index.ts
+++ b/packages/summarizer/src/index.ts
@@ -8,11 +8,16 @@
  */
 
 import {
+  acquireSummarizer,
+  type ConfigureSummarizerCacheOptions,
   type CreateMonitor,
   checkAvailability,
-  getOrCreateSummarizer,
+  clearSummarizerSession,
+  clearSummarizerSessions,
+  configureSummarizerCache,
   getSummarizerApi,
   isAvailable,
+  leaseSummarizer,
   type SummarizerApi,
   type SummarizerAvailability,
   type SummarizerAvailabilityOptions,
@@ -30,6 +35,7 @@ import { cleanSummary } from "./skeleton.js";
 
 export type {
   CacheOption,
+  ConfigureSummarizerCacheOptions,
   CreateMonitor,
   SummarizerApi,
   SummarizerAvailability,
@@ -38,7 +44,14 @@ export type {
   SummarizerInstance,
   SummaryCache,
 };
-export { checkAvailability, DEFAULT_CACHE_TTL_MS, isAvailable };
+export {
+  checkAvailability,
+  clearSummarizerSession,
+  clearSummarizerSessions,
+  configureSummarizerCache,
+  DEFAULT_CACHE_TTL_MS,
+  isAvailable,
+};
 
 export interface SummarizeOptions {
   /** Text to summarize. Empty / whitespace input resolves to `{ output: null }`. */
@@ -112,6 +125,115 @@ export class SummarizerUnavailableError extends Error {
 }
 
 /**
+ * Session-affecting subset of `SummarizeOptions`. `prepareSummarizer` and
+ * `summarize` derive the same native create options from these fields, so a
+ * prepared session is reused by the matching call.
+ */
+export type PrepareSummarizerOptions = Pick<
+  SummarizeOptions,
+  | "language"
+  | "supportedLanguages"
+  | "type"
+  | "length"
+  | "format"
+  | "preference"
+  | "sharedContext"
+  | "monitor"
+>;
+
+interface SessionConfig {
+  lang: string;
+  languageHints: boolean;
+  createOptions: SummarizerCreateOptions;
+}
+
+/**
+ * Single source of the option-to-session mapping. The session cache keys by
+ * `createOptions`, so `summarize` and `prepareSummarizer` must both go
+ * through this derivation.
+ */
+const resolveSessionConfig = (
+  options: PrepareSummarizerOptions,
+): SessionConfig => {
+  const lang = NORMALIZE_LANG(options.language);
+  const supported = new Set(
+    (options.supportedLanguages ?? DEFAULT_SUPPORTED_LANGUAGES).map(
+      NORMALIZE_LANG,
+    ),
+  );
+  const languageHints = supported.has(lang);
+
+  const langOptions: Pick<
+    SummarizerCreateOptions,
+    "expectedInputLanguages" | "expectedContextLanguages" | "outputLanguage"
+  > = languageHints
+    ? {
+        expectedInputLanguages: [lang],
+        expectedContextLanguages: [lang],
+        outputLanguage: lang,
+      }
+    : {};
+
+  const createOptions: SummarizerCreateOptions = {
+    type: options.type ?? "tldr",
+    format: options.format ?? "plain-text",
+    length: options.length ?? "medium",
+    preference: options.preference ?? "auto",
+    sharedContext: options.sharedContext ?? "",
+    ...langOptions,
+    ...(options.monitor ? { monitor: options.monitor } : {}),
+  };
+
+  return { lang, languageHints, createOptions };
+};
+
+export interface SummarizerLease {
+  /**
+   * Resolves when the native session is created. Rejects with
+   * `SummarizerUnavailableError` when the API is missing or creation fails.
+   */
+  ready: Promise<void>;
+  /**
+   * Idempotent. The final release destroys the session once no other lease
+   * or in-flight call uses it.
+   */
+  release(): void;
+}
+
+/**
+ * Start native session creation as soon as user intent is clear, before the
+ * input exists. The matching `summarize` call reuses the prepared session
+ * without a second create. Never throws synchronously; unavailability and
+ * creation failures reject `ready`. Failed preparations leave the cache so a
+ * later call can retry.
+ */
+export const prepareSummarizer = (
+  options: PrepareSummarizerOptions,
+): SummarizerLease => {
+  const api = getSummarizerApi();
+  if (!api?.create) {
+    const ready = Promise.reject(
+      new SummarizerUnavailableError(
+        "Summarizer API is not available in this environment.",
+      ),
+    );
+    // Keep unobserved leases from surfacing unhandled rejections.
+    ready.catch(() => {});
+    return { ready, release: () => {} };
+  }
+  const { createOptions } = resolveSessionConfig(options);
+  const lease = leaseSummarizer(api, createOptions);
+  const ready = lease.ready.catch((err) => {
+    const message = (err as Error)?.message ?? String(err);
+    throw new SummarizerUnavailableError(
+      `Summarizer.create() failed: ${message}`,
+    );
+  });
+  ready.catch(() => {});
+  return { ready, release: lease.release };
+};
+
+/**
  * Generate a summary. Uses streaming when the underlying instance supports
  * it, one-shot otherwise. Returns `{ output: null }` for empty input.
  * Throws `SummarizerUnavailableError` when the API isn't present in the
@@ -135,12 +257,7 @@ export const summarize = async (
   const text = options.input.trim();
   if (!text) return { output: null, cached: false };
 
-  const lang = NORMALIZE_LANG(options.language);
-  const supportedLanguages = (
-    options.supportedLanguages ?? DEFAULT_SUPPORTED_LANGUAGES
-  ).map(NORMALIZE_LANG);
-  const supported = new Set(supportedLanguages);
-  const languageHints = supported.has(lang);
+  const { lang, languageHints, createOptions } = resolveSessionConfig(options);
   const cache = resolveCache(options.cache, options.cacheTtl);
   const cacheKey =
     options.cacheKey ??
@@ -159,50 +276,28 @@ export const summarize = async (
     if (cached) return { output: cached, cached: true };
   }
 
-  const langOptions: Pick<
-    SummarizerCreateOptions,
-    "expectedInputLanguages" | "expectedContextLanguages" | "outputLanguage"
-  > = languageHints
-    ? {
-        expectedInputLanguages: [lang],
-        expectedContextLanguages: [lang],
-        outputLanguage: lang,
-      }
-    : {};
-
-  const baseCreateOptions: SummarizerCreateOptions = {
-    type: options.type ?? "tldr",
-    format: options.format ?? "plain-text",
-    length: options.length ?? "medium",
-    preference: options.preference ?? "auto",
-    sharedContext: options.sharedContext ?? "",
-    ...langOptions,
-    ...(options.monitor ? { monitor: options.monitor } : {}),
-  };
-
   // Pass the relevant create options to availability() so the probe describes
   // the configuration we are about to create. The narrower
   // SummarizerAvailabilityOptions shape filters out create-only fields such as
   // `sharedContext`.
   const availability = await api
     .availability({
-      ...(baseCreateOptions.type ? { type: baseCreateOptions.type } : {}),
-      ...(baseCreateOptions.format ? { format: baseCreateOptions.format } : {}),
-      ...(baseCreateOptions.length ? { length: baseCreateOptions.length } : {}),
-      ...(baseCreateOptions.preference
-        ? { preference: baseCreateOptions.preference }
+      ...(createOptions.type ? { type: createOptions.type } : {}),
+      ...(createOptions.format ? { format: createOptions.format } : {}),
+      ...(createOptions.length ? { length: createOptions.length } : {}),
+      ...(createOptions.preference
+        ? { preference: createOptions.preference }
         : {}),
-      ...(baseCreateOptions.expectedInputLanguages
-        ? { expectedInputLanguages: baseCreateOptions.expectedInputLanguages }
+      ...(createOptions.expectedInputLanguages
+        ? { expectedInputLanguages: createOptions.expectedInputLanguages }
         : {}),
-      ...(baseCreateOptions.expectedContextLanguages
+      ...(createOptions.expectedContextLanguages
         ? {
-            expectedContextLanguages:
-              baseCreateOptions.expectedContextLanguages,
+            expectedContextLanguages: createOptions.expectedContextLanguages,
           }
         : {}),
-      ...(baseCreateOptions.outputLanguage
-        ? { outputLanguage: baseCreateOptions.outputLanguage }
+      ...(createOptions.outputLanguage
+        ? { outputLanguage: createOptions.outputLanguage }
         : {}),
     })
     .catch(() => "unavailable" as const);
@@ -211,51 +306,59 @@ export const summarize = async (
   }
   if (options.signal?.aborted) throw new AbortError();
 
-  const sessionPromise = getOrCreateSummarizer(api, baseCreateOptions);
-
-  // Wrap session-create failures with context so consumers can branch on
-  // a single typed error instead of parsing browser-specific messages.
-  let summarizer: SummarizerInstance;
+  // The pin defers destruction (lease release, clear, eviction) until this
+  // call finishes.
+  const acquired = acquireSummarizer(api, createOptions);
   try {
-    summarizer = await sessionPromise;
-  } catch (err) {
-    if (err instanceof AbortError) throw err;
-    const message = (err as Error)?.message ?? String(err);
-    throw new SummarizerUnavailableError(
-      `Summarizer.create() failed: ${message}`,
-    );
-  }
-  if (options.signal?.aborted) throw new AbortError();
-
-  // Browser implementations may emit delta or cumulative chunks. Detect the
-  // shape per chunk and merge accordingly.
-  const mergeChunk = (buffer: string, chunk: string): string =>
-    chunk.startsWith(buffer) ? chunk : buffer + chunk;
-
-  let finalText: string;
-  if (typeof summarizer.summarizeStreaming === "function" && options.onUpdate) {
-    let buffer = "";
-    for await (const chunk of summarizer.summarizeStreaming(text)) {
-      if (options.signal?.aborted) throw new AbortError();
-      buffer = mergeChunk(buffer, chunk);
-      options.onUpdate(cleanSummary(buffer));
+    // Wrap session-create failures with context so consumers can branch on
+    // a single typed error instead of parsing browser-specific messages.
+    let summarizer: SummarizerInstance;
+    try {
+      summarizer = await acquired.session;
+    } catch (err) {
+      if (err instanceof AbortError) throw err;
+      const message = (err as Error)?.message ?? String(err);
+      throw new SummarizerUnavailableError(
+        `Summarizer.create() failed: ${message}`,
+      );
     }
-    finalText = cleanSummary(buffer);
-  } else if (typeof summarizer.summarizeStreaming === "function") {
-    let buffer = "";
-    for await (const chunk of summarizer.summarizeStreaming(text)) {
-      if (options.signal?.aborted) throw new AbortError();
-      buffer = mergeChunk(buffer, chunk);
-    }
-    finalText = cleanSummary(buffer);
-  } else {
-    const raw = await summarizer.summarize(text);
     if (options.signal?.aborted) throw new AbortError();
-    finalText = cleanSummary(raw);
-  }
 
-  if (finalText && cache) cache.set(cacheKey, finalText);
-  return { output: finalText || null, cached: false };
+    // Browser implementations may emit delta or cumulative chunks. Detect the
+    // shape per chunk and merge accordingly.
+    const mergeChunk = (buffer: string, chunk: string): string =>
+      chunk.startsWith(buffer) ? chunk : buffer + chunk;
+
+    let finalText: string;
+    if (
+      typeof summarizer.summarizeStreaming === "function" &&
+      options.onUpdate
+    ) {
+      let buffer = "";
+      for await (const chunk of summarizer.summarizeStreaming(text)) {
+        if (options.signal?.aborted) throw new AbortError();
+        buffer = mergeChunk(buffer, chunk);
+        options.onUpdate(cleanSummary(buffer));
+      }
+      finalText = cleanSummary(buffer);
+    } else if (typeof summarizer.summarizeStreaming === "function") {
+      let buffer = "";
+      for await (const chunk of summarizer.summarizeStreaming(text)) {
+        if (options.signal?.aborted) throw new AbortError();
+        buffer = mergeChunk(buffer, chunk);
+      }
+      finalText = cleanSummary(buffer);
+    } else {
+      const raw = await summarizer.summarize(text);
+      if (options.signal?.aborted) throw new AbortError();
+      finalText = cleanSummary(raw);
+    }
+
+    if (finalText && cache) cache.set(cacheKey, finalText);
+    return { output: finalText || null, cached: false };
+  } finally {
+    acquired.done();
+  }
 };
 
 class AbortError extends Error {

--- a/packages/summarizer/src/index.ts
+++ b/packages/summarizer/src/index.ts
@@ -128,6 +128,7 @@ export class SummarizerUnavailableError extends Error {
  * Session-affecting subset of `SummarizeOptions`. `prepareSummarizer` and
  * `summarize` derive the same native create options from these fields, so a
  * prepared session is reused by the matching call.
+ * `monitor` observes creation only; it never affects the cache key.
  */
 export type PrepareSummarizerOptions = Pick<
   SummarizeOptions,
@@ -148,8 +149,9 @@ interface SessionConfig {
 }
 
 /**
- * Single source of the option-to-session mapping. The session cache keys by
- * `createOptions`, so `summarize` and `prepareSummarizer` must both go
+ * Single source of the option-to-session mapping. The session cache key derives from
+ * the stable fields of `createOptions` (`monitor` never fragments reuse),
+ * so `summarize` and `prepareSummarizer` must both go
  * through this derivation.
  */
 const resolveSessionConfig = (

--- a/packages/summarizer/src/prepare.test.ts
+++ b/packages/summarizer/src/prepare.test.ts
@@ -1,0 +1,212 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  __clearSessionCacheForTests,
+  configureSummarizerCache,
+} from "./api.js";
+import {
+  clearSummarizerSessions,
+  prepareSummarizer,
+  SummarizerUnavailableError,
+  summarize,
+} from "./index.js";
+
+interface FakeSummarizer {
+  summarize: ReturnType<typeof vi.fn>;
+  destroy: ReturnType<typeof vi.fn>;
+}
+
+const makeInstance = (): FakeSummarizer => ({
+  summarize: vi.fn(async () => "TLDR."),
+  destroy: vi.fn(),
+});
+
+const installFakeApi = () => {
+  const instances: FakeSummarizer[] = [];
+  const api = {
+    availability: vi.fn(async () => "available" as const),
+    create: vi.fn(async () => {
+      const instance = makeInstance();
+      instances.push(instance);
+      return instance;
+    }),
+  };
+  (globalThis as { Summarizer?: unknown }).Summarizer = api;
+  return { api, instances };
+};
+
+const tick = () => new Promise<void>((resolve) => setTimeout(resolve, 0));
+
+beforeEach(() => {
+  __clearSessionCacheForTests();
+});
+
+afterEach(() => {
+  (globalThis as { Summarizer?: unknown }).Summarizer = undefined;
+});
+
+describe("prepareSummarizer", () => {
+  it("starts creation immediately and the matching summarize reuses it", async () => {
+    const { api } = installFakeApi();
+    const lease = prepareSummarizer({ language: "en" });
+    expect(api.create).toHaveBeenCalledTimes(1);
+    await lease.ready;
+
+    const result = await summarize({ language: "en", input: "Long text." });
+    expect(result.output).toBe("TLDR.");
+    expect(api.create).toHaveBeenCalledTimes(1);
+    lease.release();
+  });
+
+  it("never throws when the API is missing; ready rejects instead", async () => {
+    const lease = prepareSummarizer({ language: "en" });
+    await expect(lease.ready).rejects.toBeInstanceOf(
+      SummarizerUnavailableError,
+    );
+    expect(() => lease.release()).not.toThrow();
+  });
+
+  it("shares one session between concurrent leases and destroys exactly once", async () => {
+    const { api, instances } = installFakeApi();
+    const first = prepareSummarizer({ language: "en" });
+    const second = prepareSummarizer({ language: "en" });
+    expect(api.create).toHaveBeenCalledTimes(1);
+    await Promise.all([first.ready, second.ready]);
+
+    first.release();
+    first.release();
+    await tick();
+    expect(instances[0]?.destroy).not.toHaveBeenCalled();
+
+    second.release();
+    second.release();
+    await tick();
+    expect(instances[0]?.destroy).toHaveBeenCalledTimes(1);
+  });
+
+  it("release before creation settles destroys the session once created", async () => {
+    const { api } = installFakeApi();
+    let resolveCreate: (instance: FakeSummarizer) => void = () => {};
+    const instance = makeInstance();
+    api.create.mockImplementationOnce(
+      () =>
+        new Promise<FakeSummarizer>((resolve) => {
+          resolveCreate = resolve;
+        }),
+    );
+
+    const lease = prepareSummarizer({ language: "en" });
+    lease.release();
+    await tick();
+    expect(instance.destroy).not.toHaveBeenCalled();
+
+    resolveCreate(instance);
+    await tick();
+    expect(instance.destroy).toHaveBeenCalledTimes(1);
+
+    // The released entry left the cache, so preparing again creates anew.
+    const retry = prepareSummarizer({ language: "en" });
+    expect(api.create).toHaveBeenCalledTimes(2);
+    await retry.ready;
+    retry.release();
+  });
+
+  it("creation failure rejects ready, evicts the entry, and allows retry", async () => {
+    const { api } = installFakeApi();
+    api.create.mockRejectedValueOnce(new Error("no space"));
+
+    const failed = prepareSummarizer({ language: "en" });
+    await expect(failed.ready).rejects.toBeInstanceOf(
+      SummarizerUnavailableError,
+    );
+    failed.release();
+
+    const retry = prepareSummarizer({ language: "en" });
+    expect(api.create).toHaveBeenCalledTimes(2);
+    await expect(retry.ready).resolves.toBeUndefined();
+    retry.release();
+  });
+
+  it("defers destruction while inference is in flight", async () => {
+    const { instances } = installFakeApi();
+    const lease = prepareSummarizer({ language: "en" });
+    await lease.ready;
+
+    const instance = instances[0];
+    if (!instance) throw new Error("expected a created instance");
+    let resolveSummarize: (text: string) => void = () => {};
+    instance.summarize.mockImplementationOnce(
+      () =>
+        new Promise<string>((resolve) => {
+          resolveSummarize = resolve;
+        }),
+    );
+
+    const running = summarize({ language: "en", input: "Long text." });
+    await tick();
+    lease.release();
+    await tick();
+    expect(instance.destroy).not.toHaveBeenCalled();
+
+    resolveSummarize("TLDR.");
+    await expect(running).resolves.toEqual({ output: "TLDR.", cached: false });
+    await tick();
+    expect(instance.destroy).toHaveBeenCalledTimes(1);
+  });
+
+  it("pins leased entries against LRU eviction", async () => {
+    const { instances } = installFakeApi();
+    configureSummarizerCache({ max: 1 });
+
+    const lease = prepareSummarizer({ language: "en" });
+    await lease.ready;
+    await summarize({ language: "es", input: "Texto largo." });
+    await tick();
+
+    // Inserting a third entry trims to max; the leased "en" session survives
+    // and the unpinned "es" session is evicted.
+    const third = prepareSummarizer({ language: "ja" });
+    await third.ready;
+    await tick();
+    expect(instances[0]?.destroy).not.toHaveBeenCalled();
+    expect(instances[1]?.destroy).toHaveBeenCalledTimes(1);
+
+    lease.release();
+    third.release();
+  });
+
+  it("isolates leases per option key", async () => {
+    const { api, instances } = installFakeApi();
+    const english = prepareSummarizer({ language: "en" });
+    await english.ready;
+
+    await summarize({ language: "es", input: "Texto largo." });
+    expect(api.create).toHaveBeenCalledTimes(2);
+
+    english.release();
+    await tick();
+    expect(instances[0]?.destroy).toHaveBeenCalledTimes(1);
+    expect(instances[1]?.destroy).not.toHaveBeenCalled();
+
+    // The other configuration stays cached and reusable.
+    await summarize({ language: "es", input: "Texto largo." });
+    expect(api.create).toHaveBeenCalledTimes(2);
+  });
+
+  it("clear detaches leased sessions and destroys them on final release", async () => {
+    const { api, instances } = installFakeApi();
+    const lease = prepareSummarizer({ language: "en" });
+    await lease.ready;
+
+    clearSummarizerSessions();
+    await tick();
+    expect(instances[0]?.destroy).not.toHaveBeenCalled();
+
+    // The detached session no longer serves new calls.
+    await summarize({ language: "en", input: "Long text." });
+    expect(api.create).toHaveBeenCalledTimes(2);
+
+    lease.release();
+    await tick();
+    expect(instances[0]?.destroy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/summarizer/src/prepare.test.ts
+++ b/packages/summarizer/src/prepare.test.ts
@@ -209,4 +209,17 @@ describe("prepareSummarizer", () => {
     await tick();
     expect(instances[0]?.destroy).toHaveBeenCalledTimes(1);
   });
+
+  it("re-trims the cache when the last in-flight pin drops", async () => {
+    const { api, instances } = installFakeApi();
+    configureSummarizerCache({ max: 0 });
+
+    await summarize({ language: "en", input: "Long text." });
+    await tick();
+    expect(instances[0]?.destroy).toHaveBeenCalledTimes(1);
+
+    // Nothing stayed cached, so the same call creates a fresh session.
+    await summarize({ language: "en", input: "Long text." });
+    expect(api.create).toHaveBeenCalledTimes(2);
+  });
 });

--- a/packages/translator/README.md
+++ b/packages/translator/README.md
@@ -116,11 +116,36 @@ Forwards to the spec's `availability()` call. Returns `null` if the global is mi
 
 ### Session cache controls
 
-`configureTranslatorCache({ max })` bounds the internal warm `Translator` session cache (default `8`). `clearTranslatorSessions()` drops every warm session, and `clearTranslatorSession({ sourceLanguage, targetLanguage })` drops one matching language pair.
+`configureTranslatorCache({ max })` bounds the internal warm `Translator` session cache (default `8`). `clearTranslatorSessions()` drops every warm session, and `clearTranslatorSession({ sourceLanguage, targetLanguage })` drops one matching language pair. Clearing detaches sessions pinned by a lease or an in-flight call and destroys them when the last pin drops.
 
-### Lower-level helpers (advanced)
+### Prepare and release
 
-`getTranslatorApi`, `getOrCreateTranslator`, and `defaultCacheKey` are exported so you can compose your own pipeline or cache policy.
+`prepareTranslator(options)` starts native session creation when user intent is clear, before the input exists. It returns a `TranslatorLease`: `{ ready: Promise<void>; release(): void }`.
+
+```ts
+import { prepareTranslator, translate } from "@web-ai-sdk/translator";
+
+// User opens the translation menu: warm the session now.
+const translatorModel = prepareTranslator({ sourceLanguage: "en", targetLanguage: "pt" });
+
+// The matching call reuses the prepared session; no second create.
+const result = await translate({
+  input: "Hello, world.",
+  sourceLanguage: "en",
+  targetLanguage: "pt",
+});
+
+// User dismisses the feature: let the session go.
+translatorModel.release();
+```
+
+- `prepareTranslator` never throws synchronously. Unavailability and creation failure reject `ready` with `TranslatorUnavailableError`.
+- `release()` is idempotent. The final release destroys the session once no other lease or in-flight call uses it.
+- Releasing before creation settles destroys the session after creation succeeds.
+- Failed creation evicts the entry, so a later prepare retries.
+- Sessions with active leases never evict from the LRU cache.
+
+Reuse requires the same session-affecting options as the `translate` call. For this package those are `sourceLanguage`, `targetLanguage`, and `monitor` (`PrepareTranslatorOptions`).
 
 ## Caching
 

--- a/packages/translator/README.md
+++ b/packages/translator/README.md
@@ -145,7 +145,7 @@ translatorModel.release();
 - Failed creation evicts the entry, so a later prepare retries.
 - Sessions with active leases never evict from the LRU cache.
 
-Reuse requires the same session-affecting options as the `translate` call. For this package those are `sourceLanguage`, `targetLanguage`, and `monitor` (`PrepareTranslatorOptions`).
+Reuse requires the same session-affecting options as the `translate` call. For this package those are `sourceLanguage` and `targetLanguage` (`PrepareTranslatorOptions`). `monitor` observes creation only and never affects reuse.
 
 ## Caching
 

--- a/packages/translator/src/api.ts
+++ b/packages/translator/src/api.ts
@@ -273,6 +273,9 @@ export const acquireTranslator = (
       released = true;
       entry.inFlightCount -= 1;
       settleEntry(entry);
+      // The dropped pin may leave the cache over its cap; re-trim now
+      // instead of waiting for the next create or configure call.
+      trim();
     },
   };
 };

--- a/packages/translator/src/api.ts
+++ b/packages/translator/src/api.ts
@@ -89,10 +89,26 @@ interface CacheConfig {
 
 const cacheConfig: CacheConfig = { max: DEFAULT_MAX_CACHED_SESSIONS };
 
+interface SessionEntry {
+  key: string;
+  session: Promise<TranslatorInstance>;
+  /** Active prepare leases. Leased entries never evict. */
+  leaseCount: number;
+  /** Operations currently running inference on this session. */
+  inFlightCount: number;
+  /** Still reachable through `sessionCache`. */
+  inMap: boolean;
+  /** Destruction already scheduled; guards double-destroy. */
+  destroyed: boolean;
+}
+
 // Map iteration order is insertion order, which lets us use it as an LRU:
 // on hit we re-insert to bump recency, and on overflow we evict the
 // oldest (first) entry.
-const sessionCache = new Map<string, Promise<TranslatorInstance>>();
+const sessionCache = new Map<string, SessionEntry>();
+
+const isPinned = (entry: SessionEntry): boolean =>
+  entry.leaseCount > 0 || entry.inFlightCount > 0;
 
 const normalizeCacheMax = (max: number): number =>
   Number.isFinite(max) ? Math.max(0, Math.floor(max)) : 0;
@@ -119,11 +135,11 @@ export const configureTranslatorCache = (
   trim();
 };
 
-const destroySession = (entry: Promise<TranslatorInstance>): void => {
-  entry
-    .then((session) => {
+const destroySession = (session: Promise<TranslatorInstance>): void => {
+  session
+    .then((instance) => {
       try {
-        session.destroy?.();
+        instance.destroy?.();
       } catch {
         // best-effort; the spec doesn't require destroy to be infallible.
       }
@@ -133,22 +149,45 @@ const destroySession = (entry: Promise<TranslatorInstance>): void => {
     });
 };
 
+const detachEntry = (entry: SessionEntry): void => {
+  if (!entry.inMap) return;
+  entry.inMap = false;
+  sessionCache.delete(entry.key);
+};
+
+/**
+ * Destroy a detached entry once nothing pins it. Pinned entries are settled
+ * again when their last lease releases or their last in-flight call ends.
+ */
+const settleEntry = (entry: SessionEntry): void => {
+  if (entry.inMap || entry.destroyed || isPinned(entry)) return;
+  entry.destroyed = true;
+  destroySession(entry.session);
+};
+
 const trim = (): void => {
-  while (sessionCache.size > cacheConfig.max) {
-    const oldestKey = sessionCache.keys().next().value;
-    if (oldestKey === undefined) return;
-    const evicted = sessionCache.get(oldestKey);
-    sessionCache.delete(oldestKey);
-    if (evicted) destroySession(evicted);
+  if (sessionCache.size <= cacheConfig.max) return;
+  for (const entry of [...sessionCache.values()]) {
+    if (sessionCache.size <= cacheConfig.max) return;
+    // Leased or in-flight entries never evict, so the cache may temporarily
+    // exceed `max` while they stay pinned.
+    if (isPinned(entry)) continue;
+    detachEntry(entry);
+    settleEntry(entry);
   }
 };
 
-/** Drop every cached translator session. */
+/**
+ * Drop every cached translator session. Sessions live for the tab lifetime by
+ * default; call this to free them eagerly when navigating away from a feature
+ * that won't be revisited. Sessions pinned by a lease or an in-flight call
+ * leave the cache now and are destroyed once the last pin drops.
+ */
 export const clearTranslatorSessions = (): void => {
-  for (const entry of sessionCache.values()) {
-    destroySession(entry);
+  for (const entry of [...sessionCache.values()]) {
+    detachEntry(entry);
+    settleEntry(entry);
   }
-  sessionCache.clear();
 };
 
 const cacheKeyFor = (options: TranslatorAvailabilityOptions): string =>
@@ -156,41 +195,126 @@ const cacheKeyFor = (options: TranslatorAvailabilityOptions): string =>
     options.targetLanguage,
   )}`;
 
-/** Drop the cached translator session whose language pair matches `options`. */
+/**
+ * Drop the cached translator session whose language pair matches `options`.
+ */
 export const clearTranslatorSession = (
   options: TranslatorAvailabilityOptions,
 ): void => {
-  const key = cacheKeyFor(options);
-  const entry = sessionCache.get(key);
+  const entry = sessionCache.get(cacheKeyFor(options));
   if (!entry) return;
-  sessionCache.delete(key);
-  destroySession(entry);
+  detachEntry(entry);
+  settleEntry(entry);
 };
 
 /**
- * Get or create a `Translator` session for the given language pair. Sessions
- * live for the tab lifetime so navigating between same-language documents
- * skips the ~1-3s cold start. On `create()` failure the cache slot is purged
- * so the next call retries instead of returning a poisoned promise.
+ * Get or create the cache entry for the given language pair. Sessions live
+ * for the tab lifetime so navigating between same-language documents skips
+ * the ~1-3s cold start. On `create()` failure the cache slot is purged so the
+ * next call retries instead of returning a poisoned promise.
  */
-export const getOrCreateTranslator = (
+const getOrCreateEntry = (
   api: TranslatorApi,
   options: TranslatorCreateOptions,
-): Promise<TranslatorInstance> => {
+): SessionEntry => {
   const key = cacheKeyFor(options);
-  let session = sessionCache.get(key);
-  if (session) {
+  const existing = sessionCache.get(key);
+  if (existing) {
+    // Bump recency: delete + reinsert so this entry moves to the end of the
+    // LRU order.
     sessionCache.delete(key);
-    sessionCache.set(key, session);
-    return session;
+    sessionCache.set(key, existing);
+    return existing;
   }
-  session = api.create(options).catch((err) => {
-    sessionCache.delete(key);
-    throw err;
-  });
-  sessionCache.set(key, session);
+  const entry: SessionEntry = {
+    key,
+    session: api.create(options).catch((err) => {
+      detachEntry(entry);
+      throw err;
+    }),
+    leaseCount: 0,
+    inFlightCount: 0,
+    inMap: true,
+    destroyed: false,
+  };
+  // A prepare-only caller may never observe the session promise; keep the
+  // stored branch handled so failed creation cannot surface as an unhandled
+  // rejection.
+  entry.session.catch(() => {});
+  sessionCache.set(key, entry);
+  return entry;
+};
+
+export interface AcquiredTranslator {
+  session: Promise<TranslatorInstance>;
+  /** Release the in-flight pin. Idempotent. */
+  done(): void;
+}
+
+/**
+ * Get or create a `Translator` session and pin it for one operation. The pin
+ * defers destruction (final lease release, clear, eviction) until `done()`
+ * runs, so in-flight inference can never lose its session.
+ */
+export const acquireTranslator = (
+  api: TranslatorApi,
+  options: TranslatorCreateOptions,
+): AcquiredTranslator => {
+  const entry = getOrCreateEntry(api, options);
+  // Pin before trimming so a fresh entry can never evict itself when every
+  // other entry is pinned.
+  entry.inFlightCount += 1;
   trim();
-  return session;
+  let released = false;
+  return {
+    session: entry.session,
+    done: () => {
+      if (released) return;
+      released = true;
+      entry.inFlightCount -= 1;
+      settleEntry(entry);
+    },
+  };
+};
+
+export interface TranslatorSessionLease {
+  /** Settles with the underlying `create()` outcome. */
+  ready: Promise<void>;
+  /** Idempotent. The final release detaches and destroys once safe. */
+  release(): void;
+}
+
+/**
+ * Start (or join) session creation for the given language pair and hold a
+ * lease on the entry. Leases pin the entry against LRU eviction. The final
+ * release removes the entry from the cache and destroys the session as soon
+ * as no in-flight call uses it; released-before-ready sessions are destroyed
+ * when creation later succeeds.
+ */
+export const leaseTranslator = (
+  api: TranslatorApi,
+  options: TranslatorCreateOptions,
+): TranslatorSessionLease => {
+  const entry = getOrCreateEntry(api, options);
+  // Pin before trimming so a fresh entry can never evict itself when every
+  // other entry is pinned.
+  entry.leaseCount += 1;
+  trim();
+  let released = false;
+  const ready = entry.session.then(() => undefined);
+  // Keep unobserved leases from surfacing unhandled rejections.
+  ready.catch(() => {});
+  return {
+    ready,
+    release: () => {
+      if (released) return;
+      released = true;
+      entry.leaseCount -= 1;
+      if (entry.leaseCount > 0) return;
+      detachEntry(entry);
+      settleEntry(entry);
+    },
+  };
 };
 
 /** Test-only escape hatch; drop every cached session. */

--- a/packages/translator/src/index.ts
+++ b/packages/translator/src/index.ts
@@ -8,14 +8,15 @@
  */
 
 import {
+  acquireTranslator,
   type ConfigureTranslatorCacheOptions,
   checkAvailability,
   clearTranslatorSession,
   clearTranslatorSessions,
   configureTranslatorCache,
-  getOrCreateTranslator,
   getTranslatorApi,
   isAvailable,
+  leaseTranslator,
   type TranslatorApi,
   type TranslatorAvailability,
   type TranslatorAvailabilityOptions,
@@ -111,6 +112,86 @@ export class TranslatorUnavailableError extends Error {
   override readonly name = "TranslatorUnavailableError";
 }
 
+/**
+ * Session-affecting subset of `TranslateOptions`. `prepareTranslator` and
+ * `translate` derive the same native create options from these fields, so a
+ * prepared session is reused by the matching call.
+ */
+export type PrepareTranslatorOptions = Pick<
+  TranslateOptions,
+  "sourceLanguage" | "targetLanguage" | "monitor"
+>;
+
+interface SessionConfig {
+  sourceLanguage: string;
+  targetLanguage: string;
+  createOptions: TranslatorCreateOptions;
+}
+
+/**
+ * Single source of the option-to-session mapping. The session cache keys by
+ * the normalized language pair, so `translate` and `prepareTranslator` must
+ * both go through this derivation.
+ */
+const resolveSessionConfig = (
+  options: PrepareTranslatorOptions,
+): SessionConfig => {
+  const sourceLanguage = NORMALIZE_LANG(options.sourceLanguage);
+  const targetLanguage = NORMALIZE_LANG(options.targetLanguage ?? "en");
+  const createOptions: TranslatorCreateOptions = {
+    sourceLanguage,
+    targetLanguage,
+    ...(options.monitor ? { monitor: options.monitor } : {}),
+  };
+  return { sourceLanguage, targetLanguage, createOptions };
+};
+
+export interface TranslatorLease {
+  /**
+   * Resolves when the native session is created. Rejects with
+   * `TranslatorUnavailableError` when the API is missing or creation fails.
+   */
+  ready: Promise<void>;
+  /**
+   * Idempotent. The final release destroys the session once no other lease
+   * or in-flight call uses it.
+   */
+  release(): void;
+}
+
+/**
+ * Start native session creation as soon as user intent is clear, before the
+ * input exists. The matching `translate` call reuses the prepared session
+ * without a second create. Never throws synchronously; unavailability and
+ * creation failures reject `ready`. Failed preparations leave the cache so a
+ * later call can retry.
+ */
+export const prepareTranslator = (
+  options: PrepareTranslatorOptions,
+): TranslatorLease => {
+  const api = getTranslatorApi();
+  if (!api?.create) {
+    const ready = Promise.reject(
+      new TranslatorUnavailableError(
+        "Translator API is not available in this environment.",
+      ),
+    );
+    // Keep unobserved leases from surfacing unhandled rejections.
+    ready.catch(() => {});
+    return { ready, release: () => {} };
+  }
+  const { createOptions } = resolveSessionConfig(options);
+  const lease = leaseTranslator(api, createOptions);
+  const ready = lease.ready.catch((err) => {
+    const message = (err as Error)?.message ?? String(err);
+    throw new TranslatorUnavailableError(
+      `Translator.create() failed: ${message}`,
+    );
+  });
+  ready.catch(() => {});
+  return { ready, release: lease.release };
+};
+
 class TranslateAbortError extends Error {
   override readonly name = "AbortError";
   constructor() {
@@ -169,8 +250,8 @@ export const translate = async (
   const text = options.input.trim();
   if (!text) return { output: null, cached: false };
 
-  const sourceLanguage = NORMALIZE_LANG(options.sourceLanguage);
-  const targetLanguage = NORMALIZE_LANG(options.targetLanguage ?? "en");
+  const { sourceLanguage, targetLanguage, createOptions } =
+    resolveSessionConfig(options);
   if (sourceLanguage === targetLanguage) {
     return { output: null, cached: false };
   }
@@ -184,12 +265,6 @@ export const translate = async (
     if (cached) return { output: cached, cached: true };
   }
 
-  const createOptions: TranslatorCreateOptions = {
-    sourceLanguage,
-    targetLanguage,
-    ...(options.monitor ? { monitor: options.monitor } : {}),
-  };
-
   const availability = await api
     .availability({ sourceLanguage, targetLanguage })
     .catch(() => "unavailable" as const);
@@ -198,57 +273,65 @@ export const translate = async (
   }
   if (options.signal?.aborted) throw new TranslateAbortError();
 
-  const sessionPromise = getOrCreateTranslator(api, createOptions);
-
-  let session: TranslatorInstance;
+  // The pin defers destruction (lease release, clear, eviction) until this
+  // call finishes, including the streaming and abort paths below.
+  const acquired = acquireTranslator(api, createOptions);
   try {
-    // raceAbort rejects only this caller; the cached session promise stays
-    // untouched so other callers can still reuse it.
-    session = await raceAbort(sessionPromise, options.signal);
-  } catch (err) {
-    if (err instanceof TranslateAbortError) throw err;
-    const message = (err as Error)?.message ?? String(err);
-    throw new TranslatorUnavailableError(
-      `Translator.create() failed: ${message}`,
-    );
-  }
-
-  const taskOptions: TranslatorTranslateOptions = {
-    ...(options.signal ? { signal: options.signal } : {}),
-  };
-
-  // Browser implementations may emit delta or cumulative chunks. Detect the
-  // shape per chunk and merge accordingly.
-  const mergeChunk = (buffer: string, chunk: string): string =>
-    chunk.startsWith(buffer) ? chunk : buffer + chunk;
-
-  let output: string;
-  if (options.onUpdate && typeof session.translateStreaming === "function") {
-    const reader = session.translateStreaming(text, taskOptions).getReader();
-    let buffer = "";
+    let session: TranslatorInstance;
     try {
-      for (;;) {
-        const { done, value } = await raceAbort(reader.read(), options.signal);
-        if (done) break;
-        buffer = mergeChunk(buffer, value);
-        options.onUpdate(buffer);
-      }
+      // raceAbort rejects only this caller; the cached session promise stays
+      // untouched so other callers can still reuse it.
+      session = await raceAbort(acquired.session, options.signal);
     } catch (err) {
-      // Stop native work; the reader may already be errored, so best-effort.
-      reader.cancel().catch(() => {});
-      throw err;
+      if (err instanceof TranslateAbortError) throw err;
+      const message = (err as Error)?.message ?? String(err);
+      throw new TranslatorUnavailableError(
+        `Translator.create() failed: ${message}`,
+      );
     }
-    output = buffer;
-  } else {
-    output = await raceAbort(
-      session.translate(text, taskOptions),
-      options.signal,
-    );
-    // No native streaming: deliver the one-shot result as one final update.
-    if (output) options.onUpdate?.(output);
-  }
-  if (options.signal?.aborted) throw new TranslateAbortError();
 
-  if (output && cache) cache.set(cacheKey, output);
-  return { output: output || null, cached: false };
+    const taskOptions: TranslatorTranslateOptions = {
+      ...(options.signal ? { signal: options.signal } : {}),
+    };
+
+    // Browser implementations may emit delta or cumulative chunks. Detect the
+    // shape per chunk and merge accordingly.
+    const mergeChunk = (buffer: string, chunk: string): string =>
+      chunk.startsWith(buffer) ? chunk : buffer + chunk;
+
+    let output: string;
+    if (options.onUpdate && typeof session.translateStreaming === "function") {
+      const reader = session.translateStreaming(text, taskOptions).getReader();
+      let buffer = "";
+      try {
+        for (;;) {
+          const { done, value } = await raceAbort(
+            reader.read(),
+            options.signal,
+          );
+          if (done) break;
+          buffer = mergeChunk(buffer, value);
+          options.onUpdate(buffer);
+        }
+      } catch (err) {
+        // Stop native work; the reader may already be errored, so best-effort.
+        reader.cancel().catch(() => {});
+        throw err;
+      }
+      output = buffer;
+    } else {
+      output = await raceAbort(
+        session.translate(text, taskOptions),
+        options.signal,
+      );
+      // No native streaming: deliver the one-shot result as one final update.
+      if (output) options.onUpdate?.(output);
+    }
+    if (options.signal?.aborted) throw new TranslateAbortError();
+
+    if (output && cache) cache.set(cacheKey, output);
+    return { output: output || null, cached: false };
+  } finally {
+    acquired.done();
+  }
 };

--- a/packages/translator/src/index.ts
+++ b/packages/translator/src/index.ts
@@ -116,6 +116,7 @@ export class TranslatorUnavailableError extends Error {
  * Session-affecting subset of `TranslateOptions`. `prepareTranslator` and
  * `translate` derive the same native create options from these fields, so a
  * prepared session is reused by the matching call.
+ * `monitor` observes creation only; it never affects the cache key.
  */
 export type PrepareTranslatorOptions = Pick<
   TranslateOptions,

--- a/packages/translator/src/prepare.test.ts
+++ b/packages/translator/src/prepare.test.ts
@@ -275,4 +275,25 @@ describe("prepareTranslator", () => {
     await tick();
     expect(instances[0]?.destroy).toHaveBeenCalledTimes(1);
   });
+
+  it("re-trims the cache when the last in-flight pin drops", async () => {
+    const { api, instances } = installFakeApi();
+    configureTranslatorCache({ max: 0 });
+
+    await translate({
+      input: "Olá",
+      sourceLanguage: "pt",
+      targetLanguage: "en",
+    });
+    await tick();
+    expect(instances[0]?.destroy).toHaveBeenCalledTimes(1);
+
+    // Nothing stayed cached, so the same call creates a fresh session.
+    await translate({
+      input: "Olá",
+      sourceLanguage: "pt",
+      targetLanguage: "en",
+    });
+    expect(api.create).toHaveBeenCalledTimes(2);
+  });
 });

--- a/packages/translator/src/prepare.test.ts
+++ b/packages/translator/src/prepare.test.ts
@@ -1,0 +1,278 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  __clearSessionCacheForTests,
+  configureTranslatorCache,
+} from "./api.js";
+import {
+  clearTranslatorSessions,
+  prepareTranslator,
+  TranslatorUnavailableError,
+  translate,
+} from "./index.js";
+
+interface FakeTranslator {
+  translate: ReturnType<typeof vi.fn>;
+  destroy: ReturnType<typeof vi.fn>;
+}
+
+const makeInstance = (): FakeTranslator => ({
+  translate: vi.fn(async (text: string) => `[t]${text}`),
+  destroy: vi.fn(),
+});
+
+const installFakeApi = () => {
+  const instances: FakeTranslator[] = [];
+  const api = {
+    availability: vi.fn(async () => "available" as const),
+    create: vi.fn(async () => {
+      const instance = makeInstance();
+      instances.push(instance);
+      return instance;
+    }),
+  };
+  (globalThis as { Translator?: unknown }).Translator = api;
+  return { api, instances };
+};
+
+const tick = () => new Promise<void>((resolve) => setTimeout(resolve, 0));
+
+beforeEach(() => {
+  __clearSessionCacheForTests();
+});
+
+afterEach(() => {
+  (globalThis as { Translator?: unknown }).Translator = undefined;
+});
+
+describe("prepareTranslator", () => {
+  it("starts creation immediately and the matching translate reuses it", async () => {
+    const { api } = installFakeApi();
+    const lease = prepareTranslator({
+      sourceLanguage: "pt",
+      targetLanguage: "en",
+    });
+    expect(api.create).toHaveBeenCalledTimes(1);
+    await lease.ready;
+
+    const result = await translate({
+      input: "Olá",
+      sourceLanguage: "pt",
+      targetLanguage: "en",
+    });
+    expect(result.output).toBe("[t]Olá");
+    expect(api.create).toHaveBeenCalledTimes(1);
+    lease.release();
+  });
+
+  it("never throws when the API is missing; ready rejects instead", async () => {
+    const lease = prepareTranslator({
+      sourceLanguage: "pt",
+      targetLanguage: "en",
+    });
+    await expect(lease.ready).rejects.toBeInstanceOf(
+      TranslatorUnavailableError,
+    );
+    expect(() => lease.release()).not.toThrow();
+  });
+
+  it("shares one session between concurrent leases and destroys exactly once", async () => {
+    const { api, instances } = installFakeApi();
+    const first = prepareTranslator({
+      sourceLanguage: "pt",
+      targetLanguage: "en",
+    });
+    const second = prepareTranslator({
+      sourceLanguage: "pt",
+      targetLanguage: "en",
+    });
+    expect(api.create).toHaveBeenCalledTimes(1);
+    await Promise.all([first.ready, second.ready]);
+
+    first.release();
+    first.release();
+    await tick();
+    expect(instances[0]?.destroy).not.toHaveBeenCalled();
+
+    second.release();
+    second.release();
+    await tick();
+    expect(instances[0]?.destroy).toHaveBeenCalledTimes(1);
+  });
+
+  it("release before creation settles destroys the session once created", async () => {
+    const { api } = installFakeApi();
+    let resolveCreate: (instance: FakeTranslator) => void = () => {};
+    const instance = makeInstance();
+    api.create.mockImplementationOnce(
+      () =>
+        new Promise<FakeTranslator>((resolve) => {
+          resolveCreate = resolve;
+        }),
+    );
+
+    const lease = prepareTranslator({
+      sourceLanguage: "pt",
+      targetLanguage: "en",
+    });
+    lease.release();
+    await tick();
+    expect(instance.destroy).not.toHaveBeenCalled();
+
+    resolveCreate(instance);
+    await tick();
+    expect(instance.destroy).toHaveBeenCalledTimes(1);
+
+    // The released entry left the cache, so preparing again creates anew.
+    const retry = prepareTranslator({
+      sourceLanguage: "pt",
+      targetLanguage: "en",
+    });
+    expect(api.create).toHaveBeenCalledTimes(2);
+    await retry.ready;
+    retry.release();
+  });
+
+  it("creation failure rejects ready, evicts the entry, and allows retry", async () => {
+    const { api } = installFakeApi();
+    api.create.mockRejectedValueOnce(new Error("no space"));
+
+    const failed = prepareTranslator({
+      sourceLanguage: "pt",
+      targetLanguage: "en",
+    });
+    await expect(failed.ready).rejects.toBeInstanceOf(
+      TranslatorUnavailableError,
+    );
+    failed.release();
+
+    const retry = prepareTranslator({
+      sourceLanguage: "pt",
+      targetLanguage: "en",
+    });
+    expect(api.create).toHaveBeenCalledTimes(2);
+    await expect(retry.ready).resolves.toBeUndefined();
+    retry.release();
+  });
+
+  it("defers destruction while inference is in flight", async () => {
+    const { instances } = installFakeApi();
+    const lease = prepareTranslator({
+      sourceLanguage: "pt",
+      targetLanguage: "en",
+    });
+    await lease.ready;
+
+    const instance = instances[0];
+    if (!instance) throw new Error("expected a created instance");
+    let resolveTranslate: (text: string) => void = () => {};
+    instance.translate.mockImplementationOnce(
+      () =>
+        new Promise<string>((resolve) => {
+          resolveTranslate = resolve;
+        }),
+    );
+
+    const running = translate({
+      input: "Olá",
+      sourceLanguage: "pt",
+      targetLanguage: "en",
+    });
+    await tick();
+    lease.release();
+    await tick();
+    expect(instance.destroy).not.toHaveBeenCalled();
+
+    resolveTranslate("[t]Olá");
+    await expect(running).resolves.toEqual({
+      output: "[t]Olá",
+      cached: false,
+    });
+    await tick();
+    expect(instance.destroy).toHaveBeenCalledTimes(1);
+  });
+
+  it("pins leased entries against LRU eviction", async () => {
+    const { instances } = installFakeApi();
+    configureTranslatorCache({ max: 1 });
+
+    const lease = prepareTranslator({
+      sourceLanguage: "pt",
+      targetLanguage: "en",
+    });
+    await lease.ready;
+    await translate({
+      input: "Hola",
+      sourceLanguage: "es",
+      targetLanguage: "en",
+    });
+    await tick();
+
+    // Inserting a third entry trims to max; the leased "pt->en" session
+    // survives and the unpinned "es->en" session is evicted.
+    const third = prepareTranslator({
+      sourceLanguage: "fr",
+      targetLanguage: "en",
+    });
+    await third.ready;
+    await tick();
+    expect(instances[0]?.destroy).not.toHaveBeenCalled();
+    expect(instances[1]?.destroy).toHaveBeenCalledTimes(1);
+
+    lease.release();
+    third.release();
+  });
+
+  it("isolates leases per language pair", async () => {
+    const { api, instances } = installFakeApi();
+    const ptToEn = prepareTranslator({
+      sourceLanguage: "pt",
+      targetLanguage: "en",
+    });
+    await ptToEn.ready;
+
+    await translate({
+      input: "Hola",
+      sourceLanguage: "es",
+      targetLanguage: "en",
+    });
+    expect(api.create).toHaveBeenCalledTimes(2);
+
+    ptToEn.release();
+    await tick();
+    expect(instances[0]?.destroy).toHaveBeenCalledTimes(1);
+    expect(instances[1]?.destroy).not.toHaveBeenCalled();
+
+    // The other language pair stays cached and reusable.
+    await translate({
+      input: "Hola",
+      sourceLanguage: "es",
+      targetLanguage: "en",
+    });
+    expect(api.create).toHaveBeenCalledTimes(2);
+  });
+
+  it("clear detaches leased sessions and destroys them on final release", async () => {
+    const { api, instances } = installFakeApi();
+    const lease = prepareTranslator({
+      sourceLanguage: "pt",
+      targetLanguage: "en",
+    });
+    await lease.ready;
+
+    clearTranslatorSessions();
+    await tick();
+    expect(instances[0]?.destroy).not.toHaveBeenCalled();
+
+    // The detached session no longer serves new calls.
+    await translate({
+      input: "Olá",
+      sourceLanguage: "pt",
+      targetLanguage: "en",
+    });
+    expect(api.create).toHaveBeenCalledTimes(2);
+
+    lease.release();
+    await tick();
+    expect(instances[0]?.destroy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/writer/README.md
+++ b/packages/writer/README.md
@@ -102,7 +102,43 @@ import {
 } from "@web-ai-sdk/writer";
 ```
 
-The internal session cache is LRU-bounded (default 8). Evicted sessions have their `destroy()` invoked when present.
+The internal session cache is LRU-bounded (default 8). Evicted sessions have their `destroy()` invoked when present. Clearing detaches sessions pinned by a lease or an in-flight call and destroys them when the last pin drops.
+
+### Prepare and release
+
+`prepareWriter(options)` starts native session creation when user intent is clear, before the input exists. It returns a `WriterLease`:
+
+```ts
+interface WriterLease {
+  ready: Promise<void>; // settles when native creation settles
+  release(): void;      // idempotent
+}
+```
+
+```ts
+import { prepareWriter, write } from "@web-ai-sdk/writer";
+
+// User opened the compose panel; warm the session now.
+const writerModel = prepareWriter({ tone: "formal", length: "medium" });
+
+// The matching call reuses the prepared session with no second create.
+const result = await write({
+  input: "An inquiry to my bank about how to enable wire transfers.",
+  tone: "formal",
+  length: "medium",
+});
+
+// User dismissed the panel.
+writerModel.release();
+```
+
+- `prepareWriter` never throws synchronously. Unavailability and creation failure reject `ready` with `WriterUnavailableError`.
+- `release()` is idempotent. The final release destroys the session once no other lease or in-flight call uses it.
+- Releasing before creation settles destroys the session after creation succeeds.
+- Failed creation evicts the entry, so a later prepare retries.
+- Sessions with active leases never evict from the LRU cache.
+
+Reuse requires the same session-affecting options as the `write` call. `PrepareWriterOptions` covers `language`, `supportedLanguages`, `tone`, `format`, `length`, `sharedContext`, and `monitor`.
 
 ## Result caching
 

--- a/packages/writer/README.md
+++ b/packages/writer/README.md
@@ -138,7 +138,7 @@ writerModel.release();
 - Failed creation evicts the entry, so a later prepare retries.
 - Sessions with active leases never evict from the LRU cache.
 
-Reuse requires the same session-affecting options as the `write` call. `PrepareWriterOptions` covers `language`, `supportedLanguages`, `tone`, `format`, `length`, `sharedContext`, and `monitor`.
+Reuse requires the same session-affecting options as the `write` call. `PrepareWriterOptions` covers `language`, `supportedLanguages`, `tone`, `format`, `length`, and `sharedContext`. `monitor` observes creation only and never affects reuse.
 
 ## Result caching
 

--- a/packages/writer/src/api.ts
+++ b/packages/writer/src/api.ts
@@ -297,6 +297,9 @@ export const acquireWriter = (
       released = true;
       entry.inFlightCount -= 1;
       settleEntry(entry);
+      // The dropped pin may leave the cache over its cap; re-trim now
+      // instead of waiting for the next create or configure call.
+      trim();
     },
   };
 };

--- a/packages/writer/src/api.ts
+++ b/packages/writer/src/api.ts
@@ -110,10 +110,26 @@ interface CacheConfig {
 
 const cacheConfig: CacheConfig = { max: DEFAULT_MAX_CACHED_SESSIONS };
 
+interface SessionEntry {
+  key: string;
+  session: Promise<WriterInstance>;
+  /** Active prepare leases. Leased entries never evict. */
+  leaseCount: number;
+  /** Operations currently running inference on this session. */
+  inFlightCount: number;
+  /** Still reachable through `sessionCache`. */
+  inMap: boolean;
+  /** Destruction already scheduled; guards double-destroy. */
+  destroyed: boolean;
+}
+
 // Map iteration order is insertion order, which lets us use it as an LRU:
 // on hit we re-insert to bump recency, and on overflow we evict the
 // oldest (first) entry.
-const sessionCache = new Map<string, Promise<WriterInstance>>();
+const sessionCache = new Map<string, SessionEntry>();
+
+const isPinned = (entry: SessionEntry): boolean =>
+  entry.leaseCount > 0 || entry.inFlightCount > 0;
 
 const normalizeCacheMax = (max: number): number =>
   Number.isFinite(max) ? Math.max(0, Math.floor(max)) : 0;
@@ -137,11 +153,11 @@ export const configureWriterCache = (
   trim();
 };
 
-const destroySession = (entry: Promise<WriterInstance>): void => {
-  entry
-    .then((session) => {
+const destroySession = (session: Promise<WriterInstance>): void => {
+  session
+    .then((instance) => {
       try {
-        session.destroy?.();
+        instance.destroy?.();
       } catch {
         // best-effort; the spec doesn't require destroy to be infallible.
       }
@@ -151,26 +167,45 @@ const destroySession = (entry: Promise<WriterInstance>): void => {
     });
 };
 
+const detachEntry = (entry: SessionEntry): void => {
+  if (!entry.inMap) return;
+  entry.inMap = false;
+  sessionCache.delete(entry.key);
+};
+
+/**
+ * Destroy a detached entry once nothing pins it. Pinned entries are settled
+ * again when their last lease releases or their last in-flight call ends.
+ */
+const settleEntry = (entry: SessionEntry): void => {
+  if (entry.inMap || entry.destroyed || isPinned(entry)) return;
+  entry.destroyed = true;
+  destroySession(entry.session);
+};
+
 const trim = (): void => {
-  while (sessionCache.size > cacheConfig.max) {
-    const oldestKey = sessionCache.keys().next().value;
-    if (oldestKey === undefined) return;
-    const evicted = sessionCache.get(oldestKey);
-    sessionCache.delete(oldestKey);
-    if (evicted) destroySession(evicted);
+  if (sessionCache.size <= cacheConfig.max) return;
+  for (const entry of [...sessionCache.values()]) {
+    if (sessionCache.size <= cacheConfig.max) return;
+    // Leased or in-flight entries never evict, so the cache may temporarily
+    // exceed `max` while they stay pinned.
+    if (isPinned(entry)) continue;
+    detachEntry(entry);
+    settleEntry(entry);
   }
 };
 
 /**
  * Drop every cached writer session. Sessions live for the tab lifetime by
  * default; call this to free them eagerly when navigating away from a feature
- * that won't be revisited.
+ * that won't be revisited. Sessions pinned by a lease or an in-flight call
+ * leave the cache now and are destroyed once the last pin drops.
  */
 export const clearWriterSessions = (): void => {
-  for (const entry of sessionCache.values()) {
-    destroySession(entry);
+  for (const entry of [...sessionCache.values()]) {
+    detachEntry(entry);
+    settleEntry(entry);
   }
-  sessionCache.clear();
 };
 
 // `signal` and `monitor` are per-call ephemera; drop them from the key so
@@ -190,37 +225,120 @@ const cacheKeyFor = (options: WriterCreateOptions): string =>
  * Drop the cached writer whose create-options match `options`.
  */
 export const clearWriterSession = (options: WriterCreateOptions): void => {
-  const key = cacheKeyFor(options);
-  const entry = sessionCache.get(key);
+  const entry = sessionCache.get(cacheKeyFor(options));
   if (!entry) return;
-  sessionCache.delete(key);
-  destroySession(entry);
+  detachEntry(entry);
+  settleEntry(entry);
 };
 
 /**
- * Get or create a `Writer` session for the given options. Sessions live for
- * the tab lifetime so consecutive same-config calls skip the cold start. On
+ * Get or create the cache entry for the given options. Sessions live for the
+ * tab lifetime so consecutive same-config calls skip the cold start. On
  * `create()` failure the cache slot is purged so the next call retries
  * instead of returning a poisoned promise.
  */
-export const getOrCreateWriter = (
+const getOrCreateEntry = (
   api: WriterApi,
   options: WriterCreateOptions,
-): Promise<WriterInstance> => {
+): SessionEntry => {
   const key = cacheKeyFor(options);
-  let session = sessionCache.get(key);
-  if (session) {
+  const existing = sessionCache.get(key);
+  if (existing) {
+    // Bump recency: delete + reinsert so this entry moves to the end of the
+    // LRU order.
     sessionCache.delete(key);
-    sessionCache.set(key, session);
-    return session;
+    sessionCache.set(key, existing);
+    return existing;
   }
-  session = api.create(options).catch((err) => {
-    sessionCache.delete(key);
-    throw err;
-  });
-  sessionCache.set(key, session);
+  const entry: SessionEntry = {
+    key,
+    session: api.create(options).catch((err) => {
+      detachEntry(entry);
+      throw err;
+    }),
+    leaseCount: 0,
+    inFlightCount: 0,
+    inMap: true,
+    destroyed: false,
+  };
+  // A prepare-only caller may never observe the session promise; keep the
+  // stored branch handled so failed creation cannot surface as an unhandled
+  // rejection.
+  entry.session.catch(() => {});
+  sessionCache.set(key, entry);
+  return entry;
+};
+
+export interface AcquiredWriter {
+  session: Promise<WriterInstance>;
+  /** Release the in-flight pin. Idempotent. */
+  done(): void;
+}
+
+/**
+ * Get or create a `Writer` session and pin it for one operation. The pin
+ * defers destruction (final lease release, clear, eviction) until `done()`
+ * runs, so in-flight inference can never lose its session.
+ */
+export const acquireWriter = (
+  api: WriterApi,
+  options: WriterCreateOptions,
+): AcquiredWriter => {
+  const entry = getOrCreateEntry(api, options);
+  // Pin before trimming so a fresh entry can never evict itself when every
+  // other entry is pinned.
+  entry.inFlightCount += 1;
   trim();
-  return session;
+  let released = false;
+  return {
+    session: entry.session,
+    done: () => {
+      if (released) return;
+      released = true;
+      entry.inFlightCount -= 1;
+      settleEntry(entry);
+    },
+  };
+};
+
+export interface WriterSessionLease {
+  /** Settles with the underlying `create()` outcome. */
+  ready: Promise<void>;
+  /** Idempotent. The final release detaches and destroys once safe. */
+  release(): void;
+}
+
+/**
+ * Start (or join) session creation for the given options and hold a lease on
+ * the entry. Leases pin the entry against LRU eviction. The final release
+ * removes the entry from the cache and destroys the session as soon as no
+ * in-flight call uses it; released-before-ready sessions are destroyed when
+ * creation later succeeds.
+ */
+export const leaseWriter = (
+  api: WriterApi,
+  options: WriterCreateOptions,
+): WriterSessionLease => {
+  const entry = getOrCreateEntry(api, options);
+  // Pin before trimming so a fresh entry can never evict itself when every
+  // other entry is pinned.
+  entry.leaseCount += 1;
+  trim();
+  let released = false;
+  const ready = entry.session.then(() => undefined);
+  // Keep unobserved leases from surfacing unhandled rejections.
+  ready.catch(() => {});
+  return {
+    ready,
+    release: () => {
+      if (released) return;
+      released = true;
+      entry.leaseCount -= 1;
+      if (entry.leaseCount > 0) return;
+      detachEntry(entry);
+      settleEntry(entry);
+    },
+  };
 };
 
 /** Test-only escape hatch; drop every cached session. */

--- a/packages/writer/src/index.ts
+++ b/packages/writer/src/index.ts
@@ -124,6 +124,7 @@ class WriterAbortError extends Error {
  * Session-affecting subset of `WriteOptions`. `prepareWriter` and `write`
  * derive the same native create options from these fields, so a prepared
  * session is reused by the matching call.
+ * `monitor` observes creation only; it never affects the cache key.
  */
 export type PrepareWriterOptions = Pick<
   WriteOptions,
@@ -143,8 +144,9 @@ interface SessionConfig {
 }
 
 /**
- * Single source of the option-to-session mapping. The session cache keys by
- * `createOptions`, so `write` and `prepareWriter` must both go through this
+ * Single source of the option-to-session mapping. The session cache key derives from
+ * the stable fields of `createOptions` (`monitor` never fragments reuse),
+ * so `write` and `prepareWriter` must both go through this
  * derivation.
  */
 const resolveSessionConfig = (options: PrepareWriterOptions): SessionConfig => {

--- a/packages/writer/src/index.ts
+++ b/packages/writer/src/index.ts
@@ -8,9 +8,11 @@
  */
 
 import {
+  acquireWriter,
+  type ConfigureWriterCacheOptions,
   type CreateMonitor,
-  getOrCreateWriter,
   getWriterApi,
+  leaseWriter,
   type WriterApi,
   type WriterAvailability,
   type WriterAvailabilityOptions,
@@ -29,19 +31,14 @@ export {
   clearWriterSession,
   clearWriterSessions,
   configureWriterCache,
-  getOrCreateWriter,
-  getWriterApi,
   isAvailable,
 } from "./api.js";
 
-export {
-  DEFAULT_CACHE_TTL_MS,
-  defaultCacheKey,
-  resolveCache,
-} from "./cache.js";
+export { DEFAULT_CACHE_TTL_MS } from "./cache.js";
 
 export type {
   CacheOption,
+  ConfigureWriterCacheOptions,
   CreateMonitor,
   WriteCache,
   WriterApi,
@@ -124,6 +121,108 @@ class WriterAbortError extends Error {
 }
 
 /**
+ * Session-affecting subset of `WriteOptions`. `prepareWriter` and `write`
+ * derive the same native create options from these fields, so a prepared
+ * session is reused by the matching call.
+ */
+export type PrepareWriterOptions = Pick<
+  WriteOptions,
+  | "language"
+  | "supportedLanguages"
+  | "tone"
+  | "format"
+  | "length"
+  | "sharedContext"
+  | "monitor"
+>;
+
+interface SessionConfig {
+  lang: string | undefined;
+  languageHints: boolean;
+  createOptions: WriterCreateOptions;
+}
+
+/**
+ * Single source of the option-to-session mapping. The session cache keys by
+ * `createOptions`, so `write` and `prepareWriter` must both go through this
+ * derivation.
+ */
+const resolveSessionConfig = (options: PrepareWriterOptions): SessionConfig => {
+  const lang = options.language ? NORMALIZE_LANG(options.language) : undefined;
+  const supported = new Set(
+    (options.supportedLanguages ?? DEFAULT_SUPPORTED_LANGUAGES).map(
+      NORMALIZE_LANG,
+    ),
+  );
+  const languageHints = lang ? supported.has(lang) : false;
+
+  const langOptions: Pick<
+    WriterCreateOptions,
+    "expectedInputLanguages" | "expectedContextLanguages" | "outputLanguage"
+  > =
+    lang && languageHints
+      ? {
+          expectedInputLanguages: [lang],
+          expectedContextLanguages: [lang],
+          outputLanguage: lang,
+        }
+      : {};
+
+  const createOptions: WriterCreateOptions = {
+    tone: options.tone ?? "neutral",
+    format: options.format ?? "markdown",
+    length: options.length ?? "short",
+    sharedContext: options.sharedContext ?? "",
+    ...langOptions,
+    ...(options.monitor ? { monitor: options.monitor } : {}),
+  };
+
+  return { lang, languageHints, createOptions };
+};
+
+export interface WriterLease {
+  /**
+   * Resolves when the native session is created. Rejects with
+   * `WriterUnavailableError` when the API is missing or creation fails.
+   */
+  ready: Promise<void>;
+  /**
+   * Idempotent. The final release destroys the session once no other lease
+   * or in-flight call uses it.
+   */
+  release(): void;
+}
+
+/**
+ * Start native session creation as soon as user intent is clear, before the
+ * input exists. The matching `write` call reuses the prepared session
+ * without a second create. Never throws synchronously; unavailability and
+ * creation failures reject `ready`. Failed preparations leave the cache so a
+ * later call can retry.
+ */
+export const prepareWriter = (options: PrepareWriterOptions): WriterLease => {
+  const api = getWriterApi();
+  if (!api?.create) {
+    const ready = Promise.reject(
+      new WriterUnavailableError(
+        "Writer API is not available in this environment.",
+      ),
+    );
+    // Keep unobserved leases from surfacing unhandled rejections.
+    ready.catch(() => {});
+    return { ready, release: () => {} };
+  }
+  const { createOptions } = resolveSessionConfig(options);
+  const lease = leaseWriter(api, createOptions);
+  const ready = lease.ready.catch((err) => {
+    const message = (err as Error)?.message ?? String(err);
+    throw new WriterUnavailableError(`Writer.create() failed: ${message}`);
+  });
+  ready.catch(() => {});
+  return { ready, release: lease.release };
+};
+
+/**
  * Generate new content for a writing task. Uses streaming when the underlying
  * instance supports it, one-shot otherwise. Returns `{ output: null }` for
  * empty input. Throws `WriterUnavailableError` when the API isn't present in
@@ -143,12 +242,7 @@ export const write = async (options: WriteOptions): Promise<WriteResult> => {
   const text = options.input.trim();
   if (!text) return { output: null, cached: false };
 
-  const lang = options.language ? NORMALIZE_LANG(options.language) : undefined;
-  const supportedLanguages = (
-    options.supportedLanguages ?? DEFAULT_SUPPORTED_LANGUAGES
-  ).map(NORMALIZE_LANG);
-  const supported = new Set(supportedLanguages);
-  const languageHints = lang ? supported.has(lang) : false;
+  const { lang, languageHints, createOptions } = resolveSessionConfig(options);
   const cache = resolveCache(options.cache, options.cacheTtl);
   const cacheKey =
     options.cacheKey ??
@@ -167,45 +261,23 @@ export const write = async (options: WriteOptions): Promise<WriteResult> => {
     if (cached) return { output: cached, cached: true };
   }
 
-  const langOptions: Pick<
-    WriterCreateOptions,
-    "expectedInputLanguages" | "expectedContextLanguages" | "outputLanguage"
-  > =
-    lang && languageHints
-      ? {
-          expectedInputLanguages: [lang],
-          expectedContextLanguages: [lang],
-          outputLanguage: lang,
-        }
-      : {};
-
-  const baseCreateOptions: WriterCreateOptions = {
-    tone: options.tone ?? "neutral",
-    format: options.format ?? "markdown",
-    length: options.length ?? "short",
-    sharedContext: options.sharedContext ?? "",
-    ...langOptions,
-    ...(options.monitor ? { monitor: options.monitor } : {}),
-  };
-
   // Pass the same shape to availability() as we do to create() so engines
   // that warn on mismatch stay quiet.
   const availability = await api
     .availability({
-      ...(baseCreateOptions.tone ? { tone: baseCreateOptions.tone } : {}),
-      ...(baseCreateOptions.format ? { format: baseCreateOptions.format } : {}),
-      ...(baseCreateOptions.length ? { length: baseCreateOptions.length } : {}),
-      ...(baseCreateOptions.expectedInputLanguages
-        ? { expectedInputLanguages: baseCreateOptions.expectedInputLanguages }
+      ...(createOptions.tone ? { tone: createOptions.tone } : {}),
+      ...(createOptions.format ? { format: createOptions.format } : {}),
+      ...(createOptions.length ? { length: createOptions.length } : {}),
+      ...(createOptions.expectedInputLanguages
+        ? { expectedInputLanguages: createOptions.expectedInputLanguages }
         : {}),
-      ...(baseCreateOptions.expectedContextLanguages
+      ...(createOptions.expectedContextLanguages
         ? {
-            expectedContextLanguages:
-              baseCreateOptions.expectedContextLanguages,
+            expectedContextLanguages: createOptions.expectedContextLanguages,
           }
         : {}),
-      ...(baseCreateOptions.outputLanguage
-        ? { outputLanguage: baseCreateOptions.outputLanguage }
+      ...(createOptions.outputLanguage
+        ? { outputLanguage: createOptions.outputLanguage }
         : {}),
     })
     .catch(() => "unavailable" as const);
@@ -214,45 +286,50 @@ export const write = async (options: WriteOptions): Promise<WriteResult> => {
   }
   if (options.signal?.aborted) throw new WriterAbortError();
 
-  const sessionPromise = getOrCreateWriter(api, baseCreateOptions);
-
-  // Wrap session-create failures with context so consumers can branch on a
-  // single typed error instead of parsing browser-specific messages.
-  let writer: WriterInstance;
+  // The pin defers destruction (lease release, clear, eviction) until this
+  // call finishes.
+  const acquired = acquireWriter(api, createOptions);
   try {
-    writer = await sessionPromise;
-  } catch (err) {
-    if (err instanceof WriterAbortError) throw err;
-    const message = (err as Error)?.message ?? String(err);
-    throw new WriterUnavailableError(`Writer.create() failed: ${message}`);
-  }
-  if (options.signal?.aborted) throw new WriterAbortError();
-
-  const taskOptions = {
-    ...(options.context !== undefined ? { context: options.context } : {}),
-    ...(options.signal ? { signal: options.signal } : {}),
-  };
-
-  // Browser implementations may emit delta or cumulative chunks. Detect the
-  // shape per chunk and merge accordingly.
-  const mergeChunk = (buffer: string, chunk: string): string =>
-    chunk.startsWith(buffer) ? chunk : buffer + chunk;
-
-  let finalText: string;
-  if (typeof writer.writeStreaming === "function") {
-    let buffer = "";
-    for await (const chunk of writer.writeStreaming(text, taskOptions)) {
-      if (options.signal?.aborted) throw new WriterAbortError();
-      buffer = mergeChunk(buffer, chunk);
-      options.onUpdate?.(buffer);
+    // Wrap session-create failures with context so consumers can branch on a
+    // single typed error instead of parsing browser-specific messages.
+    let writer: WriterInstance;
+    try {
+      writer = await acquired.session;
+    } catch (err) {
+      if (err instanceof WriterAbortError) throw err;
+      const message = (err as Error)?.message ?? String(err);
+      throw new WriterUnavailableError(`Writer.create() failed: ${message}`);
     }
-    finalText = buffer.trim();
-  } else {
-    const raw = await writer.write(text, taskOptions);
     if (options.signal?.aborted) throw new WriterAbortError();
-    finalText = raw.trim();
-  }
 
-  if (finalText && cache) cache.set(cacheKey, finalText);
-  return { output: finalText || null, cached: false };
+    const taskOptions = {
+      ...(options.context !== undefined ? { context: options.context } : {}),
+      ...(options.signal ? { signal: options.signal } : {}),
+    };
+
+    // Browser implementations may emit delta or cumulative chunks. Detect the
+    // shape per chunk and merge accordingly.
+    const mergeChunk = (buffer: string, chunk: string): string =>
+      chunk.startsWith(buffer) ? chunk : buffer + chunk;
+
+    let finalText: string;
+    if (typeof writer.writeStreaming === "function") {
+      let buffer = "";
+      for await (const chunk of writer.writeStreaming(text, taskOptions)) {
+        if (options.signal?.aborted) throw new WriterAbortError();
+        buffer = mergeChunk(buffer, chunk);
+        options.onUpdate?.(buffer);
+      }
+      finalText = buffer.trim();
+    } else {
+      const raw = await writer.write(text, taskOptions);
+      if (options.signal?.aborted) throw new WriterAbortError();
+      finalText = raw.trim();
+    }
+
+    if (finalText && cache) cache.set(cacheKey, finalText);
+    return { output: finalText || null, cached: false };
+  } finally {
+    acquired.done();
+  }
 };

--- a/packages/writer/src/prepare.test.ts
+++ b/packages/writer/src/prepare.test.ts
@@ -1,0 +1,208 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { __clearSessionCacheForTests, configureWriterCache } from "./api.js";
+import {
+  clearWriterSessions,
+  prepareWriter,
+  WriterUnavailableError,
+  write,
+} from "./index.js";
+
+interface FakeWriter {
+  write: ReturnType<typeof vi.fn>;
+  destroy: ReturnType<typeof vi.fn>;
+}
+
+const makeInstance = (): FakeWriter => ({
+  write: vi.fn(async () => "Generated."),
+  destroy: vi.fn(),
+});
+
+const installFakeApi = () => {
+  const instances: FakeWriter[] = [];
+  const api = {
+    availability: vi.fn(async () => "available" as const),
+    create: vi.fn(async () => {
+      const instance = makeInstance();
+      instances.push(instance);
+      return instance;
+    }),
+  };
+  (globalThis as { Writer?: unknown }).Writer = api;
+  return { api, instances };
+};
+
+const tick = () => new Promise<void>((resolve) => setTimeout(resolve, 0));
+
+beforeEach(() => {
+  __clearSessionCacheForTests();
+});
+
+afterEach(() => {
+  (globalThis as { Writer?: unknown }).Writer = undefined;
+});
+
+describe("prepareWriter", () => {
+  it("starts creation immediately and the matching write reuses it", async () => {
+    const { api } = installFakeApi();
+    const lease = prepareWriter({ tone: "casual" });
+    expect(api.create).toHaveBeenCalledTimes(1);
+    await lease.ready;
+
+    const result = await write({ tone: "casual", input: "Draft an email." });
+    expect(result.output).toBe("Generated.");
+    expect(api.create).toHaveBeenCalledTimes(1);
+    lease.release();
+  });
+
+  it("never throws when the API is missing; ready rejects instead", async () => {
+    const lease = prepareWriter({});
+    await expect(lease.ready).rejects.toBeInstanceOf(WriterUnavailableError);
+    expect(() => lease.release()).not.toThrow();
+  });
+
+  it("shares one session between concurrent leases and destroys exactly once", async () => {
+    const { api, instances } = installFakeApi();
+    const first = prepareWriter({});
+    const second = prepareWriter({});
+    expect(api.create).toHaveBeenCalledTimes(1);
+    await Promise.all([first.ready, second.ready]);
+
+    first.release();
+    first.release();
+    await tick();
+    expect(instances[0]?.destroy).not.toHaveBeenCalled();
+
+    second.release();
+    second.release();
+    await tick();
+    expect(instances[0]?.destroy).toHaveBeenCalledTimes(1);
+  });
+
+  it("release before creation settles destroys the session once created", async () => {
+    const { api } = installFakeApi();
+    let resolveCreate: (instance: FakeWriter) => void = () => {};
+    const instance = makeInstance();
+    api.create.mockImplementationOnce(
+      () =>
+        new Promise<FakeWriter>((resolve) => {
+          resolveCreate = resolve;
+        }),
+    );
+
+    const lease = prepareWriter({});
+    lease.release();
+    await tick();
+    expect(instance.destroy).not.toHaveBeenCalled();
+
+    resolveCreate(instance);
+    await tick();
+    expect(instance.destroy).toHaveBeenCalledTimes(1);
+
+    // The released entry left the cache, so preparing again creates anew.
+    const retry = prepareWriter({});
+    expect(api.create).toHaveBeenCalledTimes(2);
+    await retry.ready;
+    retry.release();
+  });
+
+  it("creation failure rejects ready, evicts the entry, and allows retry", async () => {
+    const { api } = installFakeApi();
+    api.create.mockRejectedValueOnce(new Error("no space"));
+
+    const failed = prepareWriter({});
+    await expect(failed.ready).rejects.toBeInstanceOf(WriterUnavailableError);
+    failed.release();
+
+    const retry = prepareWriter({});
+    expect(api.create).toHaveBeenCalledTimes(2);
+    await expect(retry.ready).resolves.toBeUndefined();
+    retry.release();
+  });
+
+  it("defers destruction while inference is in flight", async () => {
+    const { instances } = installFakeApi();
+    const lease = prepareWriter({});
+    await lease.ready;
+
+    const instance = instances[0];
+    if (!instance) throw new Error("expected a created instance");
+    let resolveWrite: (text: string) => void = () => {};
+    instance.write.mockImplementationOnce(
+      () =>
+        new Promise<string>((resolve) => {
+          resolveWrite = resolve;
+        }),
+    );
+
+    const running = write({ input: "Draft an email." });
+    await tick();
+    lease.release();
+    await tick();
+    expect(instance.destroy).not.toHaveBeenCalled();
+
+    resolveWrite("Generated.");
+    await expect(running).resolves.toEqual({
+      output: "Generated.",
+      cached: false,
+    });
+    await tick();
+    expect(instance.destroy).toHaveBeenCalledTimes(1);
+  });
+
+  it("pins leased entries against LRU eviction", async () => {
+    const { instances } = installFakeApi();
+    configureWriterCache({ max: 1 });
+
+    const lease = prepareWriter({ tone: "formal" });
+    await lease.ready;
+    await write({ tone: "neutral", input: "Draft an email." });
+    await tick();
+
+    // Inserting a third entry trims to max; the leased "formal" session
+    // survives and the unpinned "neutral" session is evicted.
+    const third = prepareWriter({ tone: "casual" });
+    await third.ready;
+    await tick();
+    expect(instances[0]?.destroy).not.toHaveBeenCalled();
+    expect(instances[1]?.destroy).toHaveBeenCalledTimes(1);
+
+    lease.release();
+    third.release();
+  });
+
+  it("isolates leases per option key", async () => {
+    const { api, instances } = installFakeApi();
+    const formal = prepareWriter({ tone: "formal" });
+    await formal.ready;
+
+    await write({ tone: "casual", input: "Draft an email." });
+    expect(api.create).toHaveBeenCalledTimes(2);
+
+    formal.release();
+    await tick();
+    expect(instances[0]?.destroy).toHaveBeenCalledTimes(1);
+    expect(instances[1]?.destroy).not.toHaveBeenCalled();
+
+    // The other configuration stays cached and reusable.
+    await write({ tone: "casual", input: "Draft an email." });
+    expect(api.create).toHaveBeenCalledTimes(2);
+  });
+
+  it("clear detaches leased sessions and destroys them on final release", async () => {
+    const { api, instances } = installFakeApi();
+    const lease = prepareWriter({});
+    await lease.ready;
+
+    clearWriterSessions();
+    await tick();
+    expect(instances[0]?.destroy).not.toHaveBeenCalled();
+
+    // The detached session no longer serves new calls.
+    await write({ input: "Draft an email." });
+    expect(api.create).toHaveBeenCalledTimes(2);
+
+    lease.release();
+    await tick();
+    expect(instances[0]?.destroy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/writer/src/prepare.test.ts
+++ b/packages/writer/src/prepare.test.ts
@@ -205,4 +205,17 @@ describe("prepareWriter", () => {
     await tick();
     expect(instances[0]?.destroy).toHaveBeenCalledTimes(1);
   });
+
+  it("re-trims the cache when the last in-flight pin drops", async () => {
+    const { api, instances } = installFakeApi();
+    configureWriterCache({ max: 0 });
+
+    await write({ tone: "casual", input: "Draft an email." });
+    await tick();
+    expect(instances[0]?.destroy).toHaveBeenCalledTimes(1);
+
+    // Nothing stayed cached, so the same call creates a fresh session.
+    await write({ tone: "casual", input: "Draft an email." });
+    expect(api.create).toHaveBeenCalledTimes(2);
+  });
 });


### PR DESCRIPTION
Closes #149

## What

- All seven task packages expose the same lifecycle surface: `prepare<Noun>(options)` returns `{ ready: Promise<void>; release(): void }`. Preparation starts native create on user intent, before input exists. The matching operation reuses the prepared session without a second create.
- The session caches are now lease-aware: refcounted leases, in-flight pins, lease-pinned entries never evict, final release destroys exactly once and only when safe, release-before-ready defers destruction, creation failure evicts for clean retry.
- Prompt: `prepareLanguageModel` warms the base that `ask()` clones from. `createSession()` and `clone()` are unchanged. The manual fallback-base destruction (WeakSet) became redundant and was removed.
- Export reconciliation: session cache controls (`configure*Cache`, `clear*Session(s)`) are now uniform across all seven packages (summarizer's dead unexported functions exposed, prompt's added). Breaking: writer, rewriter, and proofreader no longer export `getOrCreate*`, `get*Api`, `defaultCacheKey`, `resolveCache`.
- Docs: new [Session lifecycle guide](https://github.com/obetomuniz/web-ai-sdk/blob/bm/lifecycle-prepare-release/apps/site/src/content/docs/guides/session-lifecycle.mdx) covering rationale, use cases, and Chrome's guidance references; per-package README sections; lifecycle links from every package guide and hook page; false export claims removed from translator/detector docs; vanilla Prompt guide live demo removed.
- Changeset: minor for all seven packages plus `@web-ai-sdk/all`, breaking removals documented.

## Verification

- 63 new lifecycle tests across the seven packages (concurrent leases, release-before-ready, creation failure, in-flight deferral, LRU pinning, option-key isolation) plus sdk runtime and compile-time parity tripwires.
- Full `pnpm gate` passes.
- Verified in real Chrome against on-device models: single create per configuration, reuse with zero extra creates, refcounted destroy-exactly-once, and the user-gesture download failure surfacing through `ready`.
