### PR TITLE
feat(site): align AI demos with prepared-session UX

### DIFF
--- a/apps/site/src/content/docs/react/use-detector.mdx
+++ b/apps/site/src/content/docs/react/use-detector.mdx
@@ -15,7 +15,7 @@ To warm the session before the hook first runs, call `prepareLanguageDetector` f
 
 <DetectorDemo client:only="react" />
 
-Edit the input; the badge updates as you type. The list under the badge shows the top candidates with their confidences.
+Edit the input. The demo debounces typing: detection runs 600 ms after you pause, not on every keystroke. The list under the badge shows the top candidates with their confidences.
 
 ## Usage
 

--- a/apps/site/src/content/docs/react/use-detector.mdx
+++ b/apps/site/src/content/docs/react/use-detector.mdx
@@ -4,6 +4,7 @@ description: React adapter for @web-ai-sdk/detector. Auto-detects the language o
 ---
 
 import { DetectorDemo } from "../../../features/docs/components/DetectorDemo.tsx";
+import DemoSlot from "../../../features/docs/components/DemoSlot.astro";
 
 React adapter for `@web-ai-sdk/detector`. Auto-detects the language of `input` on mount and re-runs whenever it changes. For the conceptual overview see [Detector](/docs/guides/detector/).
 
@@ -13,7 +14,9 @@ To warm the session before the hook first runs, call `prepareLanguageDetector` f
 
 ## Live demo
 
-<DetectorDemo client:only="react" />
+<DemoSlot minHeight={309}>
+  <DetectorDemo client:only="react" />
+</DemoSlot>
 
 Edit the input. The demo debounces typing: detection runs 600 ms after you pause, not on every keystroke. The list under the badge shows the top candidates with their confidences.
 

--- a/apps/site/src/content/docs/react/use-prompt.mdx
+++ b/apps/site/src/content/docs/react/use-prompt.mdx
@@ -4,6 +4,7 @@ description: React adapter for @web-ai-sdk/prompt with an idle / loading / strea
 ---
 
 import { PromptDemo } from "../../../features/docs/components/PromptDemo.tsx";
+import DemoSlot from "../../../features/docs/components/DemoSlot.astro";
 
 React adapter for `@web-ai-sdk/prompt`. Runs single-shot prompts on demand via `ask(input)` and exposes status, streaming output text, and abort / reset controls. For the conceptual overview of the underlying API see [Prompt](/docs/guides/prompt/).
 
@@ -13,7 +14,9 @@ To warm the session before the hook first runs, call `prepareLanguageModel` from
 
 ## Live demo
 
-<PromptDemo client:only="react" />
+<DemoSlot minHeight={97}>
+  <PromptDemo client:only="react" />
+</DemoSlot>
 
 Type a question and click "Ask". Tokens stream in as the model produces them. Click "Cancel" to abort mid-stream.
 

--- a/apps/site/src/content/docs/react/use-proofreader.mdx
+++ b/apps/site/src/content/docs/react/use-proofreader.mdx
@@ -4,6 +4,7 @@ description: React adapter for @web-ai-sdk/proofreader. Auto-runs on mount and r
 ---
 
 import { ProofreaderDemo } from "../../../features/docs/components/ProofreaderDemo.tsx";
+import DemoSlot from "../../../features/docs/components/DemoSlot.astro";
 
 React adapter for `@web-ai-sdk/proofreader`. Auto-runs on mount and re-runs when `input` changes. For the conceptual overview see [Proofreader](/docs/guides/proofreader/).
 
@@ -13,7 +14,9 @@ To warm the session before the hook first runs, call `prepareProofreader` from t
 
 ## Live demo
 
-<ProofreaderDemo client:only="react" />
+<DemoSlot minHeight={217}>
+  <ProofreaderDemo client:only="react" />
+</DemoSlot>
 
 Edit the text, then click Proofread. The corrected version and the number of corrections appear once the model resolves; your original text stays unchanged. Results are cached for ten minutes; use "Fresh run" to bypass the cache.
 

--- a/apps/site/src/content/docs/react/use-proofreader.mdx
+++ b/apps/site/src/content/docs/react/use-proofreader.mdx
@@ -15,7 +15,7 @@ To warm the session before the hook first runs, call `prepareProofreader` from t
 
 <ProofreaderDemo client:only="react" />
 
-Edit the text; the corrected version and the number of corrections appear once the model resolves.
+Edit the text, then click Proofread. The corrected version and the number of corrections appear once the model resolves; your original text stays unchanged. Results are cached for ten minutes; use "Fresh run" to bypass the cache.
 
 ## Usage
 

--- a/apps/site/src/content/docs/react/use-rewriter.mdx
+++ b/apps/site/src/content/docs/react/use-rewriter.mdx
@@ -4,6 +4,7 @@ description: React adapter for @web-ai-sdk/rewriter. Auto-runs on mount and re-r
 ---
 
 import { RewriterDemo } from "../../../features/docs/components/RewriterDemo.tsx";
+import DemoSlot from "../../../features/docs/components/DemoSlot.astro";
 
 React adapter for `@web-ai-sdk/rewriter`. Auto-runs on mount, re-runs when `input` / config options change, and streams chunks through state updates. For the conceptual overview see [Rewriter](/docs/guides/rewriter/).
 
@@ -13,7 +14,9 @@ To warm the session before the hook first runs, call `prepareRewriter` from the 
 
 ## Live demo
 
-<RewriterDemo client:only="react" />
+<DemoSlot minHeight={217}>
+  <RewriterDemo client:only="react" />
+</DemoSlot>
 
 Edit the source text, then click Rewrite. The rewrite streams in as the model produces it and never replaces your original text. Click Stop to cancel a run. Edits after a rewrite mark it stale until you run again or dismiss it.
 

--- a/apps/site/src/content/docs/react/use-rewriter.mdx
+++ b/apps/site/src/content/docs/react/use-rewriter.mdx
@@ -15,7 +15,7 @@ To warm the session before the hook first runs, call `prepareRewriter` from the 
 
 <RewriterDemo client:only="react" />
 
-Edit the source text; the rewrite streams in as the model produces it.
+Edit the source text, then click Rewrite. The rewrite streams in as the model produces it and never replaces your original text. Click Stop to cancel a run. Edits after a rewrite mark it stale until you run again or dismiss it.
 
 ## Usage
 

--- a/apps/site/src/content/docs/react/use-session.mdx
+++ b/apps/site/src/content/docs/react/use-session.mdx
@@ -4,12 +4,15 @@ description: Lifecycle-only React adapter for createSession. Each call owns one 
 ---
 
 import { SessionDemo } from "../../../features/docs/components/SessionDemo.tsx";
+import DemoSlot from "../../../features/docs/components/DemoSlot.astro";
 
 `useSession` is the React adapter for [`createSession()`](/docs/guides/prompt/#chat-createsession). Each call owns one native instance. The hook detects support, waits for creation, destroys on unmount, and recreates after option changes.
 
 ## Live demo: multimodal session
 
-<SessionDemo client:only="react" />
+<DemoSlot minHeight={97}>
+  <SessionDemo client:only="react" />
+</DemoSlot>
 
 Pick an image and click "Describe". The session sends one message with a text part and an image part, then streams the description back. The selected `File` is a browser-native image value; the SDK forwards it to the model unchanged. See [Multimodal input](/docs/guides/prompt/#multimodal-input-text-image-audio) for the content-part contract.
 

--- a/apps/site/src/content/docs/react/use-summarizer.mdx
+++ b/apps/site/src/content/docs/react/use-summarizer.mdx
@@ -15,7 +15,7 @@ To warm the session before the hook first runs, call `prepareSummarizer` from th
 
 <SummarizerDemo client:only="react" />
 
-Pick a sample text or paste your own. The summary streams in as the model produces it.
+Click "Summarize the article" to run the model on the article below; nothing runs on page load. The summary streams in as the model produces it. Click Stop to cancel. Results are cached for ten minutes; use "Fresh run" to regenerate.
 
 ## Usage
 

--- a/apps/site/src/content/docs/react/use-summarizer.mdx
+++ b/apps/site/src/content/docs/react/use-summarizer.mdx
@@ -4,6 +4,7 @@ description: React adapter for @web-ai-sdk/summarizer. Auto-runs on mount and re
 ---
 
 import { SummarizerDemo } from "../../../features/docs/components/SummarizerDemo.tsx";
+import DemoSlot from "../../../features/docs/components/DemoSlot.astro";
 
 React adapter for `@web-ai-sdk/summarizer`. Auto-runs on mount, re-runs when `input` / `language` / config options change, and streams chunks through state updates. For the conceptual overview see [Summarizer](/docs/guides/summarizer/).
 
@@ -13,7 +14,9 @@ To warm the session before the hook first runs, call `prepareSummarizer` from th
 
 ## Live demo
 
-<SummarizerDemo client:only="react" />
+<DemoSlot minHeight={539}>
+  <SummarizerDemo client:only="react" />
+</DemoSlot>
 
 Click "Summarize the article" to run the model on the article below; nothing runs on page load. The summary streams in as the model produces it. Click Stop to cancel. Results are cached for ten minutes; use "Fresh run" to regenerate.
 

--- a/apps/site/src/content/docs/react/use-translator.mdx
+++ b/apps/site/src/content/docs/react/use-translator.mdx
@@ -4,6 +4,7 @@ description: React adapter for @web-ai-sdk/translator. Auto-translates text on m
 ---
 
 import { TranslatorDemo } from "../../../features/docs/components/TranslatorDemo.tsx";
+import DemoSlot from "../../../features/docs/components/DemoSlot.astro";
 
 React adapter for `@web-ai-sdk/translator`. Auto-translates `input` from `sourceLanguage` to `targetLanguage` and re-runs whenever the inputs change. For the conceptual overview see [Translator](/docs/guides/translator/).
 
@@ -13,7 +14,9 @@ To warm the session before the hook first runs, call `prepareTranslator` from th
 
 ## Live demo
 
-<TranslatorDemo client:only="react" />
+<DemoSlot minHeight={291}>
+  <TranslatorDemo client:only="react" />
+</DemoSlot>
 
 Type in the source field. The demo debounces typing: translation runs 600 ms after you pause, not on every keystroke. Repeat inputs come from a ten-minute result cache; use "Fresh run" to bypass it.
 

--- a/apps/site/src/content/docs/react/use-translator.mdx
+++ b/apps/site/src/content/docs/react/use-translator.mdx
@@ -15,7 +15,7 @@ To warm the session before the hook first runs, call `prepareTranslator` from th
 
 <TranslatorDemo client:only="react" />
 
-Type in the source field; the translation updates whenever the text changes.
+Type in the source field. The demo debounces typing: translation runs 600 ms after you pause, not on every keystroke. Repeat inputs come from a ten-minute result cache; use "Fresh run" to bypass it.
 
 ## Usage
 

--- a/apps/site/src/content/docs/react/use-web-mcp.mdx
+++ b/apps/site/src/content/docs/react/use-web-mcp.mdx
@@ -4,12 +4,15 @@ description: Register WebMCP tools and reactively retrieve every tool exposed to
 ---
 
 import { WebMCPDemo } from "../../../features/docs/components/WebMCPDemo.tsx";
+import DemoSlot from "../../../features/docs/components/DemoSlot.astro";
 
 React adapter for `@web-ai-sdk/webmcp`. `useWebMCP` registers tools with component lifecycle cleanup and returns every tool exposed to the current document, refreshing after native `toolchange` events. For the conceptual overview see [WebMCP](/docs/guides/webmcp/).
 
 ## Live demo
 
-<WebMCPDemo client:only="react" />
+<DemoSlot minHeight={562}>
+  <WebMCPDemo client:only="react" />
+</DemoSlot>
 
 Use the invoke controls below to call a registered tool. The demo reads live tools from `useWebMCP()` and dispatches the selected `RegisteredTool` through the SDK's `executeTool()` helper.
 

--- a/apps/site/src/content/docs/react/use-writer.mdx
+++ b/apps/site/src/content/docs/react/use-writer.mdx
@@ -15,7 +15,7 @@ To warm the session before the hook first runs, call `prepareWriter` from the co
 
 <WriterDemo client:only="react" />
 
-Edit the writing task; the draft streams in as the model produces it.
+Edit the writing task, then click Write. The draft streams in as the model produces it. Click Stop to cancel a run. If you edit the task after a draft, the draft stays visible and is marked stale until you run again or dismiss it.
 
 ## Usage
 

--- a/apps/site/src/content/docs/react/use-writer.mdx
+++ b/apps/site/src/content/docs/react/use-writer.mdx
@@ -4,6 +4,7 @@ description: React adapter for @web-ai-sdk/writer. Auto-runs on mount and re-run
 ---
 
 import { WriterDemo } from "../../../features/docs/components/WriterDemo.tsx";
+import DemoSlot from "../../../features/docs/components/DemoSlot.astro";
 
 React adapter for `@web-ai-sdk/writer`. Auto-runs on mount, re-runs when `input` / config options change, and streams chunks through state updates. For the conceptual overview see [Writer](/docs/guides/writer/).
 
@@ -13,7 +14,9 @@ To warm the session before the hook first runs, call `prepareWriter` from the co
 
 ## Live demo
 
-<WriterDemo client:only="react" />
+<DemoSlot minHeight={217}>
+  <WriterDemo client:only="react" />
+</DemoSlot>
 
 Edit the writing task, then click Write. The draft streams in as the model produces it. Click Stop to cancel a run. If you edit the task after a draft, the draft stays visible and is marked stale until you run again or dismiss it.
 

--- a/apps/site/src/features/docs/components/DemoSlot.astro
+++ b/apps/site/src/features/docs/components/DemoSlot.astro
@@ -1,0 +1,22 @@
+---
+/**
+ * Reserves a live demo's footprint while its client-only island hydrates,
+ * so docs content below the demo does not shift. The placeholder mirrors
+ * the demo card chrome and hides once the real card mounts.
+ */
+interface Props {
+  /** Height in px of the demo card's initial rendering. */
+  minHeight: number;
+  /** Match `.demo-card--narrow` (560px) instead of the 640px default. */
+  narrow?: boolean;
+}
+
+const { minHeight, narrow = false } = Astro.props;
+---
+
+<div
+  class:list={["demo-slot", { "demo-slot--narrow": narrow }]}
+  style={`--demo-slot-min: ${minHeight}px`}
+>
+  <slot />
+</div>

--- a/apps/site/src/features/docs/components/DetectorDemo.test.tsx
+++ b/apps/site/src/features/docs/components/DetectorDemo.test.tsx
@@ -1,0 +1,76 @@
+// @vitest-environment happy-dom
+
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { DetectorDemo } from "./DetectorDemo.js";
+
+interface DetectorHookOptions {
+  input: string;
+}
+
+const mocks = vi.hoisted(() => ({
+  useDetector: vi.fn((_options: DetectorHookOptions) => ({
+    status: "idle" as const,
+    output: null,
+    error: null,
+    fromCache: false,
+  })),
+}));
+
+vi.mock("@web-ai-sdk/detector/react", () => ({
+  useDetector: mocks.useDetector,
+}));
+
+(
+  globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+let root: Root | undefined;
+let container: HTMLDivElement;
+
+const lastOptions = (): DetectorHookOptions => {
+  const call = mocks.useDetector.mock.calls.at(-1);
+  if (!call) throw new Error("useDetector was not called");
+  return call[0];
+};
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  mocks.useDetector.mockClear();
+  container = document.createElement("div");
+  document.body.append(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root?.unmount());
+  root = undefined;
+  document.body.replaceChildren();
+  vi.useRealTimers();
+});
+
+describe("docs DetectorDemo", () => {
+  it("debounces typing instead of updating the hook per keystroke", () => {
+    act(() => root?.render(<DetectorDemo initial="hola" />));
+    expect(lastOptions().input).toBe("hola");
+
+    const input = container.querySelector("textarea");
+    act(() => {
+      if (!input) return;
+      // Assign through the prototype setter so React's value tracker
+      // registers the change.
+      Object.getOwnPropertyDescriptor(
+        HTMLTextAreaElement.prototype,
+        "value",
+      )?.set?.call(input, "hola mundo");
+      input.dispatchEvent(new Event("input", { bubbles: true }));
+    });
+    // Before the pause elapses the hook still sees the old input.
+    expect(lastOptions().input).toBe("hola");
+    expect(container.textContent).toContain("Detection runs after you pause");
+
+    act(() => vi.advanceTimersByTime(600));
+    expect(lastOptions().input).toBe("hola mundo");
+  });
+});

--- a/apps/site/src/features/docs/components/DetectorDemo.tsx
+++ b/apps/site/src/features/docs/components/DetectorDemo.tsx
@@ -1,21 +1,25 @@
 import { useDetector } from "@web-ai-sdk/detector/react";
 import { useState } from "react";
+import { useDebouncedValue } from "../../../shared/demoLifecycle.js";
 import { UnavailableHint } from "./UnavailableHint.js";
 
 export interface DetectorDemoProps {
   initial?: string;
 }
 
+// Detection waits for a typing pause instead of running on every keystroke.
+const DETECT_DEBOUNCE_MS = 600;
+
 export const DetectorDemo = ({
   initial = "Olá, mundo! Os blocos modulares são uma boa ideia.",
 }: DetectorDemoProps) => {
   const [text, setText] = useState(initial);
-  const { status, output, error, fromCache } = useDetector({
-    input: text,
-  });
+  const debounced = useDebouncedValue(text, DETECT_DEBOUNCE_MS);
+  const { status, output, error } = useDetector({ input: debounced });
   const language = output?.language ?? null;
   const confidence = output?.confidence ?? 0;
   const all = output?.all ?? [];
+  const pending = text !== debounced;
 
   return (
     <div className="demo-card demo-card--narrow">
@@ -39,9 +43,9 @@ export const DetectorDemo = ({
       {error && <p className="demo-error">{error.message}</p>}
       <article className="demo-response">
         <header className="demo-response__header">
-          <span>
-            {fromCache
-              ? "Cached"
+          <span role="status">
+            {pending
+              ? "Input changed. Detection runs after you pause."
               : status === "loading"
                 ? "Detecting…"
                 : status === "idle"

--- a/apps/site/src/features/docs/components/DetectorDemo.tsx
+++ b/apps/site/src/features/docs/components/DetectorDemo.tsx
@@ -22,7 +22,7 @@ export const DetectorDemo = ({
   const pending = text !== debounced;
 
   return (
-    <div className="demo-card demo-card--narrow">
+    <div className="demo-card">
       {status === "unavailable" && (
         <UnavailableHint
           api="Language Detector"

--- a/apps/site/src/features/docs/components/FreshRunAction.tsx
+++ b/apps/site/src/features/docs/components/FreshRunAction.tsx
@@ -1,0 +1,46 @@
+/**
+ * Icon-only fresh-generation control for docs demos, shown once a run has
+ * completed. Mirrors the home demos' treatment: a borderless rotate icon
+ * with a custom hover/focus tooltip.
+ */
+export const FreshRunAction = ({
+  show,
+  onClick,
+  tooltipSide = "left",
+}: {
+  show: boolean;
+  onClick: () => void;
+  tooltipSide?: "left" | "right";
+}) => {
+  if (!show) return null;
+  return (
+    <span className="demo-tip-wrap">
+      <button
+        type="button"
+        className="demo-icon-button"
+        onClick={onClick}
+        aria-label="Fresh run"
+      >
+        <svg
+          width="16"
+          height="16"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          aria-hidden="true"
+        >
+          <path d="M21 12a9 9 0 1 1-9-9c2.52 0 4.93 1 6.74 2.74L21 8" />
+          <path d="M21 3v5h-5" />
+        </svg>
+      </button>
+      <span
+        className={`demo-tooltip ${tooltipSide === "right" ? "demo-tooltip--right" : ""}`}
+      >
+        Skip the cached result and run the model again
+      </span>
+    </span>
+  );
+};

--- a/apps/site/src/features/docs/components/PromptDemo.tsx
+++ b/apps/site/src/features/docs/components/PromptDemo.tsx
@@ -3,6 +3,7 @@ import {
   usePrompt,
 } from "@web-ai-sdk/prompt/react";
 import { type ComponentProps, useState } from "react";
+import { ModelMarkdown } from "../../../shared/components/ModelMarkdown.js";
 import { UnavailableHint } from "./UnavailableHint.js";
 
 export interface PromptDemoProps {
@@ -15,7 +16,7 @@ export const PromptDemo = ({
   samplingMode = "balanced",
 }: PromptDemoProps) => {
   const [input, setInput] = useState("What is React.js, in one sentence?");
-  const { status, output, error, fromCache, ask, abort, reset } = usePrompt({
+  const { status, output, error, ask, abort, reset } = usePrompt({
     systemPrompt,
     samplingMode,
   });
@@ -74,14 +75,12 @@ export const PromptDemo = ({
       {(output || busy) && (
         <article className="demo-response">
           <header className="demo-response__header">
-            <span>
-              {fromCache
-                ? "Cached"
-                : status === "streaming"
-                  ? "Streaming…"
-                  : status === "loading"
-                    ? "Thinking…"
-                    : "Answer"}
+            <span role="status">
+              {status === "streaming"
+                ? "Streaming…"
+                : status === "loading"
+                  ? "Thinking…"
+                  : "Answer"}
             </span>
             {output && (
               <button
@@ -95,7 +94,9 @@ export const PromptDemo = ({
             )}
           </header>
           {output ? (
-            <p className="demo-response__body">{output}</p>
+            <div className="demo-response__body">
+              <ModelMarkdown content={output} streaming={busy} />
+            </div>
           ) : (
             <p className="demo-muted" style={{ margin: 0 }}>
               …

--- a/apps/site/src/features/docs/components/ProofreaderDemo.tsx
+++ b/apps/site/src/features/docs/components/ProofreaderDemo.tsx
@@ -17,7 +17,7 @@ export const ProofreaderDemo = () => {
   const [enabled, setEnabled] = useState(false);
   const [stopped, setStopped] = useState(false);
   // Bumping the nonce changes the cache key, so a fresh generation skips the
-  // stored result and replaces it.
+  // stored result and writes under a new key. Old entries expire via TTL.
   const [freshNonce, setFreshNonce] = useState(0);
 
   const { status, output, error, fromCache } = useProofreader({

--- a/apps/site/src/features/docs/components/ProofreaderDemo.tsx
+++ b/apps/site/src/features/docs/components/ProofreaderDemo.tsx
@@ -1,14 +1,50 @@
 import { useProofreader } from "@web-ai-sdk/proofreader/react";
 import { useState } from "react";
+import { FreshRunAction } from "./FreshRunAction.js";
 import { UnavailableHint } from "./UnavailableHint.js";
 
 const SAMPLE =
   "I seen him yesterday at the store, and he bought two loafs of bread.";
 
+// Corrections are deterministic enough to reuse; expire them after ten minutes.
+const RESULT_TTL_MS = 10 * 60 * 1000;
+
 export const ProofreaderDemo = () => {
   const [input, setInput] = useState(SAMPLE);
+  // The hook only sees input committed by the Proofread button; typing alone
+  // never invokes the model.
+  const [committed, setCommitted] = useState<string | null>(null);
+  const [enabled, setEnabled] = useState(false);
+  const [stopped, setStopped] = useState(false);
+  // Bumping the nonce changes the cache key, so a fresh generation skips the
+  // stored result and replaces it.
+  const [freshNonce, setFreshNonce] = useState(0);
 
-  const { status, output, error, fromCache } = useProofreader({ input });
+  const { status, output, error, fromCache } = useProofreader({
+    input: committed ?? "",
+    cache: "session",
+    cacheTtl: RESULT_TTL_MS,
+    cacheKey: `docs-proofreader:${freshNonce}:${committed ?? ""}`,
+    enabled: enabled && committed !== null,
+  });
+
+  const busy = !stopped && status === "loading";
+  const stale = !busy && !!output && committed !== null && input !== committed;
+
+  const run = () => {
+    setCommitted(input);
+    setEnabled(true);
+    setStopped(false);
+  };
+  // Disabling the hook aborts the in-flight call; Proofread re-enables it.
+  const stop = () => {
+    setEnabled(false);
+    setStopped(true);
+  };
+  const freshRun = () => {
+    setFreshNonce((n) => n + 1);
+    run();
+  };
 
   return (
     <div className="demo-card">
@@ -22,6 +58,23 @@ export const ProofreaderDemo = () => {
           spellCheck={false}
         />
       </label>
+      <div className="demo-row">
+        {busy ? (
+          <button type="button" onClick={stop} className="demo-button">
+            Stop
+          </button>
+        ) : (
+          <button
+            type="button"
+            onClick={run}
+            disabled={status === "unavailable" || !input.trim()}
+            className="demo-button"
+          >
+            Proofread
+          </button>
+        )}
+        <FreshRunAction show={status === "done" && !busy} onClick={freshRun} />
+      </div>
       {status === "unavailable" && !error && (
         <UnavailableHint
           api="Proofreader API"
@@ -41,16 +94,31 @@ export const ProofreaderDemo = () => {
         />
       )}
       {error && <p className="demo-error">{error.message}</p>}
+      {stale && (
+        <p className="demo-hint" role="status">
+          The text changed after this correction. Run Proofread again to update
+          it.
+        </p>
+      )}
       {output && (
         <aside className="demo-response">
           <header className="demo-response__header">
-            <span>{fromCache ? "Cached correction" : "Corrected"}</span>
+            <span role="status">
+              {stopped
+                ? "Stopped"
+                : stale
+                  ? "Corrected (stale)"
+                  : fromCache && status === "done"
+                    ? "Cached correction"
+                    : "Corrected"}
+            </span>
           </header>
           <p className="demo-response__body">{output.correctedInput}</p>
           {output.corrections.length > 0 && (
             <p className="demo-hint">
               {output.corrections.length} correction
-              {output.corrections.length === 1 ? "" : "s"} suggested.
+              {output.corrections.length === 1 ? "" : "s"} suggested. The
+              original text above stays unchanged.
             </p>
           )}
         </aside>

--- a/apps/site/src/features/docs/components/RewriterDemo.tsx
+++ b/apps/site/src/features/docs/components/RewriterDemo.tsx
@@ -1,18 +1,46 @@
 import { useRewriter } from "@web-ai-sdk/rewriter/react";
 import { useState } from "react";
+import { ModelMarkdown } from "../../../shared/components/ModelMarkdown.js";
 import { UnavailableHint } from "./UnavailableHint.js";
 
 const SAMPLE = "hey, can u send me that doc when u get a sec? thx a bunch";
 
 export const RewriterDemo = ({ language = "en" }: { language?: string }) => {
   const [input, setInput] = useState(SAMPLE);
+  // The hook only sees input committed by the Rewrite button; typing alone
+  // never invokes the model.
+  const [committed, setCommitted] = useState<string | null>(null);
+  const [enabled, setEnabled] = useState(false);
+  const [stopped, setStopped] = useState(false);
+  const [dismissed, setDismissed] = useState(false);
 
-  const { status, output, error, fromCache, dismiss } = useRewriter({
-    input,
+  const { status, output, error } = useRewriter({
+    input: committed ?? "",
     language,
     tone: "more-formal",
     length: "as-is",
+    enabled: enabled && committed !== null,
   });
+
+  const busy = !stopped && (status === "loading" || status === "streaming");
+  const stale =
+    !busy &&
+    !!output &&
+    committed !== null &&
+    input !== committed &&
+    !dismissed;
+
+  const run = () => {
+    setCommitted(input);
+    setEnabled(true);
+    setStopped(false);
+    setDismissed(false);
+  };
+  // Disabling the hook aborts the in-flight call; Rewrite re-enables it.
+  const stop = () => {
+    setEnabled(false);
+    setStopped(true);
+  };
 
   return (
     <div className="demo-card">
@@ -26,6 +54,22 @@ export const RewriterDemo = ({ language = "en" }: { language?: string }) => {
           spellCheck={false}
         />
       </label>
+      <div className="demo-row">
+        {busy ? (
+          <button type="button" onClick={stop} className="demo-button">
+            Stop
+          </button>
+        ) : (
+          <button
+            type="button"
+            onClick={run}
+            disabled={status === "unavailable" || !input.trim()}
+            className="demo-button"
+          >
+            Rewrite
+          </button>
+        )}
+      </div>
       {status === "unavailable" && !error && (
         <UnavailableHint
           api="Rewriter API"
@@ -45,23 +89,34 @@ export const RewriterDemo = ({ language = "en" }: { language?: string }) => {
         />
       )}
       {error && <p className="demo-error">{error.message}</p>}
-      {output && (
+      {stale && (
+        <p className="demo-hint" role="status">
+          The text changed after this rewrite. Run Rewrite again to update it,
+          or dismiss the rewrite.
+        </p>
+      )}
+      {output && !dismissed && (
         <aside className="demo-response">
           <header className="demo-response__header">
-            <span>
-              {fromCache ? "Cached rewrite" : "Rewrite"}{" "}
-              {status === "streaming" && <em>(streaming…)</em>}
+            <span role="status">
+              {stopped ? "Stopped" : stale ? "Rewrite (stale)" : "Rewrite"}{" "}
+              {busy && status === "streaming" && <em>(streaming…)</em>}
             </span>
             <button
               type="button"
-              onClick={dismiss}
+              onClick={() => setDismissed(true)}
               className="demo-dismiss"
               aria-label="dismiss"
             >
               ×
             </button>
           </header>
-          <p className="demo-response__body">{output}</p>
+          <div className="demo-response__body">
+            <ModelMarkdown
+              content={output}
+              streaming={busy && status === "streaming"}
+            />
+          </div>
         </aside>
       )}
     </div>

--- a/apps/site/src/features/docs/components/SummarizerDemo.test.tsx
+++ b/apps/site/src/features/docs/components/SummarizerDemo.test.tsx
@@ -1,0 +1,98 @@
+// @vitest-environment happy-dom
+
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { SummarizerDemo } from "./SummarizerDemo.js";
+
+interface SummarizerHookOptions {
+  input: string;
+  enabled?: boolean;
+  cache?: string;
+  cacheTtl?: number;
+  cacheKey?: string;
+}
+
+const mocks = vi.hoisted(() => ({
+  state: {
+    status: "idle" as "idle" | "loading" | "streaming" | "done" | "unavailable",
+    output: null as string | null,
+    fromCache: false,
+  },
+  useSummarizer: vi.fn((_options: SummarizerHookOptions) => ({
+    status: mocks.state.status,
+    output: mocks.state.output,
+    error: null,
+    fromCache: mocks.state.fromCache,
+    dismiss: vi.fn(),
+  })),
+}));
+
+vi.mock("@web-ai-sdk/summarizer/react", () => ({
+  useSummarizer: mocks.useSummarizer,
+}));
+
+(
+  globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+let root: Root | undefined;
+let container: HTMLDivElement;
+
+const lastOptions = (): SummarizerHookOptions => {
+  const call = mocks.useSummarizer.mock.calls.at(-1);
+  if (!call) throw new Error("useSummarizer was not called");
+  return call[0];
+};
+
+const findButton = (text: string) =>
+  [...container.querySelectorAll("button")].find((button) =>
+    button.textContent?.includes(text),
+  );
+
+beforeEach(() => {
+  mocks.state.status = "idle";
+  mocks.state.output = null;
+  mocks.state.fromCache = false;
+  mocks.useSummarizer.mockClear();
+  container = document.createElement("div");
+  document.body.append(container);
+  root = createRoot(container);
+  act(() => root?.render(<SummarizerDemo />));
+});
+
+afterEach(() => {
+  act(() => root?.unmount());
+  root = undefined;
+  document.body.replaceChildren();
+});
+
+describe("docs SummarizerDemo", () => {
+  it("does not run on page load; the button enables the hook", () => {
+    expect(lastOptions().enabled).toBe(false);
+
+    act(() => findButton("Summarize the article")?.click());
+    expect(lastOptions().enabled).toBe(true);
+  });
+
+  it("passes the TTL cache options", () => {
+    expect(lastOptions().cache).toBe("session");
+    expect(lastOptions().cacheTtl).toBe(10 * 60 * 1000);
+  });
+
+  it("bumps the cache key on Fresh run to regenerate", () => {
+    act(() => findButton("Summarize the article")?.click());
+    const firstKey = lastOptions().cacheKey;
+    mocks.state.status = "done";
+    mocks.state.output = "A summary.";
+    mocks.state.fromCache = true;
+    act(() => root?.render(<SummarizerDemo />));
+
+    const fresh = container.querySelector<HTMLButtonElement>(
+      'button[aria-label="Fresh run"]',
+    );
+    expect(fresh).not.toBeNull();
+    act(() => fresh?.click());
+    expect(lastOptions().cacheKey).not.toBe(firstKey);
+  });
+});

--- a/apps/site/src/features/docs/components/SummarizerDemo.tsx
+++ b/apps/site/src/features/docs/components/SummarizerDemo.tsx
@@ -31,7 +31,7 @@ export const SummarizerDemo = ({ language = "en" }: SummarizerDemoProps) => {
   const [stopped, setStopped] = useState(false);
   const [dismissed, setDismissed] = useState(false);
   // Bumping the nonce changes the cache key, so a fresh generation skips the
-  // stored result and replaces it.
+  // stored result and writes under a new key. Old entries expire via TTL.
   const [freshNonce, setFreshNonce] = useState(0);
 
   useEffect(() => {

--- a/apps/site/src/features/docs/components/SummarizerDemo.tsx
+++ b/apps/site/src/features/docs/components/SummarizerDemo.tsx
@@ -1,5 +1,7 @@
 import { useSummarizer } from "@web-ai-sdk/summarizer/react";
 import { useEffect, useRef, useState } from "react";
+import { ModelMarkdown } from "../../../shared/components/ModelMarkdown.js";
+import { FreshRunAction } from "./FreshRunAction.js";
 import { UnavailableHint } from "./UnavailableHint.js";
 
 export interface SummarizerDemoProps {
@@ -7,6 +9,10 @@ export interface SummarizerDemoProps {
   title?: string;
   description?: string;
 }
+
+// Summaries of the fixed article are deterministic enough to reuse; expire
+// them after ten minutes.
+const RESULT_TTL_MS = 10 * 60 * 1000;
 
 const DEFAULT_BODY = `
   <h2>The case for a lifecycle layer</h2>
@@ -20,15 +26,43 @@ const DEFAULT_BODY = `
 export const SummarizerDemo = ({ language = "en" }: SummarizerDemoProps) => {
   const articleRef = useRef<HTMLDivElement | null>(null);
   const [input, setInput] = useState("");
+  // The summary runs only on the button, never on page load.
+  const [enabled, setEnabled] = useState(false);
+  const [stopped, setStopped] = useState(false);
+  const [dismissed, setDismissed] = useState(false);
+  // Bumping the nonce changes the cache key, so a fresh generation skips the
+  // stored result and replaces it.
+  const [freshNonce, setFreshNonce] = useState(0);
 
   useEffect(() => {
     setInput(articleRef.current?.innerText ?? "");
   }, []);
 
-  const { status, output, error, fromCache, dismiss } = useSummarizer({
+  const { status, output, error, fromCache } = useSummarizer({
     language,
     input,
+    cache: "session",
+    cacheTtl: RESULT_TTL_MS,
+    cacheKey: `docs-summarizer:${language}:${freshNonce}`,
+    enabled: enabled && input.trim().length > 0,
   });
+
+  const busy = !stopped && (status === "loading" || status === "streaming");
+
+  const run = () => {
+    setEnabled(true);
+    setStopped(false);
+    setDismissed(false);
+  };
+  // Disabling the hook aborts the in-flight call; Run re-enables it.
+  const stop = () => {
+    setEnabled(false);
+    setStopped(true);
+  };
+  const freshRun = () => {
+    setFreshNonce((n) => n + 1);
+    run();
+  };
 
   return (
     <div className="demo-card">
@@ -40,23 +74,52 @@ export const SummarizerDemo = ({ language = "en" }: SummarizerDemoProps) => {
         />
       )}
       {error && <p className="demo-error">{error.message}</p>}
-      {output && (
+      <div className="demo-row">
+        {busy ? (
+          <button type="button" onClick={stop} className="demo-button">
+            Stop
+          </button>
+        ) : (
+          <button
+            type="button"
+            onClick={run}
+            disabled={status === "unavailable"}
+            className="demo-button"
+          >
+            Summarize the article
+          </button>
+        )}
+        <FreshRunAction
+          show={status === "done" && !busy && !dismissed}
+          onClick={freshRun}
+        />
+      </div>
+      {output && !dismissed && (
         <aside className="demo-response">
           <header className="demo-response__header">
-            <span>
-              {fromCache ? "Cached summary" : "Summary"}{" "}
-              {status === "streaming" && <em>(streaming…)</em>}
+            <span role="status">
+              {stopped
+                ? "Stopped"
+                : fromCache && status === "done"
+                  ? "Cached summary"
+                  : "Summary"}{" "}
+              {busy && status === "streaming" && <em>(streaming…)</em>}
             </span>
             <button
               type="button"
-              onClick={dismiss}
+              onClick={() => setDismissed(true)}
               className="demo-dismiss"
               aria-label="dismiss"
             >
               ×
             </button>
           </header>
-          <p className="demo-response__body">{output}</p>
+          <div className="demo-response__body">
+            <ModelMarkdown
+              content={output}
+              streaming={busy && status === "streaming"}
+            />
+          </div>
         </aside>
       )}
       <div

--- a/apps/site/src/features/docs/components/TranslatorDemo.tsx
+++ b/apps/site/src/features/docs/components/TranslatorDemo.tsx
@@ -1,5 +1,7 @@
 import { useTranslator } from "@web-ai-sdk/translator/react";
 import { useState } from "react";
+import { useDebouncedValue } from "../../../shared/demoLifecycle.js";
+import { FreshRunAction } from "./FreshRunAction.js";
 import { UnavailableHint } from "./UnavailableHint.js";
 
 export interface TranslatorDemoProps {
@@ -8,17 +10,30 @@ export interface TranslatorDemoProps {
   initial?: string;
 }
 
+// Translation waits for a typing pause instead of running on every keystroke.
+const TRANSLATE_DEBOUNCE_MS = 600;
+// Translations are deterministic enough to reuse; expire them after ten minutes.
+const RESULT_TTL_MS = 10 * 60 * 1000;
+
 export const TranslatorDemo = ({
   sourceLanguage = "pt",
   targetLanguage = "en",
   initial = "Olá! As built-in AI APIs do navegador transformam o desenvolvimento web.",
 }: TranslatorDemoProps) => {
   const [input, setInput] = useState(initial);
+  const debounced = useDebouncedValue(input, TRANSLATE_DEBOUNCE_MS);
+  // Bumping the nonce changes the cache key, so a fresh generation skips the
+  // stored result and replaces it.
+  const [freshNonce, setFreshNonce] = useState(0);
   const { status, output, error, fromCache } = useTranslator({
-    input,
+    input: debounced,
     sourceLanguage,
     targetLanguage,
+    cache: "session",
+    cacheTtl: RESULT_TTL_MS,
+    cacheKey: `docs-translator:${sourceLanguage}:${targetLanguage}:${freshNonce}:${debounced}`,
   });
+  const pending = input !== debounced;
 
   return (
     <div className="demo-card">
@@ -42,16 +57,23 @@ export const TranslatorDemo = ({
       </label>
       <article className="demo-response">
         <header className="demo-response__header">
-          <span>
-            {fromCache
-              ? "Cached"
-              : status === "loading"
-                ? "Translating…"
-                : status === "idle"
-                  ? "Waiting for input"
-                  : `Translation (${targetLanguage})`}{" "}
+          <span role="status">
+            {pending
+              ? "Input changed. Translation runs after you pause."
+              : fromCache && status === "done"
+                ? "Cached translation"
+                : status === "loading"
+                  ? "Translating…"
+                  : status === "idle"
+                    ? "Waiting for input"
+                    : `Translation (${targetLanguage})`}{" "}
             {status === "streaming" && <em>(streaming…)</em>}
           </span>
+          <FreshRunAction
+            show={status === "done" && !pending}
+            onClick={() => setFreshNonce((n) => n + 1)}
+            tooltipSide="right"
+          />
         </header>
         <p className="demo-response__body">
           {output ?? (

--- a/apps/site/src/features/docs/components/TranslatorDemo.tsx
+++ b/apps/site/src/features/docs/components/TranslatorDemo.tsx
@@ -23,7 +23,7 @@ export const TranslatorDemo = ({
   const [input, setInput] = useState(initial);
   const debounced = useDebouncedValue(input, TRANSLATE_DEBOUNCE_MS);
   // Bumping the nonce changes the cache key, so a fresh generation skips the
-  // stored result and replaces it.
+  // stored result and writes under a new key. Old entries expire via TTL.
   const [freshNonce, setFreshNonce] = useState(0);
   const { status, output, error, fromCache } = useTranslator({
     input: debounced,

--- a/apps/site/src/features/docs/components/WebMCPDemo.tsx
+++ b/apps/site/src/features/docs/components/WebMCPDemo.tsx
@@ -97,7 +97,7 @@ export const WebMCPDemo = () => {
   };
 
   return (
-    <div className="demo-card demo-card--narrow">
+    <div className="demo-card">
       <p className="demo-muted">
         Two titled, read-only tools registered against{" "}
         <code>document.modelContext</code>. The echo tool validates its input,

--- a/apps/site/src/features/docs/components/WriterDemo.test.tsx
+++ b/apps/site/src/features/docs/components/WriterDemo.test.tsx
@@ -1,0 +1,125 @@
+// @vitest-environment happy-dom
+
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { WriterDemo } from "./WriterDemo.js";
+
+interface WriterHookOptions {
+  input: string;
+  enabled?: boolean;
+}
+
+const mocks = vi.hoisted(() => ({
+  state: {
+    status: "idle" as "idle" | "loading" | "streaming" | "done" | "unavailable",
+    output: null as string | null,
+  },
+  useWriter: vi.fn((_options: WriterHookOptions) => ({
+    status: mocks.state.status,
+    output: mocks.state.output,
+    error: null,
+    fromCache: false,
+    dismiss: vi.fn(),
+  })),
+}));
+
+vi.mock("@web-ai-sdk/writer/react", () => ({
+  useWriter: mocks.useWriter,
+}));
+
+(
+  globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+let root: Root | undefined;
+let container: HTMLDivElement;
+
+const lastOptions = (): WriterHookOptions => {
+  const call = mocks.useWriter.mock.calls.at(-1);
+  if (!call) throw new Error("useWriter was not called");
+  return call[0];
+};
+
+const findButton = (text: string) =>
+  [...container.querySelectorAll("button")].find(
+    (button) => button.textContent?.trim() === text,
+  );
+
+// Assign through the prototype setter so React's value tracker registers the
+// change and the synthetic input event is not deduplicated.
+const typeInput = (value: string) => {
+  const input = container.querySelector("textarea");
+  act(() => {
+    if (!input) return;
+    Object.getOwnPropertyDescriptor(
+      HTMLTextAreaElement.prototype,
+      "value",
+    )?.set?.call(input, value);
+    input.dispatchEvent(new Event("input", { bubbles: true }));
+  });
+};
+
+beforeEach(() => {
+  mocks.state.status = "idle";
+  mocks.state.output = null;
+  mocks.useWriter.mockClear();
+  container = document.createElement("div");
+  document.body.append(container);
+  root = createRoot(container);
+  act(() => root?.render(<WriterDemo />));
+});
+
+afterEach(() => {
+  act(() => root?.unmount());
+  root = undefined;
+  document.body.replaceChildren();
+});
+
+describe("docs WriterDemo", () => {
+  it("never invokes the hook from typing alone", () => {
+    expect(lastOptions().enabled).toBe(false);
+    typeInput("A different task.");
+    expect(lastOptions().enabled).toBe(false);
+    expect(lastOptions().input).toBe("");
+  });
+
+  it("commits the input on Write and runs only then", () => {
+    typeInput("Announce the release.");
+    act(() => findButton("Write")?.click());
+    expect(lastOptions().enabled).toBe(true);
+    expect(lastOptions().input).toBe("Announce the release.");
+
+    // Later keystrokes leave the committed input untouched.
+    typeInput("Announce the release. More detail.");
+    expect(lastOptions().input).toBe("Announce the release.");
+  });
+
+  it("shows Stop while busy and disables the hook when clicked", () => {
+    act(() => findButton("Write")?.click());
+    mocks.state.status = "streaming";
+    mocks.state.output = "Partial draft";
+    typeInput("nudge rerender");
+    typeInput("nudge rerender.");
+
+    const stop = findButton("Stop");
+    expect(stop).toBeDefined();
+    act(() => stop?.click());
+    expect(lastOptions().enabled).toBe(false);
+    expect(container.textContent).toContain("Stopped");
+  });
+
+  it("marks the draft stale after edits and keeps it visible", () => {
+    typeInput("First task.");
+    act(() => findButton("Write")?.click());
+    mocks.state.status = "done";
+    mocks.state.output = "The finished draft.";
+    typeInput("Second task.");
+
+    expect(container.textContent).toContain("The finished draft.");
+    expect(container.textContent).toContain(
+      "The task changed after this draft",
+    );
+    expect(container.textContent).toContain("Draft (stale)");
+  });
+});

--- a/apps/site/src/features/docs/components/WriterDemo.tsx
+++ b/apps/site/src/features/docs/components/WriterDemo.tsx
@@ -1,5 +1,6 @@
 import { useWriter } from "@web-ai-sdk/writer/react";
 import { useState } from "react";
+import { ModelMarkdown } from "../../../shared/components/ModelMarkdown.js";
 import { UnavailableHint } from "./UnavailableHint.js";
 
 const SAMPLE =
@@ -7,13 +8,40 @@ const SAMPLE =
 
 export const WriterDemo = ({ language = "en" }: { language?: string }) => {
   const [input, setInput] = useState(SAMPLE);
+  // The hook only sees input committed by the Write button; typing alone
+  // never invokes the model.
+  const [committed, setCommitted] = useState<string | null>(null);
+  const [enabled, setEnabled] = useState(false);
+  const [stopped, setStopped] = useState(false);
+  const [dismissed, setDismissed] = useState(false);
 
-  const { status, output, error, fromCache, dismiss } = useWriter({
-    input,
+  const { status, output, error } = useWriter({
+    input: committed ?? "",
     language,
     tone: "casual",
     length: "short",
+    enabled: enabled && committed !== null,
   });
+
+  const busy = !stopped && (status === "loading" || status === "streaming");
+  const stale =
+    !busy &&
+    !!output &&
+    committed !== null &&
+    input !== committed &&
+    !dismissed;
+
+  const run = () => {
+    setCommitted(input);
+    setEnabled(true);
+    setStopped(false);
+    setDismissed(false);
+  };
+  // Disabling the hook aborts the in-flight call; Write re-enables it.
+  const stop = () => {
+    setEnabled(false);
+    setStopped(true);
+  };
 
   return (
     <div className="demo-card">
@@ -27,6 +55,22 @@ export const WriterDemo = ({ language = "en" }: { language?: string }) => {
           spellCheck={false}
         />
       </label>
+      <div className="demo-row">
+        {busy ? (
+          <button type="button" onClick={stop} className="demo-button">
+            Stop
+          </button>
+        ) : (
+          <button
+            type="button"
+            onClick={run}
+            disabled={status === "unavailable" || !input.trim()}
+            className="demo-button"
+          >
+            Write
+          </button>
+        )}
+      </div>
       {status === "unavailable" && !error && (
         <UnavailableHint
           api="Writer API"
@@ -46,23 +90,34 @@ export const WriterDemo = ({ language = "en" }: { language?: string }) => {
         />
       )}
       {error && <p className="demo-error">{error.message}</p>}
-      {output && (
+      {stale && (
+        <p className="demo-hint" role="status">
+          The task changed after this draft. Run Write again to update it, or
+          dismiss the draft.
+        </p>
+      )}
+      {output && !dismissed && (
         <aside className="demo-response">
           <header className="demo-response__header">
-            <span>
-              {fromCache ? "Cached draft" : "Draft"}{" "}
-              {status === "streaming" && <em>(streaming…)</em>}
+            <span role="status">
+              {stopped ? "Stopped" : stale ? "Draft (stale)" : "Draft"}{" "}
+              {busy && status === "streaming" && <em>(streaming…)</em>}
             </span>
             <button
               type="button"
-              onClick={dismiss}
+              onClick={() => setDismissed(true)}
               className="demo-dismiss"
               aria-label="dismiss"
             >
               ×
             </button>
           </header>
-          <p className="demo-response__body">{output}</p>
+          <div className="demo-response__body">
+            <ModelMarkdown
+              content={output}
+              streaming={busy && status === "streaming"}
+            />
+          </div>
         </aside>
       )}
     </div>

--- a/apps/site/src/features/docs/styles/demos.css
+++ b/apps/site/src/features/docs/styles/demos.css
@@ -8,20 +8,24 @@
  */
 
 :root {
-  --demo-card-bg: var(--sl-color-bg);
+  /* Borderless cards separate from the page through surface elevation, so
+     light mode needs a raised tint instead of the page background. */
+  --demo-card-bg: var(--sl-color-gray-7, var(--sl-color-bg));
   --demo-card-border: var(--sl-color-hairline);
   --demo-card-shadow:
     0 1px 2px rgba(15, 23, 42, 0.04),
     0 1px 3px rgba(15, 23, 42, 0.06);
-  --demo-card-radius: var(--radius-lg);
+  --demo-card-radius: var(--radius-md);
 
   --demo-input-bg: var(--sl-color-bg);
   --demo-input-fg: var(--sl-color-text);
   --demo-input-border: var(--sl-color-hairline-shade, var(--sl-color-hairline));
 
-  --demo-button-bg: var(--sl-color-bg);
-  --demo-button-border: var(--sl-color-gray-4);
-  --demo-button-fg: var(--sl-color-text);
+  /* Primary action treatment mirroring the home demo buttons: filled with
+     the theme's strongest surface, no border. */
+  --demo-button-bg: #17181c;
+  --demo-button-bg-hover: #2a2b31;
+  --demo-button-fg: #ffffff;
 
   --demo-panel-bg: var(--sl-color-gray-7);
   --demo-panel-border: var(--sl-color-hairline);
@@ -66,8 +70,9 @@
   /* Outer-only raised shadow (no inner shadows), matching the site cards. */
   --demo-card-shadow: var(--shadow-card);
 
-  --demo-button-bg: transparent;
-  --demo-button-border: var(--sl-color-hairline);
+  --demo-button-bg: var(--color-accent);
+  --demo-button-bg-hover: var(--color-accent-bright);
+  --demo-button-fg: var(--color-bg);
 
   --demo-input-bg: var(--sl-color-black, #0a0a0c);
   --demo-input-border: var(--sl-color-hairline);
@@ -82,21 +87,15 @@
 .demo-card {
   font-family: var(--sl-font);
   width: 100%;
-  max-width: 640px;
   margin-top: 24px;
   display: flex;
   flex-direction: column;
   gap: 12px;
   padding: 28px;
-  border: 1px solid var(--demo-card-border);
   border-radius: var(--demo-card-radius);
   background: var(--demo-card-bg);
   box-shadow: var(--demo-card-shadow);
   color: var(--sl-color-text);
-}
-
-.demo-card--narrow {
-  max-width: 560px;
 }
 
 .demo-row {
@@ -117,7 +116,7 @@
 .demo-textarea {
   flex: 1;
   padding: 8px 10px;
-  border: 1px solid var(--demo-input-border);
+  border: none;
   border-radius: var(--radius-sm);
   font-size: 14px;
   font-family: inherit;
@@ -129,30 +128,30 @@
   resize: vertical;
 }
 
+/* Borderless inputs keep a crisp focus ring. */
 .demo-input:focus,
 .demo-textarea:focus {
   outline: none;
-  border-color: var(--sl-color-accent);
+  box-shadow: 0 0 0 1px var(--sl-color-accent);
 }
 
 .demo-button {
   padding: 8px 14px;
   border-radius: var(--radius-sm);
-  border: 1px solid var(--demo-button-border);
+  border: none;
   background: var(--demo-button-bg);
   color: var(--demo-button-fg);
   cursor: pointer;
   font-size: 14px;
+  font-weight: 600;
   font-family: inherit;
   transition:
-    border-color 0.15s ease,
-    color 0.15s ease,
+    background-color 0.15s ease,
     transform 0.09s ease;
 }
 
 .demo-button:hover:not(:disabled) {
-  border-color: var(--sl-color-accent);
-  color: var(--sl-color-text);
+  background: var(--demo-button-bg-hover);
 }
 
 /* Press drops the button 1px (no inset), matching the site buttons. */
@@ -173,7 +172,7 @@
 .demo-hint {
   background: var(--demo-hint-bg);
   padding: 8px 12px;
-  border-radius: 4px;
+  border-radius: var(--radius-sm);
   font-size: 12px;
   color: var(--demo-muted-fg);
   margin: 0;
@@ -182,7 +181,6 @@
 /* Unavailable-API hints reuse the home page's amber warn treatment. */
 .demo-hint--warn {
   background: var(--demo-warn-bg);
-  border: 1px solid var(--demo-warn-border);
   color: var(--demo-warn-fg);
 }
 
@@ -190,10 +188,9 @@
   background: var(--demo-error-bg);
   color: var(--demo-error-fg);
   padding: 8px 12px;
-  border-radius: 4px;
+  border-radius: var(--radius-sm);
   font-size: 12px;
   margin: 0;
-  border: 1px solid var(--demo-error-fg);
 }
 
 .demo-muted {
@@ -207,8 +204,7 @@
   gap: 6px;
   background: var(--demo-panel-bg);
   padding: 10px 12px;
-  border-radius: 4px;
-  border: 1px solid var(--demo-panel-border);
+  border-radius: var(--radius-sm);
 }
 
 .demo-panel__title {
@@ -219,8 +215,7 @@
 
 .demo-response {
   background: var(--demo-accent-bg);
-  border: 1px solid var(--demo-accent-border);
-  border-radius: 6px;
+  border-radius: var(--radius-sm);
   padding: 12px;
   color: var(--sl-color-text);
 }
@@ -244,8 +239,7 @@
   font-family: var(--sl-font-mono);
   font-size: 12px;
   padding: 2px 8px;
-  background: var(--demo-card-bg);
-  border: 1px solid var(--demo-accent-border);
+  background: var(--demo-hint-bg);
   border-radius: 999px;
   color: var(--sl-color-text);
 }
@@ -271,7 +265,7 @@
   font-family: var(--sl-font-mono);
   font-size: 12px;
   padding: 10px 12px;
-  border-radius: 4px;
+  border-radius: var(--radius-sm);
   min-height: 80px;
   white-space: pre-wrap;
 }
@@ -295,8 +289,7 @@
   display: block;
   max-width: 240px;
   max-height: 160px;
-  border: 1px solid var(--demo-card-border);
-  border-radius: 4px;
+  border-radius: var(--radius-sm);
   object-fit: contain;
 }
 
@@ -337,7 +330,7 @@
   left: 0;
   z-index: 50;
   white-space: nowrap;
-  border-radius: 6px;
+  border-radius: var(--radius-sm);
   background: var(--demo-hint-bg);
   padding: 6px 10px;
   font-size: 11px;
@@ -356,4 +349,47 @@
 .demo-tip-wrap:focus-within .demo-tooltip {
   opacity: 1;
   visibility: visible;
+}
+
+/* Reserved footprint for a client-only demo island. The slot keeps the
+   card's height from the first paint and shows a quiet placeholder until
+   the island hydrates, so content below never shifts. */
+.demo-slot {
+  position: relative;
+  margin-top: 24px;
+  min-height: var(--demo-slot-min, 280px);
+}
+
+.demo-slot .demo-card {
+  margin-top: 0;
+}
+
+.demo-slot::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: var(--demo-card-radius);
+  background: var(--demo-card-bg);
+  box-shadow: var(--demo-card-shadow);
+  animation: demo-slot-pulse 1.6s ease-in-out infinite;
+}
+
+.demo-slot:has(.demo-card)::before {
+  content: none;
+}
+
+@keyframes demo-slot-pulse {
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.55;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .demo-slot::before {
+    animation: none;
+  }
 }

--- a/apps/site/src/features/docs/styles/demos.css
+++ b/apps/site/src/features/docs/styles/demos.css
@@ -299,3 +299,61 @@
   border-radius: 4px;
   object-fit: contain;
 }
+
+/* Icon-only demo action with a custom hover/focus tooltip, matching the
+   home demos' fresh-run treatment. */
+.demo-tip-wrap {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+}
+
+.demo-icon-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  border: none;
+  border-radius: 999px;
+  background: transparent;
+  color: var(--demo-muted-fg);
+  cursor: pointer;
+  transition:
+    background-color 0.15s ease,
+    color 0.15s ease;
+}
+
+.demo-icon-button:hover,
+.demo-icon-button:focus-visible {
+  background: var(--demo-hint-bg);
+  color: var(--sl-color-text);
+}
+
+.demo-tooltip {
+  pointer-events: none;
+  position: absolute;
+  bottom: calc(100% + 8px);
+  left: 0;
+  z-index: 50;
+  white-space: nowrap;
+  border-radius: 6px;
+  background: var(--demo-hint-bg);
+  padding: 6px 10px;
+  font-size: 11px;
+  color: var(--sl-color-text);
+  opacity: 0;
+  visibility: hidden;
+  transition: opacity 0.15s ease;
+}
+
+.demo-tooltip--right {
+  left: auto;
+  right: 0;
+}
+
+.demo-tip-wrap:hover .demo-tooltip,
+.demo-tip-wrap:focus-within .demo-tooltip {
+  opacity: 1;
+  visibility: visible;
+}

--- a/apps/site/src/features/docs/styles/web-ai-sdk.css
+++ b/apps/site/src/features/docs/styles/web-ai-sdk.css
@@ -662,3 +662,13 @@ footer:has(> .pagination-links) {
     height: 0.9rem;
   }
 }
+
+/* Code blocks: match the demo surfaces. Radius comes from the shared token
+   scale, frames drop their border, and the padding mirrors the demo cards'
+   28px so code never sits against the frame edges. */
+:root {
+  --ec-brdRad: var(--radius-md);
+  --ec-brdWd: 0px;
+  --ec-codePadBlk: 1.75rem;
+  --ec-codePadInl: 1.75rem;
+}

--- a/apps/site/src/features/home/components/DetectorDemo.tsx
+++ b/apps/site/src/features/home/components/DetectorDemo.tsx
@@ -1,6 +1,14 @@
-import { isAvailable as isDetectorAvailable } from "@web-ai-sdk/detector";
+import {
+  isAvailable as isDetectorAvailable,
+  prepareLanguageDetector,
+} from "@web-ai-sdk/detector";
 import { useDetector } from "@web-ai-sdk/detector/react";
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
+import {
+  useCapabilityLease,
+  useDebouncedValue,
+  useDemoIntent,
+} from "../../../shared/demoLifecycle.js";
 import {
   card,
   cardBody,
@@ -19,10 +27,12 @@ import {
   textarea,
 } from "../../../shared/ui.js";
 import {
-  DownloadNotice,
+  type DemoIntentProps,
+  DownloadDonut,
   ErrorNotice,
   StatusBar,
   UnavailableNotice,
+  useDownloadMonitor,
   useStreamStats,
 } from "./shared.js";
 
@@ -35,11 +45,23 @@ const DETECT_EXAMPLES = [
 
 const EXAMPLE_LABELS = ["en", "pt", "ja", "es"] as const;
 
-export const DetectorDemo = () => {
+// Detection waits for a typing pause instead of running on every keystroke.
+const DETECT_DEBOUNCE_MS = 600;
+
+export const DetectorDemo = ({ intent: tabIntent }: DemoIntentProps) => {
   const [text, setText] = useState<string>(DETECT_EXAMPLES[0]);
   const [available, setAvailable] = useState<boolean | null>(null);
   const { stats, start, update, finish } = useStreamStats();
-  const { status, output, error } = useDetector({ input: text });
+  const { progress, monitor } = useDownloadMonitor();
+  const { intent, markInteracted } = useDemoIntent(tabIntent);
+  const debouncedText = useDebouncedValue(text, DETECT_DEBOUNCE_MS);
+  // Selecting the detector tab is the intent signal, so detection runs on
+  // the seeded example right away; a hydration-only mount stays idle.
+  const { status, output, error } = useDetector({
+    input: debouncedText,
+    monitor,
+    enabled: intent && available !== false,
+  });
   const language = output?.language ?? null;
   const confidence = output?.confidence ?? 0;
   const all = output?.all ?? [];
@@ -47,6 +69,12 @@ export const DetectorDemo = () => {
   useEffect(() => {
     setAvailable(isDetectorAvailable());
   }, []);
+
+  const createLease = useCallback(
+    () => prepareLanguageDetector({ monitor }),
+    [monitor],
+  );
+  useCapabilityLease(intent && available === true, createLease);
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: see comment above
   useEffect(() => {
@@ -60,19 +88,29 @@ export const DetectorDemo = () => {
   }, [status, language]);
 
   const running = status === "loading";
+  // Pending edits keep the previous result visible but marked stale.
+  const stale = intent && text !== debouncedText && status === "done";
+  const displayStats = stale ? { ...stats, status: "stale" } : stats;
 
   return (
-    <div className={card}>
+    <div
+      className={card}
+      onFocusCapture={markInteracted}
+      onPointerDownCapture={markInteracted}
+    >
       <div className={cardHead}>
         <span className={cardHeadTitle}>
           <span className={running ? cardDotLive : cardDotOk} />
-          detect() · live
+          detect() · debounced
         </span>
-        <span>
+        <span className="inline-flex items-center gap-2">
+          <DownloadDonut progress={progress} />
           {status === "done" && language
             ? `${language} · ${Math.round(confidence * 100)}%`
             : status === "idle"
-              ? "awaiting input"
+              ? intent
+                ? "awaiting input"
+                : "awaiting interaction"
               : status === "loading"
                 ? "detecting…"
                 : "-"}
@@ -82,7 +120,6 @@ export const DetectorDemo = () => {
         {available === false && (
           <UnavailableNotice api="Language Detector API" />
         )}
-        <DownloadNotice progress={null} />
         <ErrorNotice error={error?.message ?? null} />
         <div className={fieldSpaced}>
           <label className={label} htmlFor="detector-demo-input">
@@ -135,15 +172,20 @@ export const DetectorDemo = () => {
             <span className="text-fg-4 italic">
               {available === false
                 ? "Open in Chrome 138+ or Edge 148+ to detect."
-                : status === "idle"
-                  ? "Type or paste text above."
-                  : status === "loading"
-                    ? "Detecting…"
-                    : "No confident match."}
+                : !intent
+                  ? "Focus the input or pick an example to start detection."
+                  : status === "idle"
+                    ? "Type or paste text above."
+                    : status === "loading"
+                      ? "Detecting…"
+                      : "No confident match."}
             </span>
           )}
         </div>
-        <StatusBar stats={stats} label="runtime: language-detection model" />
+        <StatusBar
+          stats={displayStats}
+          label={`debounce: ${DETECT_DEBOUNCE_MS}ms`}
+        />
       </div>
     </div>
   );

--- a/apps/site/src/features/home/components/PackageExplorer.test.tsx
+++ b/apps/site/src/features/home/components/PackageExplorer.test.tsx
@@ -1,0 +1,171 @@
+// @vitest-environment happy-dom
+
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { PackageExplorer } from "./PackageExplorer.js";
+
+const mocks = vi.hoisted(() => {
+  const lease = () => ({ ready: Promise.resolve(), release: vi.fn() });
+  return {
+    prepareLanguageModel: vi.fn(lease),
+    prepareSummarizer: vi.fn(lease),
+    prepareTranslator: vi.fn(lease),
+    prepareLanguageDetector: vi.fn(lease),
+    prepareWriter: vi.fn(lease),
+    prepareRewriter: vi.fn(lease),
+    prepareProofreader: vi.fn(lease),
+  };
+});
+
+vi.mock("@web-ai-sdk/prompt", () => ({
+  ask: vi.fn(async () => ({ output: "" })),
+  isAvailable: () => true,
+  PromptUnavailableError: class PromptUnavailableError extends Error {},
+  prepareLanguageModel: mocks.prepareLanguageModel,
+}));
+
+vi.mock("@web-ai-sdk/prompt/react", () => ({
+  usePrompt: () => ({
+    status: "idle",
+    output: null,
+    error: null,
+    fromCache: false,
+    ask: vi.fn(),
+    abort: vi.fn(),
+    reset: vi.fn(),
+  }),
+}));
+
+vi.mock("@web-ai-sdk/summarizer", () => ({
+  isAvailable: () => true,
+  prepareSummarizer: mocks.prepareSummarizer,
+  SummarizerUnavailableError: class SummarizerUnavailableError extends Error {},
+  summarize: vi.fn(async () => ({ output: "", cached: false })),
+}));
+
+vi.mock("@web-ai-sdk/translator", () => ({
+  isAvailable: () => true,
+  prepareTranslator: mocks.prepareTranslator,
+  TranslatorUnavailableError: class TranslatorUnavailableError extends Error {},
+  translate: vi.fn(async () => ({ output: "", cached: false })),
+}));
+
+vi.mock("@web-ai-sdk/detector", () => ({
+  isAvailable: () => true,
+  prepareLanguageDetector: mocks.prepareLanguageDetector,
+}));
+
+vi.mock("@web-ai-sdk/detector/react", () => ({
+  useDetector: () => ({
+    status: "idle",
+    output: null,
+    error: null,
+    fromCache: false,
+  }),
+}));
+
+vi.mock("@web-ai-sdk/writer", () => ({
+  isAvailable: () => true,
+  prepareWriter: mocks.prepareWriter,
+  WriterUnavailableError: class WriterUnavailableError extends Error {},
+  write: vi.fn(async () => ({ output: "", cached: false })),
+}));
+
+vi.mock("@web-ai-sdk/rewriter", () => ({
+  isAvailable: () => true,
+  prepareRewriter: mocks.prepareRewriter,
+  RewriterUnavailableError: class RewriterUnavailableError extends Error {},
+  rewrite: vi.fn(async () => ({ output: "", cached: false })),
+}));
+
+vi.mock("@web-ai-sdk/proofreader", () => ({
+  isAvailable: () => true,
+  ProofreaderUnavailableError: class ProofreaderUnavailableError extends Error {},
+  prepareProofreader: mocks.prepareProofreader,
+  proofread: vi.fn(async () => ({ output: null, cached: false })),
+}));
+
+vi.mock("@web-ai-sdk/webmcp", () => ({
+  executeTool: vi.fn(async () => "{}"),
+  getTools: vi.fn(async () => []),
+  isAvailable: () => true,
+}));
+
+vi.mock("@web-ai-sdk/webmcp/react", () => ({
+  useWebMCP: () => ({
+    tools: [],
+    status: "ready",
+    error: null,
+    refresh: vi.fn(async () => []),
+  }),
+}));
+
+(
+  globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+let root: Root | undefined;
+let container: HTMLDivElement;
+
+const allPrepareMocks = [
+  mocks.prepareLanguageModel,
+  mocks.prepareSummarizer,
+  mocks.prepareTranslator,
+  mocks.prepareLanguageDetector,
+  mocks.prepareWriter,
+  mocks.prepareRewriter,
+  mocks.prepareProofreader,
+];
+
+const selectTab = (slug: string) => {
+  const tab = container.querySelector<HTMLButtonElement>(`#pkg-tab-${slug}`);
+  expect(tab).not.toBeNull();
+  act(() => tab?.click());
+};
+
+beforeEach(() => {
+  for (const mock of allPrepareMocks) mock.mockClear();
+  window.location.hash = "";
+  container = document.createElement("div");
+  document.body.append(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root?.unmount());
+  root = undefined;
+  document.body.replaceChildren();
+});
+
+describe("PackageExplorer preparation intent", () => {
+  it("prepares nothing on hydration alone", () => {
+    act(() => root?.render(<PackageExplorer />));
+    for (const mock of allPrepareMocks) {
+      expect(mock).not.toHaveBeenCalled();
+    }
+  });
+
+  it("prepares only the selected package on tab selection", () => {
+    act(() => root?.render(<PackageExplorer />));
+    selectTab("summarizer");
+
+    expect(mocks.prepareSummarizer).toHaveBeenCalledTimes(1);
+    expect(mocks.prepareLanguageModel).not.toHaveBeenCalled();
+    expect(mocks.prepareTranslator).not.toHaveBeenCalled();
+    expect(mocks.prepareWriter).not.toHaveBeenCalled();
+  });
+
+  it("releases the previous lease when the tab changes", () => {
+    act(() => root?.render(<PackageExplorer />));
+    selectTab("summarizer");
+    const lease = mocks.prepareSummarizer.mock.results[0]?.value as {
+      release: ReturnType<typeof vi.fn>;
+    };
+    expect(lease.release).not.toHaveBeenCalled();
+
+    selectTab("translator");
+    expect(lease.release).toHaveBeenCalledTimes(1);
+    expect(mocks.prepareTranslator).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/site/src/features/home/components/PackageExplorer.tsx
+++ b/apps/site/src/features/home/components/PackageExplorer.tsx
@@ -29,6 +29,7 @@ import { PromptDemo } from "./PromptDemo.js";
 import { ProofreaderDemo } from "./ProofreaderDemo.js";
 import { RewriterDemo } from "./RewriterDemo.js";
 import { SummarizerDemo } from "./SummarizerDemo.js";
+import type { DemoIntentProps } from "./shared.js";
 import { TranslatorDemo } from "./TranslatorDemo.js";
 import { WebMCPDemo } from "./WebMCPDemo.js";
 import { WriterDemo } from "./WriterDemo.js";
@@ -57,11 +58,11 @@ const PACKAGE_ROWS: PackageInfo[] = [
       ["Session reuse.", "Compatible calls reuse a cached base session."],
       [
         "Streaming first.",
-        "The vanilla session yields deltas. The React hook exposes cumulative text.",
+        "Sessions yield deltas. ask() exposes cumulative text.",
       ],
       [
         "Clean lifecycle.",
-        "React cleanup aborts work and destroys the session.",
+        "Abort signals cancel runs. Leases release prepared sessions.",
       ],
     ],
   },
@@ -72,7 +73,7 @@ const PACKAGE_ROWS: PackageInfo[] = [
     bullets: [
       [
         "Declarative tools.",
-        "Register from React and clean up with an AbortSignal.",
+        "Register typed tools and clean up with an AbortSignal.",
       ],
       [
         "Last writer wins.",
@@ -207,7 +208,7 @@ const PACKAGE_ICONS: Record<string, string> = {
   proofreader: `<circle pathLength="1" cx="12" cy="12" r="10"/><path pathLength="1" d="m9 12 2 2 4-4"/>`,
 };
 
-const DEMOS: Record<string, ComponentType> = {
+const DEMOS: Record<string, ComponentType<DemoIntentProps>> = {
   prompt: PromptDemo,
   webmcp: WebMCPDemo,
   summarizer: SummarizerDemo,
@@ -232,23 +233,31 @@ function raise(message: string): never {
 
 export const PackageExplorer = () => {
   const [slug, setSlug] = useState(FIRST_PKG.slug);
+  // Intent gate for session preparation. Hydration and load-time hashes only
+  // mount a demo; an in-page tab selection (click, keyboard, or a later hash
+  // change) is the signal that lets the mounted demo prepare its capability.
+  const [userSelected, setUserSelected] = useState(false);
 
   // Hash support (shareability, not compatibility: nothing links to the old
   // per-slug anchors). On mount and on hashchange, a hash matching a slug
   // selects that tab; clicking a tab replaces the hash without a history
   // entry. Runs only in effects, so SSR never touches window.
   useEffect(() => {
-    const applyHash = () => {
+    const applyHash = (fromNavigation: boolean) => {
       const candidate = window.location.hash.slice(1);
-      if (PACKAGE_ROWS.some((p) => p.slug === candidate)) setSlug(candidate);
+      if (!PACKAGE_ROWS.some((p) => p.slug === candidate)) return;
+      setSlug(candidate);
+      if (fromNavigation) setUserSelected(true);
     };
-    applyHash();
-    window.addEventListener("hashchange", applyHash);
-    return () => window.removeEventListener("hashchange", applyHash);
+    applyHash(false);
+    const onHashChange = () => applyHash(true);
+    window.addEventListener("hashchange", onHashChange);
+    return () => window.removeEventListener("hashchange", onHashChange);
   }, []);
 
   const select = (next: string) => {
     setSlug(next);
+    setUserSelected(true);
     history.replaceState(null, "", `#${next}`);
   };
 
@@ -364,7 +373,9 @@ export const PackageExplorer = () => {
                 </a>
               </div>
             </div>
-            <div className={pkgRight}>{active && Demo ? <Demo /> : null}</div>
+            <div className={pkgRight}>
+              {active && Demo ? <Demo intent={userSelected} /> : null}
+            </div>
           </div>
         );
       })}

--- a/apps/site/src/features/home/components/PromptDemo.tsx
+++ b/apps/site/src/features/home/components/PromptDemo.tsx
@@ -1,6 +1,13 @@
-import { isAvailable as isPromptAvailable } from "@web-ai-sdk/prompt";
+import {
+  isAvailable as isPromptAvailable,
+  prepareLanguageModel,
+} from "@web-ai-sdk/prompt";
 import { usePrompt } from "@web-ai-sdk/prompt/react";
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
+import {
+  useCapabilityLease,
+  useDemoIntent,
+} from "../../../shared/demoLifecycle.js";
 import {
   btnSm,
   btnSmGhost,
@@ -20,8 +27,10 @@ import {
   textarea,
 } from "../../../shared/ui.js";
 import {
-  DownloadNotice,
+  type DemoIntentProps,
+  DownloadDonut,
   MarkdownOutput,
+  StaleNotice,
   StatusBar,
   UnavailableNotice,
   useDownloadMonitor,
@@ -34,13 +43,17 @@ const PROMPT_EXAMPLES = [
   "What's the difference between a hook and a wrapper?",
 ] as const;
 
-export const PromptDemo = () => {
+const SYSTEM_PROMPT = "You are concise. Reply briefly and avoid preamble.";
+
+export const PromptDemo = ({ intent: tabIntent }: DemoIntentProps) => {
   const [promptText, setPromptText] = useState<string>(PROMPT_EXAMPLES[0]);
   const [available, setAvailable] = useState<boolean | null>(null);
-  const { stats, start, update, finish } = useStreamStats();
+  const [ranWith, setRanWith] = useState<string | null>(null);
+  const { stats, start, update, finish, reset: resetStats } = useStreamStats();
   const { progress, monitor } = useDownloadMonitor();
+  const { intent, markInteracted } = useDemoIntent(tabIntent);
   const { status, output, ask, abort, reset } = usePrompt({
-    systemPrompt: "You are concise. Reply briefly and avoid preamble.",
+    systemPrompt: SYSTEM_PROMPT,
     samplingMode: "balanced",
     monitor,
   });
@@ -53,7 +66,7 @@ export const PromptDemo = () => {
       if (output) update(output);
       finish("done");
     } else if (status === "idle" && stats.status === "running") {
-      finish("aborted");
+      finish("stopped");
     }
   }, [status, output]);
 
@@ -61,26 +74,57 @@ export const PromptDemo = () => {
     setAvailable(isPromptAvailable());
   }, []);
 
+  // Prepare the base session once the user shows intent. `ask()` runs on the
+  // same configuration, so the first run reuses the prepared session.
+  const createLease = useCallback(
+    () =>
+      prepareLanguageModel({
+        systemPrompt: SYSTEM_PROMPT,
+        samplingMode: "balanced",
+        monitor,
+      }),
+    [monitor],
+  );
+  useCapabilityLease(intent && available === true, createLease);
+
   const streaming = status === "loading" || status === "streaming";
+  const stale =
+    !streaming && !!output && ranWith !== null && ranWith !== promptText;
 
   const run = async () => {
     if (streaming) return;
+    const key = promptText;
     reset();
-    await ask(promptText);
+    setRanWith(key);
+    await ask(key);
   };
 
+  const dismissResult = () => {
+    reset();
+    setRanWith(null);
+    resetStats();
+  };
+
+  const displayStats = stale ? { ...stats, status: "stale" } : stats;
+
   return (
-    <div className={card}>
+    <div
+      className={card}
+      onFocusCapture={markInteracted}
+      onPointerDownCapture={markInteracted}
+    >
       <div className={cardHead}>
         <span className={cardHeadTitle}>
           <span className={streaming ? cardDotLive : cardDotOk} />
           ask() · streaming
         </span>
-        <span>session: cached · balanced</span>
+        <span className="inline-flex items-center gap-2">
+          <DownloadDonut progress={progress} />
+          session: {intent ? "prepared" : "on-demand"} · balanced
+        </span>
       </div>
       <div className={cardBody}>
         {available === false && <UnavailableNotice api="Prompt API" />}
-        <DownloadNotice progress={progress} />
         <div className={fieldSpaced}>
           <label className={label} htmlFor="prompt-demo-input">
             prompt
@@ -121,6 +165,7 @@ export const PromptDemo = () => {
             ))}
           </div>
         </div>
+        <StaleNotice show={stale} onDismiss={dismissResult} />
         <MarkdownOutput
           text={output ?? ""}
           streaming={streaming}
@@ -130,7 +175,10 @@ export const PromptDemo = () => {
               : "Output will stream here…"
           }
         />
-        <StatusBar stats={stats} label="runtime: browser-provided model" />
+        <StatusBar
+          stats={displayStats}
+          label="runtime: browser-provided model"
+        />
       </div>
     </div>
   );

--- a/apps/site/src/features/home/components/ProofreaderDemo.tsx
+++ b/apps/site/src/features/home/components/ProofreaderDemo.tsx
@@ -1,11 +1,17 @@
 import {
   isAvailable as isProofreaderAvailable,
   ProofreaderUnavailableError,
+  prepareProofreader,
   proofread,
 } from "@web-ai-sdk/proofreader";
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
+import {
+  useCapabilityLease,
+  useDemoIntent,
+} from "../../../shared/demoLifecycle.js";
 import {
   btnSm,
+  btnSmGhost,
   card,
   cardBody,
   cardDotLive,
@@ -18,9 +24,14 @@ import {
   textarea,
 } from "../../../shared/ui.js";
 import {
-  DownloadNotice,
+  CacheAwareRun,
+  DEMO_RESULT_TTL_MS,
+  type DemoIntentProps,
+  DownloadDonut,
   ErrorNotice,
+  FreshRunButton,
   Output,
+  StaleNotice,
   StatusBar,
   UnavailableNotice,
   useDownloadMonitor,
@@ -30,26 +41,45 @@ import {
 const SAMPLE_TEXT =
   "I seen him yesterday at the store, and he bought two loafs of bread.";
 
-export const ProofreaderDemo = () => {
+export const ProofreaderDemo = ({ intent: tabIntent }: DemoIntentProps) => {
   const [text, setText] = useState(SAMPLE_TEXT);
   const [output, setOutput] = useState("");
   const [corrections, setCorrections] = useState(0);
   const [running, setRunning] = useState(false);
   const [available, setAvailable] = useState<boolean | null>(null);
   const [error, setError] = useState<string | null>(null);
-  const { stats, start, update, finish } = useStreamStats();
+  const [ranWith, setRanWith] = useState<string | null>(null);
+  // Bumped when a run serves from the cache, replaying a short pulse so the
+  // instant result still gives visible feedback.
+  const [cacheFlash, setCacheFlash] = useState(0);
+  const { stats, start, update, finish, reset } = useStreamStats();
   const { progress, monitor } = useDownloadMonitor();
+  const { intent, markInteracted } = useDemoIntent(tabIntent);
   const abortRef = useRef<AbortController | null>(null);
 
   useEffect(() => {
     setAvailable(isProofreaderAvailable());
   }, []);
 
-  const run = async () => {
+  // Abort in-flight work when the demo unmounts (for example on tab change).
+  useEffect(() => () => abortRef.current?.abort(), []);
+
+  // Prepare the session once the user shows intent, mirroring the run call.
+  const createLease = useCallback(
+    () => prepareProofreader({ expectedInputLanguages: ["en"], monitor }),
+    [monitor],
+  );
+  useCapabilityLease(intent && available === true, createLease);
+
+  const stale = !running && !!output && ranWith !== null && ranWith !== text;
+
+  const run = async (refresh = false) => {
     if (running) return;
+    const key = text;
     setOutput("");
     setCorrections(0);
     setError(null);
+    setRanWith(null);
     setRunning(true);
     start();
     const ac = new AbortController();
@@ -59,6 +89,9 @@ export const ProofreaderDemo = () => {
         input: text,
         expectedInputLanguages: ["en"],
         monitor,
+        cache: "session",
+        cacheTtl: DEMO_RESULT_TTL_MS,
+        cacheRefresh: refresh,
         signal: ac.signal,
       });
       if (!ac.signal.aborted && result.output) {
@@ -66,10 +99,12 @@ export const ProofreaderDemo = () => {
         setCorrections(result.output.corrections.length);
         update(result.output.correctedInput);
       }
+      setRanWith(key);
+      if (result.cached) setCacheFlash((n) => n + 1);
       finish(result.cached ? "cached" : "done");
     } catch (err: unknown) {
       if (ac.signal.aborted) {
-        finish("aborted");
+        finish("stopped");
       } else if (err instanceof ProofreaderUnavailableError) {
         setError(err.message || "Proofreader API reported unavailable.");
         finish("unavailable");
@@ -83,18 +118,34 @@ export const ProofreaderDemo = () => {
     }
   };
 
+  const stop = () => abortRef.current?.abort();
+  const dismissResult = () => {
+    setOutput("");
+    setCorrections(0);
+    setRanWith(null);
+    reset();
+  };
+
+  const displayStats = stale ? { ...stats, status: "stale" } : stats;
+
   return (
-    <div className={card}>
+    <div
+      className={card}
+      onFocusCapture={markInteracted}
+      onPointerDownCapture={markInteracted}
+    >
       <div className={cardHead}>
         <span className={cardHeadTitle}>
           <span className={running ? cardDotLive : cardDotOk} />
           proofread() · local
         </span>
-        <span>{corrections} fixes</span>
+        <span className="inline-flex items-center gap-2">
+          <DownloadDonut progress={progress} />
+          {corrections} fixes
+        </span>
       </div>
       <div className={cardBody}>
         {available === false && <UnavailableNotice api="Proofreader API" />}
-        <DownloadNotice progress={progress} />
         <ErrorNotice error={error} />
         <div className={fieldSpaced}>
           <label className={label} htmlFor="proofreader-demo-input">
@@ -109,25 +160,47 @@ export const ProofreaderDemo = () => {
           />
         </div>
         <div className={demoControls}>
-          <button
-            type="button"
-            className={btnSm}
-            onClick={run}
-            disabled={running || !available}
-          >
-            <span>{running ? "…" : "▶"}</span> Proofread
-          </button>
+          {!running ? (
+            <CacheAwareRun cached={stats.status === "cached"}>
+              <button
+                type="button"
+                className={btnSm}
+                onClick={() => run()}
+                disabled={!available}
+              >
+                <span>▶</span> Proofread
+              </button>
+            </CacheAwareRun>
+          ) : (
+            <button type="button" className={btnSmGhost} onClick={stop}>
+              <span>■</span> Stop
+            </button>
+          )}
+          <FreshRunButton
+            show={
+              !running && (stats.status === "done" || stats.status === "cached")
+            }
+            onClick={() => run(true)}
+          />
         </div>
-        <Output
-          text={output}
-          streaming={running}
-          placeholder={
-            available === false
-              ? "Open this demo in a supported Proofreader API setup."
-              : "Run to correct grammar, spelling, and punctuation."
+        <StaleNotice show={stale} onDismiss={dismissResult} />
+        <div
+          key={cacheFlash}
+          className={
+            cacheFlash > 0 ? "animate-[demo-cache-flash_0.5s_ease-out]" : ""
           }
-        />
-        <StatusBar stats={stats} label={`${corrections} corrections`} />
+        >
+          <Output
+            text={output}
+            streaming={running}
+            placeholder={
+              available === false
+                ? "Open this demo in a supported Proofreader API setup."
+                : "Run to correct grammar, spelling, and punctuation."
+            }
+          />
+        </div>
+        <StatusBar stats={displayStats} label={`${corrections} corrections`} />
       </div>
     </div>
   );

--- a/apps/site/src/features/home/components/RewriterDemo.tsx
+++ b/apps/site/src/features/home/components/RewriterDemo.tsx
@@ -1,11 +1,17 @@
 import {
   isAvailable as isRewriterAvailable,
+  prepareRewriter,
   RewriterUnavailableError,
   rewrite,
 } from "@web-ai-sdk/rewriter";
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
+import {
+  useCapabilityLease,
+  useDemoIntent,
+} from "../../../shared/demoLifecycle.js";
 import {
   btnSm,
+  btnSmGhost,
   card,
   cardBody,
   cardDotLive,
@@ -23,9 +29,11 @@ import {
   textarea,
 } from "../../../shared/ui.js";
 import {
-  DownloadNotice,
+  type DemoIntentProps,
+  DownloadDonut,
   ErrorNotice,
   MarkdownOutput,
+  StaleNotice,
   StatusBar,
   UnavailableNotice,
   useDownloadMonitor,
@@ -38,7 +46,7 @@ const SAMPLE_TEXT =
 type Tone = "as-is" | "more-formal" | "more-casual";
 type Length = "as-is" | "shorter" | "longer";
 
-export const RewriterDemo = () => {
+export const RewriterDemo = ({ intent: tabIntent }: DemoIntentProps) => {
   const [text, setText] = useState(SAMPLE_TEXT);
   const [tone, setTone] = useState<Tone>("more-formal");
   const [length, setLength] = useState<Length>("as-is");
@@ -46,18 +54,37 @@ export const RewriterDemo = () => {
   const [streaming, setStreaming] = useState(false);
   const [available, setAvailable] = useState<boolean | null>(null);
   const [error, setError] = useState<string | null>(null);
-  const { stats, start, update, finish } = useStreamStats();
+  const [ranWith, setRanWith] = useState<string | null>(null);
+  const { stats, start, update, finish, reset } = useStreamStats();
   const { progress, monitor } = useDownloadMonitor();
+  const { intent, markInteracted } = useDemoIntent(tabIntent);
   const abortRef = useRef<AbortController | null>(null);
 
   useEffect(() => {
     setAvailable(isRewriterAvailable());
   }, []);
 
+  // Abort in-flight work when the demo unmounts (for example on tab change).
+  useEffect(() => () => abortRef.current?.abort(), []);
+
+  // Prepare the session for the current tone and length once the user shows
+  // intent. Option edits release the old lease and prepare the new one.
+  const createLease = useCallback(
+    () => prepareRewriter({ language: "en", tone, length, monitor }),
+    [tone, length, monitor],
+  );
+  useCapabilityLease(intent && available === true, createLease);
+
+  const runKey = JSON.stringify([text, tone, length]);
+  const stale =
+    !streaming && !!output && ranWith !== null && ranWith !== runKey;
+
   const run = async () => {
     if (streaming) return;
+    const key = runKey;
     setOutput("");
     setError(null);
+    setRanWith(null);
     setStreaming(true);
     start();
     const ac = new AbortController();
@@ -80,10 +107,11 @@ export const RewriterDemo = () => {
         setOutput(result.output);
         update(result.output);
       }
-      finish(result.cached ? "cached" : "done");
+      setRanWith(key);
+      finish("done");
     } catch (err: unknown) {
       if (ac.signal.aborted) {
-        finish("aborted");
+        finish("stopped");
       } else if (err instanceof RewriterUnavailableError) {
         setError(err.message || "Rewriter API reported unavailable.");
         finish("unavailable");
@@ -97,20 +125,33 @@ export const RewriterDemo = () => {
     }
   };
 
+  const stop = () => abortRef.current?.abort();
+  const dismissResult = () => {
+    setOutput("");
+    setRanWith(null);
+    reset();
+  };
+
+  const displayStats = stale ? { ...stats, status: "stale" } : stats;
+
   return (
-    <div className={card}>
+    <div
+      className={card}
+      onFocusCapture={markInteracted}
+      onPointerDownCapture={markInteracted}
+    >
       <div className={cardHead}>
         <span className={cardHeadTitle}>
           <span className={streaming ? cardDotLive : cardDotOk} />
           rewrite() · local
         </span>
-        <span>
+        <span className="inline-flex items-center gap-2">
+          <DownloadDonut progress={progress} />
           {tone} · {length}
         </span>
       </div>
       <div className={cardBody}>
         {available === false && <UnavailableNotice api="Rewriter API" />}
-        <DownloadNotice progress={progress} />
         <ErrorNotice error={error} />
         <div className={fieldSpaced}>
           <label className={label} htmlFor="rewriter-demo-input">
@@ -125,14 +166,20 @@ export const RewriterDemo = () => {
           />
         </div>
         <div className={demoControls}>
-          <button
-            type="button"
-            className={btnSm}
-            onClick={run}
-            disabled={streaming || !available}
-          >
-            <span>{streaming ? "…" : "▶"}</span> Rewrite
-          </button>
+          {!streaming ? (
+            <button
+              type="button"
+              className={btnSm}
+              onClick={run}
+              disabled={!available}
+            >
+              <span>▶</span> Rewrite
+            </button>
+          ) : (
+            <button type="button" className={btnSmGhost} onClick={stop}>
+              <span>■</span> Stop
+            </button>
+          )}
           <div className={`${chipRow} ${chipRowEnd}`}>
             {(["as-is", "more-formal", "more-casual"] as const).map((t) => (
               <button
@@ -157,6 +204,7 @@ export const RewriterDemo = () => {
             ))}
           </div>
         </div>
+        <StaleNotice show={stale} onDismiss={dismissResult} />
         <MarkdownOutput
           text={output}
           streaming={streaming}
@@ -166,7 +214,7 @@ export const RewriterDemo = () => {
               : "Run to rewrite the text above."
           }
         />
-        <StatusBar stats={stats} label={`tone: ${tone}`} />
+        <StatusBar stats={displayStats} label={`tone: ${tone}`} />
       </div>
     </div>
   );

--- a/apps/site/src/features/home/components/ScrollSpy.tsx
+++ b/apps/site/src/features/home/components/ScrollSpy.tsx
@@ -28,6 +28,13 @@ export const ScrollSpy = () => {
       document.querySelector<HTMLElement>(`[data-section="${id}"]`),
     );
 
+    // Same handoff signal the floating Back-to-top button uses: once the
+    // footer's own "Back to top" link scrolls into view, the visitor left
+    // the section flow and no nav item stays highlighted.
+    const footerLink = document.querySelector<HTMLElement>(
+      "[data-footer-top-link]",
+    );
+
     let frame = 0;
 
     const syncActive = () => {
@@ -41,19 +48,23 @@ export const ScrollSpy = () => {
         if (section.getBoundingClientRect().top <= marker) activeIndex = i;
       }
 
-      const root = document.documentElement;
-      const atDocumentEnd =
-        root.scrollHeight > window.innerHeight &&
-        Math.ceil(window.scrollY + window.innerHeight) >= root.scrollHeight - 2;
-
-      if (atDocumentEnd) {
-        for (let i = sections.length - 1; i >= 0; i--) {
-          if (sections[i]) {
-            activeIndex = i;
-            break;
-          }
-        }
+      // The short last section cannot reach the top marker before the page
+      // ends, so it activates once it fills the lower half of the viewport.
+      const lastSection = sections[sections.length - 1];
+      if (
+        lastSection &&
+        lastSection.getBoundingClientRect().top <= window.innerHeight / 2
+      ) {
+        activeIndex = sections.length - 1;
       }
+
+      // Same handoff signal that hides the floating Back-to-top button:
+      // once the footer's own link is in view, the visitor left the section
+      // flow and no nav item stays highlighted.
+      const footerLinkInView = footerLink
+        ? footerLink.getBoundingClientRect().top <= window.innerHeight
+        : false;
+      if (footerLinkInView) activeIndex = -1;
 
       links.forEach((link, i) => {
         const isActive = i === activeIndex;

--- a/apps/site/src/features/home/components/SummarizerDemo.test.tsx
+++ b/apps/site/src/features/home/components/SummarizerDemo.test.tsx
@@ -1,0 +1,235 @@
+// @vitest-environment happy-dom
+
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { SummarizerDemo } from "./SummarizerDemo.js";
+
+interface SummarizeCall {
+  input: string;
+  cache?: string;
+  cacheTtl?: number;
+  cacheRefresh?: boolean;
+  signal: AbortSignal;
+  onUpdate?: (chunk: string) => void;
+}
+
+const mocks = vi.hoisted(() => {
+  const release = vi.fn();
+  return {
+    available: true,
+    prepareSummarizer: vi.fn(() => ({ ready: Promise.resolve(), release })),
+    release,
+    resolveNext: null as
+      | ((value: { output: string; cached: boolean }) => void)
+      | null,
+    summarize: vi.fn(
+      (_options: SummarizeCall) =>
+        new Promise<{ output: string; cached: boolean }>((resolve, reject) => {
+          mocks.resolveNext = resolve;
+          _options.signal.addEventListener("abort", () =>
+            reject(new DOMException("Aborted", "AbortError")),
+          );
+        }),
+    ),
+  };
+});
+
+vi.mock("@web-ai-sdk/summarizer", () => ({
+  isAvailable: () => mocks.available,
+  prepareSummarizer: mocks.prepareSummarizer,
+  SummarizerUnavailableError: class SummarizerUnavailableError extends Error {},
+  summarize: mocks.summarize,
+}));
+
+(
+  globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+let root: Root | undefined;
+let container: HTMLDivElement;
+
+const mount = (intent = false) => {
+  container = document.createElement("div");
+  document.body.append(container);
+  root = createRoot(container);
+  act(() => root?.render(<SummarizerDemo intent={intent} />));
+};
+
+const findButton = (text: string) =>
+  [...container.querySelectorAll("button")].find((button) =>
+    button.textContent?.includes(text),
+  );
+
+const statusText = () =>
+  [...container.querySelectorAll('[role="status"]')]
+    .map((node) => node.textContent)
+    .join(" ");
+
+beforeEach(() => {
+  mocks.available = true;
+  mocks.prepareSummarizer.mockClear();
+  mocks.release.mockClear();
+  mocks.summarize.mockClear();
+  mocks.resolveNext = null;
+});
+
+afterEach(() => {
+  act(() => root?.unmount());
+  root = undefined;
+  document.body.replaceChildren();
+});
+
+describe("SummarizerDemo preparation", () => {
+  it("does not prepare on mount without intent", () => {
+    mount(false);
+    expect(mocks.prepareSummarizer).toHaveBeenCalledTimes(0);
+  });
+
+  it("prepares once on tab intent and releases the lease on unmount", () => {
+    mount(true);
+    expect(mocks.prepareSummarizer).toHaveBeenCalledTimes(1);
+    expect(mocks.prepareSummarizer).toHaveBeenCalledWith(
+      expect.objectContaining({
+        language: "en",
+        type: "key-points",
+        length: "short",
+        preference: "auto",
+      }),
+    );
+    expect(mocks.release).not.toHaveBeenCalled();
+
+    act(() => root?.unmount());
+    expect(mocks.release).toHaveBeenCalledTimes(1);
+  });
+
+  it("prepares after direct interaction when the tab gave no intent", () => {
+    mount(false);
+    const input = container.querySelector("textarea");
+    act(() => {
+      input?.dispatchEvent(new FocusEvent("focusin", { bubbles: true }));
+    });
+    expect(mocks.prepareSummarizer).toHaveBeenCalledTimes(1);
+  });
+
+  it("recycles the lease when a session option changes", () => {
+    mount(true);
+    const select = container.querySelector<HTMLSelectElement>(
+      'select[aria-label="Summary type"]',
+    );
+    expect(select).toBeDefined();
+    act(() => {
+      if (!select) return;
+      select.value = "tldr";
+      select.dispatchEvent(new Event("change", { bubbles: true }));
+    });
+    expect(mocks.release).toHaveBeenCalledTimes(1);
+    expect(mocks.prepareSummarizer).toHaveBeenCalledTimes(2);
+    expect(mocks.prepareSummarizer).toHaveBeenLastCalledWith(
+      expect.objectContaining({ type: "tldr" }),
+    );
+  });
+});
+
+describe("SummarizerDemo runs", () => {
+  it("passes the TTL cache options and reports a cached result", async () => {
+    mount(true);
+    await act(async () => {
+      findButton("Summarize")?.click();
+    });
+    const call = mocks.summarize.mock.calls[0]?.[0] as SummarizeCall;
+    expect(call.cache).toBe("session");
+    expect(call.cacheTtl).toBe(10 * 60 * 1000);
+    expect(call.cacheRefresh).toBe(false);
+
+    await act(async () => {
+      mocks.resolveNext?.({ output: "Cached summary.", cached: true });
+    });
+    expect(statusText()).toContain("cached");
+  });
+
+  it("exposes a fresh-generation control that bypasses the cache", async () => {
+    mount(true);
+    await act(async () => {
+      findButton("Summarize")?.click();
+    });
+    await act(async () => {
+      mocks.resolveNext?.({ output: "Cached summary.", cached: true });
+    });
+
+    const fresh = container.querySelector<HTMLButtonElement>(
+      'button[aria-label="Fresh run"]',
+    );
+    expect(fresh).not.toBeNull();
+    await act(async () => {
+      fresh?.click();
+    });
+    const call = mocks.summarize.mock.calls[1]?.[0] as SummarizeCall;
+    expect(call.cacheRefresh).toBe(true);
+  });
+
+  it("shows Stop while busy and aborts the run when clicked", async () => {
+    mount(true);
+    await act(async () => {
+      findButton("Summarize")?.click();
+    });
+    const call = mocks.summarize.mock.calls[0]?.[0] as SummarizeCall;
+    expect(call.signal.aborted).toBe(false);
+
+    const stop = findButton("Stop");
+    expect(stop).toBeDefined();
+    await act(async () => {
+      stop?.click();
+    });
+    expect(call.signal.aborted).toBe(true);
+    expect(statusText()).toContain("stopped");
+  });
+
+  it("aborts an in-flight run when the demo unmounts", async () => {
+    mount(true);
+    await act(async () => {
+      findButton("Summarize")?.click();
+    });
+    const call = mocks.summarize.mock.calls[0]?.[0] as SummarizeCall;
+
+    act(() => root?.unmount());
+    expect(call.signal.aborted).toBe(true);
+  });
+
+  it("keeps the previous result visible but stale after input edits", async () => {
+    mount(true);
+    await act(async () => {
+      findButton("Summarize")?.click();
+    });
+    await act(async () => {
+      mocks.resolveNext?.({ output: "The summary.", cached: false });
+    });
+    expect(container.textContent).toContain("The summary.");
+    expect(statusText()).toContain("done");
+
+    const input = container.querySelector("textarea");
+    act(() => {
+      if (!input) return;
+      // Assign through the prototype setter so React's value tracker
+      // registers the change.
+      Object.getOwnPropertyDescriptor(
+        HTMLTextAreaElement.prototype,
+        "value",
+      )?.set?.call(input, "Different text.");
+      input.dispatchEvent(new Event("input", { bubbles: true }));
+    });
+    expect(container.textContent).toContain("The summary.");
+    expect(statusText()).toContain("stale");
+    expect(container.textContent).toContain(
+      "The input changed after this result.",
+    );
+
+    await act(async () => {
+      container
+        .querySelector<HTMLButtonElement>('button[aria-label="Dismiss result"]')
+        ?.click();
+    });
+    expect(container.textContent).not.toContain("The summary.");
+    expect(statusText()).toContain("idle");
+  });
+});

--- a/apps/site/src/features/home/components/SummarizerDemo.tsx
+++ b/apps/site/src/features/home/components/SummarizerDemo.tsx
@@ -1,11 +1,17 @@
 import {
   isAvailable as isSummarizerAvailable,
+  prepareSummarizer,
   SummarizerUnavailableError,
   summarize,
 } from "@web-ai-sdk/summarizer";
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
+import {
+  useCapabilityLease,
+  useDemoIntent,
+} from "../../../shared/demoLifecycle.js";
 import {
   btnSm,
+  btnSmGhost,
   card,
   cardBody,
   cardDotLive,
@@ -24,10 +30,15 @@ import {
   textarea,
 } from "../../../shared/ui.js";
 import {
-  DownloadNotice,
+  CacheAwareRun,
+  DEMO_RESULT_TTL_MS,
+  type DemoIntentProps,
+  DownloadDonut,
   ErrorNotice,
+  FreshRunButton,
   InfoNotice,
   MarkdownOutput,
+  StaleNotice,
   StatusBar,
   UnavailableNotice,
   useDownloadMonitor,
@@ -74,7 +85,7 @@ const ChipSelect = <T extends string>({
   </span>
 );
 
-export const SummarizerDemo = () => {
+export const SummarizerDemo = ({ intent: tabIntent }: DemoIntentProps) => {
   const [text, setText] = useState(SAMPLE_ARTICLE);
   const [type, setType] = useState<SummaryType>("key-points");
   const [length, setLength] = useState<SummaryLength>("short");
@@ -83,20 +94,43 @@ export const SummarizerDemo = () => {
   const [streaming, setStreaming] = useState(false);
   const [available, setAvailable] = useState<boolean | null>(null);
   const [error, setError] = useState<string | null>(null);
-  const { stats, start, update, finish } = useStreamStats();
+  const [ranWith, setRanWith] = useState<string | null>(null);
+  // Bumped when a run serves from the cache, replaying a short pulse so the
+  // instant result still gives visible feedback.
+  const [cacheFlash, setCacheFlash] = useState(0);
+  const { stats, start, update, finish, reset } = useStreamStats();
   const { progress, monitor } = useDownloadMonitor();
+  const { intent, markInteracted } = useDemoIntent(tabIntent);
   const abortRef = useRef<AbortController | null>(null);
 
   useEffect(() => {
     setAvailable(isSummarizerAvailable());
   }, []);
 
-  const info = preference !== "auto" ? preferenceInfo(preference) : null;
+  // Abort in-flight work when the demo unmounts (for example on tab change).
+  useEffect(() => () => abortRef.current?.abort(), []);
 
-  const run = async () => {
+  // Prepare the session for the current configuration once the user shows
+  // intent. The options mirror the run call, so the first Run reuses the
+  // prepared session. Option edits release the old lease and prepare anew.
+  const createLease = useCallback(
+    () =>
+      prepareSummarizer({ language: "en", type, length, preference, monitor }),
+    [type, length, preference, monitor],
+  );
+  useCapabilityLease(intent && available === true, createLease);
+
+  const info = preference !== "auto" ? preferenceInfo(preference) : null;
+  const runKey = JSON.stringify([text, type, length, preference]);
+  const stale =
+    !streaming && !!output && ranWith !== null && ranWith !== runKey;
+
+  const run = async (refresh = false) => {
     if (streaming) return;
+    const key = runKey;
     setOutput("");
     setError(null);
+    setRanWith(null);
     setStreaming(true);
     start();
     const ac = new AbortController();
@@ -109,6 +143,9 @@ export const SummarizerDemo = () => {
         length,
         preference,
         monitor,
+        cache: "session",
+        cacheTtl: DEMO_RESULT_TTL_MS,
+        cacheRefresh: refresh,
         signal: ac.signal,
         onUpdate: (chunk) => {
           if (ac.signal.aborted) return;
@@ -120,10 +157,12 @@ export const SummarizerDemo = () => {
         setOutput(result.output);
         update(result.output);
       }
+      setRanWith(key);
+      if (result.cached) setCacheFlash((n) => n + 1);
       finish(result.cached ? "cached" : "done");
     } catch (err: unknown) {
       if (ac.signal.aborted) {
-        finish("aborted");
+        finish("stopped");
       } else if (err instanceof SummarizerUnavailableError) {
         setError(err.message || "Summarizer API reported unavailable.");
         finish("unavailable");
@@ -137,21 +176,37 @@ export const SummarizerDemo = () => {
     }
   };
 
+  const stop = () => abortRef.current?.abort();
+  const dismissResult = () => {
+    setOutput("");
+    setRanWith(null);
+    reset();
+  };
+
   const wordCount = text.trim().split(/\s+/).filter(Boolean).length;
+  const displayStats = stale ? { ...stats, status: "stale" } : stats;
 
   return (
-    <div className={card}>
+    // Focus and pointer interaction inside the card count as intent, so a
+    // visitor who starts with the demo (not the tab) still gets preparation.
+    <div
+      className={card}
+      onFocusCapture={markInteracted}
+      onPointerDownCapture={markInteracted}
+    >
       <div className={cardHead}>
         <span className={cardHeadTitle}>
           <span className={streaming ? cardDotLive : cardDotOk} />
           summarize() · local
         </span>
-        <span>{wordCount} words in</span>
+        <span className="inline-flex items-center gap-2">
+          <DownloadDonut progress={progress} />
+          {wordCount} words in
+        </span>
       </div>
       <div className={cardBody}>
         {available === false && <UnavailableNotice api="Summarizer API" />}
         <InfoNotice message={info} />
-        <DownloadNotice progress={progress} />
         <ErrorNotice error={error} />
         <div className={fieldSpaced}>
           <label className={label} htmlFor="summarizer-demo-input">
@@ -166,14 +221,29 @@ export const SummarizerDemo = () => {
           />
         </div>
         <div className={demoControls}>
-          <button
-            type="button"
-            className={btnSm}
-            onClick={run}
-            disabled={streaming || !available}
-          >
-            <span>{streaming ? "…" : "▶"}</span> Summarize
-          </button>
+          {!streaming ? (
+            <CacheAwareRun cached={stats.status === "cached"}>
+              <button
+                type="button"
+                className={btnSm}
+                onClick={() => run()}
+                disabled={!available}
+              >
+                <span>▶</span> Summarize
+              </button>
+            </CacheAwareRun>
+          ) : (
+            <button type="button" className={btnSmGhost} onClick={stop}>
+              <span>■</span> Stop
+            </button>
+          )}
+          <FreshRunButton
+            show={
+              !streaming &&
+              (stats.status === "done" || stats.status === "cached")
+            }
+            onClick={() => run(true)}
+          />
           <div className={`${chipRowInline} ${chipRowEnd}`}>
             <ChipSelect
               label="Summary type"
@@ -197,17 +267,25 @@ export const SummarizerDemo = () => {
             />
           </div>
         </div>
-        <MarkdownOutput
-          text={output}
-          streaming={streaming}
-          placeholder={
-            available === false
-              ? "Open in Chrome 138+ or Edge 138+ to summarize."
-              : "Run to summarize the article above."
+        <StaleNotice show={stale} onDismiss={dismissResult} />
+        <div
+          key={cacheFlash}
+          className={
+            cacheFlash > 0 ? "animate-[demo-cache-flash_0.5s_ease-out]" : ""
           }
-        />
+        >
+          <MarkdownOutput
+            text={output}
+            streaming={streaming}
+            placeholder={
+              available === false
+                ? "Open in Chrome 138+ or Edge 138+ to summarize."
+                : "Run to summarize the article above."
+            }
+          />
+        </div>
         <StatusBar
-          stats={stats}
+          stats={displayStats}
           label={`type: ${type} · preference: ${preference}`}
         />
       </div>

--- a/apps/site/src/features/home/components/TranslatorDemo.tsx
+++ b/apps/site/src/features/home/components/TranslatorDemo.tsx
@@ -1,11 +1,17 @@
 import {
   isAvailable as isTranslatorAvailable,
+  prepareTranslator,
   TranslatorUnavailableError,
   translate,
 } from "@web-ai-sdk/translator";
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
+import {
+  useCapabilityLease,
+  useDemoIntent,
+} from "../../../shared/demoLifecycle.js";
 import {
   btnSm,
+  btnSmGhost,
   card,
   cardBody,
   cardDotLive,
@@ -23,8 +29,13 @@ import {
   textarea,
 } from "../../../shared/ui.js";
 import {
-  DownloadNotice,
+  CacheAwareRun,
+  DEMO_RESULT_TTL_MS,
+  type DemoIntentProps,
+  DownloadDonut,
+  FreshRunButton,
   Output,
+  StaleNotice,
   StatusBar,
   UnavailableNotice,
   useDownloadMonitor,
@@ -40,7 +51,7 @@ const LANGS = [
   { code: "pt", name: "Portuguese" },
 ];
 
-export const TranslatorDemo = () => {
+export const TranslatorDemo = ({ intent: tabIntent }: DemoIntentProps) => {
   const [text, setText] = useState(
     "Building blocks ship as small modules, so they fit any framework.",
   );
@@ -49,17 +60,39 @@ export const TranslatorDemo = () => {
   const [output, setOutput] = useState("");
   const [running, setRunning] = useState(false);
   const [available, setAvailable] = useState<boolean | null>(null);
-  const { stats, start, update, finish } = useStreamStats();
+  const [ranWith, setRanWith] = useState<string | null>(null);
+  // Bumped when a run serves from the cache, replaying a short pulse so the
+  // instant result still gives visible feedback.
+  const [cacheFlash, setCacheFlash] = useState(0);
+  const { stats, start, update, finish, reset } = useStreamStats();
   const { progress, monitor } = useDownloadMonitor();
+  const { intent, markInteracted } = useDemoIntent(tabIntent);
   const abortRef = useRef<AbortController | null>(null);
 
   useEffect(() => {
     setAvailable(isTranslatorAvailable());
   }, []);
 
-  const run = async () => {
+  // Abort in-flight work when the demo unmounts (for example on tab change).
+  useEffect(() => () => abortRef.current?.abort(), []);
+
+  // Prepare the session for the selected language pair once the user shows
+  // intent. Changing the pair releases the old lease and prepares the new one.
+  const createLease = useCallback(
+    () =>
+      prepareTranslator({ sourceLanguage: from, targetLanguage: to, monitor }),
+    [from, to, monitor],
+  );
+  useCapabilityLease(intent && available === true && from !== to, createLease);
+
+  const runKey = JSON.stringify([text, from, to]);
+  const stale = !running && !!output && ranWith !== null && ranWith !== runKey;
+
+  const run = async (refresh = false) => {
     if (running || from === to) return;
+    const key = runKey;
     setOutput("");
+    setRanWith(null);
     setRunning(true);
     start();
     const ac = new AbortController();
@@ -70,6 +103,9 @@ export const TranslatorDemo = () => {
         sourceLanguage: from,
         targetLanguage: to,
         monitor,
+        cache: "session",
+        cacheTtl: DEMO_RESULT_TTL_MS,
+        cacheRefresh: refresh,
         signal: ac.signal,
         onUpdate: (chunk) => {
           if (ac.signal.aborted) return;
@@ -82,10 +118,12 @@ export const TranslatorDemo = () => {
         setOutput(result.output);
         update(result.output);
       }
+      setRanWith(key);
+      if (result.cached) setCacheFlash((n) => n + 1);
       finish(result.cached ? "cached" : "done");
     } catch (err) {
       if (ac.signal.aborted) {
-        finish("aborted");
+        finish("stopped");
       } else if (err instanceof TranslatorUnavailableError) {
         finish("unavailable");
       } else {
@@ -97,27 +135,41 @@ export const TranslatorDemo = () => {
     }
   };
 
+  const stop = () => abortRef.current?.abort();
+  const dismissResult = () => {
+    setOutput("");
+    setRanWith(null);
+    reset();
+  };
+
   const swap = () => {
     setFrom(to);
     setTo(from);
     setText(output || text);
     setOutput("");
+    setRanWith(null);
   };
 
+  const displayStats = stale ? { ...stats, status: "stale" } : stats;
+
   return (
-    <div className={card}>
+    <div
+      className={card}
+      onFocusCapture={markInteracted}
+      onPointerDownCapture={markInteracted}
+    >
       <div className={cardHead}>
         <span className={cardHeadTitle}>
           <span className={running ? cardDotLive : cardDotOk} />
-          translate() · pair cached
+          translate() · streaming
         </span>
-        <span>
+        <span className="inline-flex items-center gap-2">
+          <DownloadDonut progress={progress} />
           {from} → {to}
         </span>
       </div>
       <div className={cardBody}>
         {available === false && <UnavailableNotice api="Translator API" />}
-        <DownloadNotice progress={progress} />
         <div className={langPair}>
           <div className={fieldGroup}>
             <label className={label} htmlFor="translator-demo-from">
@@ -178,30 +230,52 @@ export const TranslatorDemo = () => {
           />
         </div>
         <div className={demoControls}>
-          <button
-            type="button"
-            className={btnSm}
-            onClick={run}
-            disabled={running || from === to || !available}
-          >
-            <span>{running ? "…" : "▶"}</span> Translate
-          </button>
+          {!running ? (
+            <CacheAwareRun cached={stats.status === "cached"}>
+              <button
+                type="button"
+                className={btnSm}
+                onClick={() => run()}
+                disabled={from === to || !available}
+              >
+                <span>▶</span> Translate
+              </button>
+            </CacheAwareRun>
+          ) : (
+            <button type="button" className={btnSmGhost} onClick={stop}>
+              <span>■</span> Stop
+            </button>
+          )}
+          <FreshRunButton
+            show={
+              !running && (stats.status === "done" || stats.status === "cached")
+            }
+            onClick={() => run(true)}
+          />
           {from === to && (
             <span className="ml-auto block rounded-sm border border-[color-mix(in_oklch,var(--color-warn)_40%,var(--color-hairline))] px-3 py-2 font-mono text-[11.5px] text-warn max-[640px]:ml-0 max-[640px]:w-full">
               Source and target are the same.
             </span>
           )}
         </div>
-        <Output
-          text={output}
-          streaming={running}
-          placeholder={
-            available === false
-              ? "Open in Chrome 138+ or Edge 148+ to translate."
-              : `Translation (${to}) will appear here.`
+        <StaleNotice show={stale} onDismiss={dismissResult} />
+        <div
+          key={cacheFlash}
+          className={
+            cacheFlash > 0 ? "animate-[demo-cache-flash_0.5s_ease-out]" : ""
           }
-        />
-        <StatusBar stats={stats} label={`pair: ${from}→${to}`} />
+        >
+          <Output
+            text={output}
+            streaming={running}
+            placeholder={
+              available === false
+                ? "Open in Chrome 138+ or Edge 148+ to translate."
+                : `Translation (${to}) will appear here.`
+            }
+          />
+        </div>
+        <StatusBar stats={displayStats} label={`pair: ${from}→${to}`} />
       </div>
     </div>
   );

--- a/apps/site/src/features/home/components/WebMCPDemo.test.tsx
+++ b/apps/site/src/features/home/components/WebMCPDemo.test.tsx
@@ -18,6 +18,10 @@ const mocks = vi.hoisted(() => {
   return {
     ask: vi.fn(async (_options: { input: string }) => ({ output: "" })),
     executeTool: vi.fn(async () => '{"ok":true}'),
+    prepareLanguageModel: vi.fn(() => ({
+      ready: Promise.resolve(),
+      release: vi.fn(),
+    })),
     promptAvailable: false,
     refresh: vi.fn(async () => tools),
     tools,
@@ -28,6 +32,7 @@ vi.mock("@web-ai-sdk/prompt", () => ({
   ask: mocks.ask,
   isAvailable: () => mocks.promptAvailable,
   PromptUnavailableError: class PromptUnavailableError extends Error {},
+  prepareLanguageModel: mocks.prepareLanguageModel,
 }));
 
 vi.mock("@web-ai-sdk/webmcp", () => ({
@@ -55,6 +60,7 @@ beforeEach(() => {
   vi.useFakeTimers();
   mocks.ask.mockClear();
   mocks.executeTool.mockClear();
+  mocks.prepareLanguageModel.mockClear();
   mocks.promptAvailable = false;
   mocks.refresh.mockClear();
 });
@@ -116,7 +122,7 @@ describe("WebMCPDemo", () => {
     });
 
     const request = mocks.ask.mock.calls[0]?.[0] as
-      | { input: string }
+      | { input: string; responseConstraint?: object }
       | undefined;
     expect(request?.input).toContain("input schema:");
     expect(request?.input).toContain('"quantity"');
@@ -124,5 +130,98 @@ describe("WebMCPDemo", () => {
       sku: "MX-200",
       quantity: 2,
     });
+  });
+
+  it("constrains the router response and parses it without scraping", async () => {
+    mocks.promptAvailable = true;
+    mocks.ask.mockResolvedValue({
+      output:
+        '{"tool":"add_to_cart","args":{"sku":"MX-200","quantity":2},"reason":"Add the requested item."}',
+    });
+    const container = document.createElement("div");
+    document.body.append(container);
+    root = createRoot(container);
+
+    act(() => root?.render(<WebMCPDemo />));
+    const runButton = [...container.querySelectorAll("button")].find((button) =>
+      button.textContent?.includes("Run agent"),
+    );
+
+    await act(async () => {
+      runButton?.click();
+      await vi.runAllTimersAsync();
+    });
+
+    const request = mocks.ask.mock.calls[0]?.[0] as {
+      responseConstraint?: { properties?: Record<string, unknown> };
+    };
+    expect(request.responseConstraint).toBeDefined();
+    expect(request.responseConstraint?.properties).toHaveProperty("tool");
+    expect(request.responseConstraint?.properties).toHaveProperty("reason");
+    expect(mocks.executeTool).toHaveBeenCalledWith(mocks.tools[1], {
+      sku: "MX-200",
+      quantity: 2,
+    });
+  });
+
+  it("refuses when the model names a tool outside the registered set", async () => {
+    mocks.promptAvailable = true;
+    mocks.ask.mockResolvedValue({
+      output: '{"tool":"delete_account","args":{},"reason":"Best match."}',
+    });
+    const container = document.createElement("div");
+    document.body.append(container);
+    root = createRoot(container);
+
+    act(() => root?.render(<WebMCPDemo />));
+    const runButton = [...container.querySelectorAll("button")].find((button) =>
+      button.textContent?.includes("Run agent"),
+    );
+
+    await act(async () => {
+      runButton?.click();
+      await vi.runAllTimersAsync();
+    });
+
+    expect(container.textContent).toContain(
+      `LM picked "delete_account" which isn't registered`,
+    );
+    expect(mocks.executeTool).not.toHaveBeenCalled();
+  });
+
+  it("refuses when the model's arguments fail the tool's input schema", async () => {
+    mocks.promptAvailable = true;
+    mocks.ask.mockResolvedValue({
+      output: '{"tool":"add_to_cart","args":{"quantity":0},"reason":"Add it."}',
+    });
+    const container = document.createElement("div");
+    document.body.append(container);
+    root = createRoot(container);
+
+    act(() => root?.render(<WebMCPDemo />));
+    const runButton = [...container.querySelectorAll("button")].find((button) =>
+      button.textContent?.includes("Run agent"),
+    );
+
+    await act(async () => {
+      runButton?.click();
+      await vi.runAllTimersAsync();
+    });
+
+    expect(container.textContent).toContain("failed schema validation");
+    expect(mocks.executeTool).not.toHaveBeenCalled();
+  });
+
+  it("prepares the routing session only after tab intent", async () => {
+    mocks.promptAvailable = true;
+    const container = document.createElement("div");
+    document.body.append(container);
+    root = createRoot(container);
+
+    act(() => root?.render(<WebMCPDemo />));
+    expect(mocks.prepareLanguageModel).not.toHaveBeenCalled();
+
+    act(() => root?.render(<WebMCPDemo intent />));
+    expect(mocks.prepareLanguageModel).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/site/src/features/home/components/WebMCPDemo.tsx
+++ b/apps/site/src/features/home/components/WebMCPDemo.tsx
@@ -2,6 +2,7 @@ import {
   ask,
   isAvailable as isPromptAvailable,
   PromptUnavailableError,
+  prepareLanguageModel,
 } from "@web-ai-sdk/prompt";
 import {
   executeTool,
@@ -10,10 +11,15 @@ import {
   type StandardSchemaV1,
 } from "@web-ai-sdk/webmcp";
 import { useWebMCP } from "@web-ai-sdk/webmcp/react";
-import { useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { z } from "zod";
 import {
+  useCapabilityLease,
+  useDemoIntent,
+} from "../../../shared/demoLifecycle.js";
+import {
   btnSm,
+  btnSmGhost,
   card,
   cardBody,
   cardDotLive,
@@ -37,7 +43,8 @@ import {
   toolToggleTrack,
 } from "../../../shared/ui.js";
 import {
-  DownloadNotice,
+  type DemoIntentProps,
+  DownloadDonut,
   StatusBar,
   UnavailableNotice,
   useDownloadMonitor,
@@ -121,6 +128,48 @@ const MCP_PROMPTS = [
   "Open my notification settings.",
 ] as const;
 
+const ROUTER_SYSTEM_PROMPT =
+  "You are a tool-routing agent. Pick one registered tool for the user " +
+  "intent, or set tool to null when no registered tool fits; don't force " +
+  "a call.";
+
+// JSON Schema passed as `responseConstraint`, so the model emits this shape
+// directly and the demo parses it without scraping.
+const ROUTE_CONSTRAINT = {
+  type: "object",
+  additionalProperties: false,
+  properties: {
+    tool: { type: ["string", "null"] },
+    args: { type: "object" },
+    reason: { type: "string" },
+  },
+  required: ["tool", "reason"],
+} as const;
+
+interface RoutePlan {
+  tool?: string | null;
+  args?: Record<string, unknown>;
+  reason?: string;
+}
+
+/** Validate LM-chosen args against the tool's registered input schema. */
+const validateArgs = async (
+  spec: ToolSpec,
+  args: Record<string, unknown>,
+): Promise<
+  { ok: true; args: Record<string, unknown> } | { ok: false; message: string }
+> => {
+  if (!spec.input) return { ok: true, args };
+  const result = await spec.input["~standard"].validate(args);
+  if (result.issues) {
+    return {
+      ok: false,
+      message: result.issues.map((issue) => issue.message).join("; "),
+    };
+  }
+  return { ok: true, args: result.value as Record<string, unknown> };
+};
+
 type TraceEvent =
   | { kind: "step"; text: string }
   | { kind: "warn"; text: string }
@@ -128,7 +177,7 @@ type TraceEvent =
   | { kind: "result"; text: string }
   | { kind: "call"; tool: string; args: unknown; reason: string };
 
-export const WebMCPDemo = () => {
+export const WebMCPDemo = ({ intent: tabIntent }: DemoIntentProps) => {
   const [enabledIds, setEnabledIds] = useState<Set<string>>(
     () => new Set(TOOL_SPECS.filter((t) => t.on).map((t) => t.id)),
   );
@@ -138,10 +187,31 @@ export const WebMCPDemo = () => {
   const [available, setAvailable] = useState<boolean | null>(null);
   const { stats, start, update, finish } = useStreamStats();
   const { progress, monitor } = useDownloadMonitor();
+  const { intent, markInteracted } = useDemoIntent(tabIntent);
+  const abortRef = useRef<AbortController | null>(null);
 
   useEffect(() => {
     setAvailable(isWebMcpAvailable());
   }, []);
+
+  // Abort in-flight routing when the demo unmounts (for example tab change).
+  useEffect(() => () => abortRef.current?.abort(), []);
+
+  // The router runs on the Prompt API, so intent prepares that base session
+  // with the exact routing configuration the run reuses.
+  const createLease = useCallback(
+    () =>
+      prepareLanguageModel({
+        systemPrompt: ROUTER_SYSTEM_PROMPT,
+        samplingMode: "most-predictable",
+        monitor,
+      }),
+    [monitor],
+  );
+  useCapabilityLease(
+    intent && available === true && isPromptAvailable(),
+    createLease,
+  );
 
   // Build the live definitions from the toggle state. `useWebMCP` re-registers only
   // when discoverable metadata changes and keeps execute callbacks current,
@@ -191,6 +261,8 @@ export const WebMCPDemo = () => {
       return next;
     });
 
+  const stop = () => abortRef.current?.abort();
+
   const run = async () => {
     if (running) return;
     // Defensive bail: on browsers without `document.modelContext` (or the
@@ -204,198 +276,224 @@ export const WebMCPDemo = () => {
     setRunning(true);
     setTrace([]);
     start();
+    const ac = new AbortController();
+    abortRef.current = ac;
+
+    const throwIfStopped = () => {
+      if (ac.signal.aborted) throw new DOMException("Aborted", "AbortError");
+    };
 
     const push = async (ev: TraceEvent, delay = 240) => {
+      throwIfStopped();
       setTrace((t) => [...t, ev]);
       update("x".repeat(JSON.stringify(ev).length));
       await new Promise((r) => setTimeout(r, delay));
+      throwIfStopped();
     };
 
-    const discovered = await refreshDiscoveredTools();
-    const discoveredDemoTools = discovered.filter((tool) =>
-      TOOL_SPECS.some((candidate) => candidate.name === tool.name),
-    );
-    const discoveredNames = new Set(
-      discoveredDemoTools.map(({ name }) => name),
-    );
-    const discoveredCount = discovered.length;
-    const demoToolCount = discoveredDemoTools.length;
-    const enabledSpecs = TOOL_SPECS.filter((tool) =>
-      discoveredNames.has(tool.name),
-    );
-    await push(
-      {
-        kind: "step",
-        text: `getTools() → ${discoveredCount} tool${discoveredCount === 1 ? "" : "s"} (${demoToolCount} in this demo)`,
-      },
-      200,
-    );
-
-    // Try a real on-device agent: ask the Prompt API which tool to call.
-    // Fall back to keyword matching when Prompt isn't available.
-    // Tracks three outcomes: a candidate (use this tool), a refusal
-    // (LM said no tool matches), or a fallback (Prompt API not available;
-    // try keyword matching).
-    let candidate: ToolSpec | null = null;
-    let chosenArgs: Record<string, unknown> = {};
-    let chosenReason = "";
-    let usedRealAgent = false;
-    let agentRefused: { reason: string } | null = null;
-
-    if (isPromptAvailable() && enabledSpecs.length > 0) {
+    try {
+      const discovered = await refreshDiscoveredTools();
+      const discoveredDemoTools = discovered.filter((tool) =>
+        TOOL_SPECS.some((candidate) => candidate.name === tool.name),
+      );
+      const discoveredNames = new Set(
+        discoveredDemoTools.map(({ name }) => name),
+      );
+      const discoveredCount = discovered.length;
+      const demoToolCount = discoveredDemoTools.length;
+      const enabledSpecs = TOOL_SPECS.filter((tool) =>
+        discoveredNames.has(tool.name),
+      );
       await push(
         {
           kind: "step",
-          text: "Prompt API → picking a tool with the on-device LM…",
+          text: `getTools() → ${discoveredCount} tool${discoveredCount === 1 ? "" : "s"} (${demoToolCount} in this demo)`,
         },
-        260,
+        200,
       );
-      const toolBlock = enabledSpecs
-        .map((tool) => {
-          const schema = tool.inputSchema
-            ? JSON.stringify(tool.inputSchema)
-            : "no input schema";
-          return `- ${tool.name}: ${tool.desc}\n  input schema: ${schema}`;
-        })
-        .join("\n");
-      const agentInput = `Registered tools:
+
+      // Try a real on-device agent: ask the Prompt API which tool to call,
+      // constrained to the routing schema so the reply parses directly.
+      // Fall back to keyword matching when Prompt isn't available.
+      // Tracks three outcomes: a candidate (use this tool), a refusal
+      // (LM said no tool matches), or a fallback (Prompt API not available;
+      // try keyword matching).
+      let candidate: ToolSpec | null = null;
+      let chosenArgs: Record<string, unknown> = {};
+      let chosenReason = "";
+      let usedRealAgent = false;
+      let agentRefused: { reason: string } | null = null;
+
+      if (isPromptAvailable() && enabledSpecs.length > 0) {
+        await push(
+          {
+            kind: "step",
+            text: "Prompt API → picking a tool with the on-device LM…",
+          },
+          260,
+        );
+        const toolBlock = enabledSpecs
+          .map((tool) => {
+            const schema = tool.inputSchema
+              ? JSON.stringify(tool.inputSchema)
+              : "no input schema";
+            return `- ${tool.name}: ${tool.desc}\n  input schema: ${schema}`;
+          })
+          .join("\n");
+        const agentInput = `Registered tools:
 ${toolBlock}
 
 User said: "${prompt}"
 
-Reply with ONLY valid JSON of the shape {"tool":"name_or_null","args":{},"reason":"one short sentence"}. Choose one of the registered tool names if the user intent maps to it. If no registered tool matches, set "tool" to null and explain briefly in "reason". No markdown, no backticks.`;
-      try {
-        const result = await ask({
-          input: agentInput,
-          systemPrompt:
-            "You are a tool-routing agent. Reply with valid JSON only. " +
-            "Set tool to null when no registered tool fits the user intent; " +
-            "don't force a call.",
-          samplingMode: "most-predictable",
-          monitor,
-        });
-        const raw = result.output ?? "";
-        const m = raw.match(/\{[\s\S]*\}/);
-        if (m) {
-          const parsed = JSON.parse(m[0]) as {
-            tool?: string | null;
-            args?: Record<string, unknown>;
-            reason?: string;
-          };
-          const reason = parsed.reason ?? "(no reason given)";
-          if (parsed.tool === null || parsed.tool === undefined) {
+Choose one of the registered tool names if the user intent maps to it, and fill "args" from its input schema. If no registered tool matches, set "tool" to null and explain briefly in "reason".`;
+        try {
+          const result = await ask({
+            input: agentInput,
+            systemPrompt: ROUTER_SYSTEM_PROMPT,
+            samplingMode: "most-predictable",
+            responseConstraint: ROUTE_CONSTRAINT,
+            monitor,
+            signal: ac.signal,
+          });
+          // The response constraint guarantees the JSON shape; parse the
+          // output directly instead of scraping it with a regex.
+          const parsed = JSON.parse(result.output ?? "null") as RoutePlan;
+          const reason = parsed?.reason ?? "(no reason given)";
+          if (parsed?.tool === null || parsed?.tool === undefined) {
             agentRefused = { reason };
             usedRealAgent = true;
           } else {
             const found = enabledSpecs.find((t) => t.name === parsed.tool);
-            if (found) {
-              candidate = found;
-              chosenArgs = parsed.args ?? {};
-              chosenReason = reason;
-              usedRealAgent = true;
-            } else {
+            if (!found) {
               // LM named a tool that isn't registered; treat as refusal
               // rather than silently calling something else.
               agentRefused = {
                 reason: `LM picked "${parsed.tool}" which isn't registered. ${reason}`,
               };
               usedRealAgent = true;
+            } else {
+              const checked = await validateArgs(found, parsed.args ?? {});
+              if (!checked.ok) {
+                agentRefused = {
+                  reason: `LM args for "${found.name}" failed schema validation: ${checked.message}`,
+                };
+                usedRealAgent = true;
+              } else {
+                candidate = found;
+                chosenArgs = checked.args;
+                chosenReason = reason;
+                usedRealAgent = true;
+              }
             }
           }
-        }
-      } catch (err) {
-        if (!(err instanceof PromptUnavailableError)) {
-          await push(
-            {
-              kind: "warn",
-              text: `Prompt API error: ${(err as Error)?.message ?? "unknown"}; falling back to keyword match.`,
-            },
-            200,
-          );
+        } catch (err) {
+          throwIfStopped();
+          if (!(err instanceof PromptUnavailableError)) {
+            await push(
+              {
+                kind: "warn",
+                text: `Prompt API error: ${(err as Error)?.message ?? "unknown"}; falling back to keyword match.`,
+              },
+              200,
+            );
+          }
         }
       }
-    }
 
-    if (agentRefused) {
-      await push({
-        kind: "warn",
-        text: `Refused: ${agentRefused.reason}`,
-      });
-      finish("refused");
-      setRunning(false);
-      return;
-    }
-
-    if (!usedRealAgent) {
-      await push(
-        {
-          kind: "step",
-          text: "Falling back to keyword match (enable Prompt API for a real agent).",
-        },
-        200,
-      );
-      const matched = enabledSpecs.find((t) => t.match.test(prompt));
-      if (!matched) {
+      if (agentRefused) {
         await push({
           kind: "warn",
-          text: "Refused: no enabled tool matched the user intent.",
+          text: `Refused: ${agentRefused.reason}`,
         });
         finish("refused");
-        setRunning(false);
         return;
       }
-      candidate = matched;
-      chosenArgs =
-        matched.id === "add_to_cart"
-          ? { sku: "MX-200", quantity: 2 }
-          : matched.id === "search_orders"
-            ? { since: "last-tuesday" }
-            : matched.id === "open_settings"
-              ? { pane: "notifications" }
-              : {};
-      chosenReason = `User intent mentions "${(prompt.match(matched.match)?.[0] ?? "").trim()}"; best match is ${matched.name}.`;
-    }
 
-    if (!candidate) {
-      await push({
-        kind: "warn",
-        text: "Refused: no candidate tool.",
-      });
-      finish("refused");
-      setRunning(false);
-      return;
-    }
-
-    await push(
-      {
-        kind: "call",
-        tool: candidate.name,
-        args: chosenArgs,
-        reason: chosenReason,
-      },
-      280,
-    );
-
-    let resultText = "null";
-    const registeredTool = discoveredDemoTools.find(
-      (tool) => tool.name === candidate.name,
-    );
-    if (!registeredTool) {
-      resultText = `error: ${candidate.name} is no longer registered`;
-    } else {
-      try {
-        const raw = await executeTool(registeredTool, chosenArgs);
-        resultText = raw ?? "navigation triggered";
-      } catch (err) {
-        resultText = `error: ${(err as Error)?.message ?? "unknown"}`;
+      if (!usedRealAgent) {
+        await push(
+          {
+            kind: "step",
+            text: "Falling back to keyword match (enable Prompt API for a real agent).",
+          },
+          200,
+        );
+        const matched = enabledSpecs.find((t) => t.match.test(prompt));
+        if (!matched) {
+          await push({
+            kind: "warn",
+            text: "Refused: no enabled tool matched the user intent.",
+          });
+          finish("refused");
+          return;
+        }
+        candidate = matched;
+        chosenArgs =
+          matched.id === "add_to_cart"
+            ? { sku: "MX-200", quantity: 2 }
+            : matched.id === "search_orders"
+              ? { since: "last-tuesday" }
+              : matched.id === "open_settings"
+                ? { pane: "notifications" }
+                : {};
+        chosenReason = `User intent mentions "${(prompt.match(matched.match)?.[0] ?? "").trim()}"; best match is ${matched.name}.`;
       }
+
+      if (!candidate) {
+        await push({
+          kind: "warn",
+          text: "Refused: no candidate tool.",
+        });
+        finish("refused");
+        return;
+      }
+
+      await push(
+        {
+          kind: "call",
+          tool: candidate.name,
+          args: chosenArgs,
+          reason: chosenReason,
+        },
+        280,
+      );
+
+      let resultText = "null";
+      const registeredTool = discoveredDemoTools.find(
+        (tool) => tool.name === candidate.name,
+      );
+      if (!registeredTool) {
+        resultText = `error: ${candidate.name} is no longer registered`;
+      } else {
+        try {
+          const raw = await executeTool(registeredTool, chosenArgs);
+          resultText = raw ?? "navigation triggered";
+        } catch (err) {
+          resultText = `error: ${(err as Error)?.message ?? "unknown"}`;
+        }
+      }
+      throwIfStopped();
+      await push(
+        { kind: "result", text: `↳ ${candidate.name}(...) → ${resultText}` },
+        200,
+      );
+      finish("done");
+    } catch (err) {
+      if (ac.signal.aborted || (err as Error)?.name === "AbortError") {
+        finish("stopped");
+      } else {
+        setTrace((t) => [
+          ...t,
+          {
+            kind: "err",
+            text: `Run failed: ${(err as Error)?.message ?? "unknown"}`,
+          },
+        ]);
+        finish("error");
+      }
+    } finally {
+      setRunning(false);
+      abortRef.current = null;
     }
-    await push(
-      { kind: "result", text: `↳ ${candidate.name}(...) → ${resultText}` },
-      200,
-    );
-    finish("done");
-    setRunning(false);
   };
 
   const registeredCount = discoveredTools.filter((tool) =>
@@ -403,20 +501,24 @@ Reply with ONLY valid JSON of the shape {"tool":"name_or_null","args":{},"reason
   ).length;
 
   return (
-    <div className={card}>
+    <div
+      className={card}
+      onFocusCapture={markInteracted}
+      onPointerDownCapture={markInteracted}
+    >
       <div className={cardHead}>
         <span className={cardHeadTitle}>
           <span className={running ? cardDotLive : cardDotOk} />
           registerTool() · agentic
         </span>
-        <span>
+        <span className="inline-flex items-center gap-2">
+          <DownloadDonut progress={progress} />
           {discoveryStatus === "loading" ? "…" : registeredCount} demo tool
           {registeredCount === 1 ? "" : "s"} registered
         </span>
       </div>
       <div className={cardBody}>
         {available === false && <UnavailableNotice api="WebMCP" />}
-        <DownloadNotice progress={progress} />
         <fieldset className={fieldset}>
           <legend className={fieldLegend}>demo tools</legend>
           <ul className={toolList}>
@@ -466,14 +568,20 @@ Reply with ONLY valid JSON of the shape {"tool":"name_or_null","args":{},"reason
           />
         </div>
         <div className={demoControls}>
-          <button
-            type="button"
-            className={btnSm}
-            onClick={run}
-            disabled={running || !available}
-          >
-            <span>{running ? "…" : "▶"}</span> Run agent
-          </button>
+          {!running ? (
+            <button
+              type="button"
+              className={btnSm}
+              onClick={run}
+              disabled={!available}
+            >
+              <span>▶</span> Run agent
+            </button>
+          ) : (
+            <button type="button" className={btnSmGhost} onClick={stop}>
+              <span>■</span> Stop
+            </button>
+          )}
           <div className={`${chipRow} ${chipRowEnd}`}>
             {MCP_PROMPTS.map((p, i) => (
               <button

--- a/apps/site/src/features/home/components/WriterDemo.tsx
+++ b/apps/site/src/features/home/components/WriterDemo.tsx
@@ -1,11 +1,17 @@
 import {
   isAvailable as isWriterAvailable,
+  prepareWriter,
   WriterUnavailableError,
   write,
 } from "@web-ai-sdk/writer";
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
+import {
+  useCapabilityLease,
+  useDemoIntent,
+} from "../../../shared/demoLifecycle.js";
 import {
   btnSm,
+  btnSmGhost,
   card,
   cardBody,
   cardDotLive,
@@ -23,9 +29,11 @@ import {
   textarea,
 } from "../../../shared/ui.js";
 import {
-  DownloadNotice,
+  type DemoIntentProps,
+  DownloadDonut,
   ErrorNotice,
   MarkdownOutput,
+  StaleNotice,
   StatusBar,
   UnavailableNotice,
   useDownloadMonitor,
@@ -38,7 +46,7 @@ const SAMPLE_TASK =
 type Tone = "formal" | "neutral" | "casual";
 type Length = "short" | "medium" | "long";
 
-export const WriterDemo = () => {
+export const WriterDemo = ({ intent: tabIntent }: DemoIntentProps) => {
   const [text, setText] = useState(SAMPLE_TASK);
   const [tone, setTone] = useState<Tone>("casual");
   const [length, setLength] = useState<Length>("short");
@@ -46,18 +54,37 @@ export const WriterDemo = () => {
   const [streaming, setStreaming] = useState(false);
   const [available, setAvailable] = useState<boolean | null>(null);
   const [error, setError] = useState<string | null>(null);
-  const { stats, start, update, finish } = useStreamStats();
+  const [ranWith, setRanWith] = useState<string | null>(null);
+  const { stats, start, update, finish, reset } = useStreamStats();
   const { progress, monitor } = useDownloadMonitor();
+  const { intent, markInteracted } = useDemoIntent(tabIntent);
   const abortRef = useRef<AbortController | null>(null);
 
   useEffect(() => {
     setAvailable(isWriterAvailable());
   }, []);
 
+  // Abort in-flight work when the demo unmounts (for example on tab change).
+  useEffect(() => () => abortRef.current?.abort(), []);
+
+  // Prepare the session for the current tone and length once the user shows
+  // intent. Option edits release the old lease and prepare the new one.
+  const createLease = useCallback(
+    () => prepareWriter({ language: "en", tone, length, monitor }),
+    [tone, length, monitor],
+  );
+  useCapabilityLease(intent && available === true, createLease);
+
+  const runKey = JSON.stringify([text, tone, length]);
+  const stale =
+    !streaming && !!output && ranWith !== null && ranWith !== runKey;
+
   const run = async () => {
     if (streaming) return;
+    const key = runKey;
     setOutput("");
     setError(null);
+    setRanWith(null);
     setStreaming(true);
     start();
     const ac = new AbortController();
@@ -80,10 +107,11 @@ export const WriterDemo = () => {
         setOutput(result.output);
         update(result.output);
       }
-      finish(result.cached ? "cached" : "done");
+      setRanWith(key);
+      finish("done");
     } catch (err: unknown) {
       if (ac.signal.aborted) {
-        finish("aborted");
+        finish("stopped");
       } else if (err instanceof WriterUnavailableError) {
         setError(err.message || "Writer API reported unavailable.");
         finish("unavailable");
@@ -97,20 +125,33 @@ export const WriterDemo = () => {
     }
   };
 
+  const stop = () => abortRef.current?.abort();
+  const dismissResult = () => {
+    setOutput("");
+    setRanWith(null);
+    reset();
+  };
+
+  const displayStats = stale ? { ...stats, status: "stale" } : stats;
+
   return (
-    <div className={card}>
+    <div
+      className={card}
+      onFocusCapture={markInteracted}
+      onPointerDownCapture={markInteracted}
+    >
       <div className={cardHead}>
         <span className={cardHeadTitle}>
           <span className={streaming ? cardDotLive : cardDotOk} />
           write() · local
         </span>
-        <span>
+        <span className="inline-flex items-center gap-2">
+          <DownloadDonut progress={progress} />
           {tone} · {length}
         </span>
       </div>
       <div className={cardBody}>
         {available === false && <UnavailableNotice api="Writer API" />}
-        <DownloadNotice progress={progress} />
         <ErrorNotice error={error} />
         <div className={fieldSpaced}>
           <label className={label} htmlFor="writer-demo-input">
@@ -125,14 +166,20 @@ export const WriterDemo = () => {
           />
         </div>
         <div className={demoControls}>
-          <button
-            type="button"
-            className={btnSm}
-            onClick={run}
-            disabled={streaming || !available}
-          >
-            <span>{streaming ? "…" : "▶"}</span> Write
-          </button>
+          {!streaming ? (
+            <button
+              type="button"
+              className={btnSm}
+              onClick={run}
+              disabled={!available}
+            >
+              <span>▶</span> Write
+            </button>
+          ) : (
+            <button type="button" className={btnSmGhost} onClick={stop}>
+              <span>■</span> Stop
+            </button>
+          )}
           <div className={`${chipRow} ${chipRowEnd}`}>
             {(["formal", "neutral", "casual"] as const).map((t) => (
               <button
@@ -157,6 +204,7 @@ export const WriterDemo = () => {
             ))}
           </div>
         </div>
+        <StaleNotice show={stale} onDismiss={dismissResult} />
         <MarkdownOutput
           text={output}
           streaming={streaming}
@@ -166,7 +214,7 @@ export const WriterDemo = () => {
               : "Run to draft content from the task above."
           }
         />
-        <StatusBar stats={stats} label={`tone: ${tone}`} />
+        <StatusBar stats={displayStats} label={`tone: ${tone}`} />
       </div>
     </div>
   );

--- a/apps/site/src/features/home/components/shared.tsx
+++ b/apps/site/src/features/home/components/shared.tsx
@@ -2,12 +2,28 @@ import { type ReactNode, useCallback, useRef, useState } from "react";
 import { ModelMarkdown } from "../../../shared/components/ModelMarkdown.js";
 import {
   caret,
+  demoIconBtn,
+  demoTooltip,
+  demoTooltipBelow,
+  demoTooltipWrap,
   markdownProse,
   markdownProseEmpty,
   outputBox,
 } from "../../../shared/ui.js";
 
 const browserSupportHref = `${import.meta.env.BASE_URL}docs/browser-support/`;
+
+/**
+ * TTL for demo result caches. Deterministic demos reuse a result for ten
+ * minutes, then expire it. Creative demos do not cache at all.
+ */
+export const DEMO_RESULT_TTL_MS = 10 * 60 * 1000;
+
+/** Props every package demo accepts from the explorer tab strip. */
+export interface DemoIntentProps {
+  /** True once the user selected this package tab. */
+  intent?: boolean;
+}
 
 interface DownloadProgressEvent extends Event {
   readonly loaded: number;
@@ -23,26 +39,26 @@ interface CreateMonitor {
  * Wire a Built-in AI `monitor` callback to React state. Returns the
  * monitor function to pass into `createOptions.monitor`, plus the current
  * progress (a fraction from 0..1) or `null` when no download is in flight.
+ * Warm-model creations emit `downloadprogress` with loaded 0 and 1 only;
+ * those events are ignored so the indicator surfaces for real downloads.
  */
 export const useDownloadMonitor = () => {
   const [progress, setProgress] = useState<number | null>(null);
 
   const monitor = useCallback((m: CreateMonitor) => {
-    // Some implementations emit a single `downloadprogress` with loaded=1 on
-    // warm starts. Suppress that case so the notice only surfaces for a real
-    // download in progress.
-    let firstEvent = true;
     m.addEventListener("downloadprogress", (e) => {
-      if (firstEvent && e.loaded >= 1) {
-        firstEvent = false;
+      if (e.loaded <= 0) return;
+      if (e.loaded >= 1) {
+        // Settle to "complete" briefly, then clear; stay hidden when no
+        // fractional progress ever showed (warm start).
+        setProgress((current) => {
+          if (current === null) return null;
+          setTimeout(() => setProgress(null), 900);
+          return 1;
+        });
         return;
       }
-      firstEvent = false;
       setProgress(e.loaded);
-      if (e.loaded >= 1) {
-        // Settle to "complete" briefly, then clear.
-        setTimeout(() => setProgress(null), 600);
-      }
     });
   }, []);
 
@@ -79,22 +95,57 @@ export const WarnNotice = ({ message }: { message: string | null }) => {
   );
 };
 
-export const DownloadNotice = ({ progress }: { progress: number | null }) => {
+const DONUT_RADIUS = 5.5;
+const DONUT_CIRCUMFERENCE = 2 * Math.PI * DONUT_RADIUS;
+
+/**
+ * Minimal donut progress indicator for model downloads. Lives in the card
+ * header, so it never shifts the demo layout. A custom tooltip carries the
+ * detail on hover or focus.
+ */
+export const DownloadDonut = ({ progress }: { progress: number | null }) => {
   if (progress === null) return null;
   const pct = Math.round(progress * 100);
+  const filled = (
+    Math.min(Math.max(progress, 0), 1) * DONUT_CIRCUMFERENCE
+  ).toFixed(2);
   return (
-    <div className="flex flex-col gap-0 rounded-sm border border-hairline bg-surface px-3 py-[9px] font-mono text-[11.5px] text-fg-3">
-      <div className="mb-1.5 flex justify-between">
-        <span>Downloading on-device model…</span>
-        <span className="tabular-nums">{pct}%</span>
-      </div>
-      <div className="h-1 overflow-hidden rounded-sm bg-surface-3">
-        <div
-          className="h-full bg-accent transition-[width] duration-200 ease-out"
-          style={{ width: `${pct}%` }}
+    // The aria-label on the live region carries the detail for keyboard and
+    // screen-reader users; the tooltip is pointer-hover supplementary text.
+    <span className={demoTooltipWrap}>
+      <svg
+        width="14"
+        height="14"
+        viewBox="0 0 15 15"
+        role="status"
+        aria-label={`Downloading on-device model ${pct}%`}
+        className="shrink-0"
+      >
+        <circle
+          cx="7.5"
+          cy="7.5"
+          r={DONUT_RADIUS}
+          fill="none"
+          stroke="var(--color-hairline-2)"
+          strokeWidth="2.5"
         />
-      </div>
-    </div>
+        <circle
+          cx="7.5"
+          cy="7.5"
+          r={DONUT_RADIUS}
+          fill="none"
+          stroke="var(--color-accent)"
+          strokeWidth="2.5"
+          strokeLinecap="round"
+          strokeDasharray={`${filled} ${DONUT_CIRCUMFERENCE.toFixed(2)}`}
+          transform="rotate(-90 7.5 7.5)"
+          className="transition-[stroke-dasharray] duration-200 ease-out"
+        />
+      </svg>
+      <span className={demoTooltipBelow}>
+        Downloading on-device model {pct}%
+      </span>
+    </span>
   );
 };
 
@@ -132,8 +183,20 @@ export const useStreamStats = () => {
   const finish = (status = "done") => {
     setStats((s) => ({ ...s, status }));
   };
+  const reset = () => {
+    setStats({ chars: 0, ms: 0, tps: 0, status: "idle" });
+  };
 
-  return { stats, start, update, finish };
+  return { stats, start, update, finish, reset };
+};
+
+// Status colors follow DESIGN.md: warn for stale input, err for failures,
+// accent for live work, neutral foreground otherwise.
+const statusToneClass = (status: string): string => {
+  if (status === "running") return "text-accent";
+  if (status === "stale") return "text-warn";
+  if (status === "error" || status === "unavailable") return "text-err";
+  return "text-fg-2";
 };
 
 export const StatusBar = ({
@@ -147,11 +210,9 @@ export const StatusBar = ({
 }) => (
   <div className="flex flex-wrap items-center justify-between gap-x-3.5 gap-y-2 font-mono text-[11px] tracking-[0.04em] text-fg-4 max-[480px]:gap-x-3.5 max-[480px]:gap-y-2">
     <div className="flex items-center gap-3.5">
-      <span className="inline-flex items-center gap-1.5">
+      <span role="status" className="inline-flex items-center gap-1.5">
         <span className="text-fg-4">status</span>
-        <span
-          className={`tabular-nums text-fg-2 ${stats.status === "running" ? "text-accent" : ""}`}
-        >
+        <span className={`tabular-nums ${statusToneClass(stats.status)}`}>
           {stats.status}
         </span>
       </span>
@@ -236,6 +297,102 @@ export const MarkdownOutput = ({
         className="whitespace-normal"
       />
       {cursor}
+    </div>
+  );
+};
+
+/**
+ * Icon-only fresh-generation control shown once a run has completed.
+ * Skips the cache read and replaces the stored value.
+ */
+export const FreshRunButton = ({
+  show,
+  onClick,
+}: {
+  show: boolean;
+  onClick: () => void;
+}) => {
+  if (!show) return null;
+  return (
+    <span className={demoTooltipWrap}>
+      <button
+        type="button"
+        className={demoIconBtn}
+        onClick={onClick}
+        aria-label="Fresh run"
+      >
+        <svg
+          width="16"
+          height="16"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          aria-hidden="true"
+        >
+          <path d="M21 12a9 9 0 1 1-9-9c2.52 0 4.93 1 6.74 2.74L21 8" />
+          <path d="M21 3v5h-5" />
+        </svg>
+      </button>
+      <span className={demoTooltip}>
+        Skip the cached result and run the model again
+      </span>
+    </span>
+  );
+};
+
+/**
+ * Wraps a demo's primary Run control. While a cached result is on screen,
+ * hovering the control explains that the run serves from the cache.
+ */
+export const CacheAwareRun = ({
+  cached,
+  children,
+}: {
+  cached: boolean;
+  children: ReactNode;
+}) => {
+  if (!cached) return <>{children}</>;
+  return (
+    <span className={demoTooltipWrap}>
+      {children}
+      <span className={demoTooltip}>
+        Serves the cached result instantly. Use ⟳ for a fresh generation.
+      </span>
+    </span>
+  );
+};
+
+/**
+ * Shown when the input changed after a completed run. The previous result
+ * stays visible until a new run starts or the user dismisses it.
+ */
+export const StaleNotice = ({
+  show,
+  onDismiss,
+}: {
+  show: boolean;
+  onDismiss: () => void;
+}) => {
+  if (!show) return null;
+  return (
+    <div
+      role="status"
+      className="flex items-center justify-between gap-3 rounded-sm border border-[color-mix(in_oklch,var(--color-warn)_40%,var(--color-hairline))] bg-surface px-3 py-[9px] font-mono text-[11.5px] text-warn"
+    >
+      <span className="text-[11px]">
+        The input changed after this result. Run again to update it.
+      </span>
+      <button
+        type="button"
+        className="shrink-0 cursor-pointer rounded-sm border border-hairline-2 px-1.5 py-0.5 text-[12px] leading-none text-fg-2 hover:bg-surface-3"
+        onClick={onDismiss}
+        aria-label="Dismiss result"
+      >
+        ×
+      </button>
     </div>
   );
 };

--- a/apps/site/src/features/home/components/shared.tsx
+++ b/apps/site/src/features/home/components/shared.tsx
@@ -44,6 +44,9 @@ interface CreateMonitor {
  */
 export const useDownloadMonitor = () => {
   const [progress, setProgress] = useState<number | null>(null);
+  // Tracked outside React state so completion can schedule its clear timer
+  // without side effects inside a state updater.
+  const visibleRef = useRef(false);
 
   const monitor = useCallback((m: CreateMonitor) => {
     m.addEventListener("downloadprogress", (e) => {
@@ -51,18 +54,21 @@ export const useDownloadMonitor = () => {
       if (e.loaded >= 1) {
         // Settle to "complete" briefly, then clear; stay hidden when no
         // fractional progress ever showed (warm start).
-        setProgress((current) => {
-          if (current === null) return null;
-          setTimeout(() => setProgress(null), 900);
-          return 1;
-        });
+        if (!visibleRef.current) return;
+        visibleRef.current = false;
+        setProgress(1);
+        setTimeout(() => setProgress(null), 900);
         return;
       }
+      visibleRef.current = true;
       setProgress(e.loaded);
     });
   }, []);
 
-  const clear = useCallback(() => setProgress(null), []);
+  const clear = useCallback(() => {
+    visibleRef.current = false;
+    setProgress(null);
+  }, []);
 
   return { progress, monitor, clear };
 };

--- a/apps/site/src/shared/demoLifecycle.test.tsx
+++ b/apps/site/src/shared/demoLifecycle.test.tsx
@@ -1,0 +1,155 @@
+// @vitest-environment happy-dom
+
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  type CapabilityLease,
+  useCapabilityLease,
+  useDebouncedValue,
+  useDemoIntent,
+} from "./demoLifecycle.js";
+
+(
+  globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+let root: Root | undefined;
+let container: HTMLDivElement;
+
+beforeEach(() => {
+  container = document.createElement("div");
+  document.body.append(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root?.unmount());
+  root = undefined;
+  document.body.replaceChildren();
+});
+
+describe("useCapabilityLease", () => {
+  const makeLease = () => {
+    const release = vi.fn();
+    const create = vi.fn(
+      (): CapabilityLease => ({ ready: Promise.resolve(), release }),
+    );
+    return { create, release };
+  };
+
+  const LeaseProbe = ({
+    intent,
+    create,
+  }: {
+    intent: boolean;
+    create: () => CapabilityLease;
+  }) => {
+    useCapabilityLease(intent, create);
+    return null;
+  };
+
+  it("acquires only when intent is true and releases on unmount", () => {
+    const { create, release } = makeLease();
+    act(() => root?.render(<LeaseProbe intent={false} create={create} />));
+    expect(create).not.toHaveBeenCalled();
+
+    act(() => root?.render(<LeaseProbe intent={true} create={create} />));
+    expect(create).toHaveBeenCalledTimes(1);
+    expect(release).not.toHaveBeenCalled();
+
+    act(() => root?.unmount());
+    expect(release).toHaveBeenCalledTimes(1);
+  });
+
+  it("recycles the lease when the factory identity changes", () => {
+    const first = makeLease();
+    const second = makeLease();
+    act(() => root?.render(<LeaseProbe intent={true} create={first.create} />));
+    act(() =>
+      root?.render(<LeaseProbe intent={true} create={second.create} />),
+    );
+    expect(first.release).toHaveBeenCalledTimes(1);
+    expect(second.create).toHaveBeenCalledTimes(1);
+    expect(second.release).not.toHaveBeenCalled();
+  });
+
+  it("swallows ready rejections", async () => {
+    const release = vi.fn();
+    const create = (): CapabilityLease => ({
+      ready: Promise.reject(new Error("unavailable")),
+      release,
+    });
+    act(() => root?.render(<LeaseProbe intent={true} create={create} />));
+    // Flush microtasks; an unhandled rejection would fail the test run.
+    await act(async () => {});
+    act(() => root?.unmount());
+    expect(release).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("useDebouncedValue", () => {
+  const Probe = ({ value }: { value: string }) => {
+    const debounced = useDebouncedValue(value, 600);
+    return <output>{debounced}</output>;
+  };
+
+  it("holds the previous value until the delay elapses", () => {
+    vi.useFakeTimers();
+    try {
+      act(() => root?.render(<Probe value="first" />));
+      act(() => vi.runAllTimers());
+      expect(container.textContent).toBe("first");
+
+      act(() => root?.render(<Probe value="second" />));
+      expect(container.textContent).toBe("first");
+
+      act(() => vi.advanceTimersByTime(599));
+      expect(container.textContent).toBe("first");
+
+      act(() => vi.advanceTimersByTime(1));
+      expect(container.textContent).toBe("second");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("restarts the delay on every change", () => {
+    vi.useFakeTimers();
+    try {
+      act(() => root?.render(<Probe value="a" />));
+      act(() => vi.runAllTimers());
+      act(() => root?.render(<Probe value="ab" />));
+      act(() => vi.advanceTimersByTime(400));
+      act(() => root?.render(<Probe value="abc" />));
+      act(() => vi.advanceTimersByTime(400));
+      expect(container.textContent).toBe("a");
+      act(() => vi.advanceTimersByTime(200));
+      expect(container.textContent).toBe("abc");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});
+
+describe("useDemoIntent", () => {
+  const Probe = ({ external }: { external?: boolean }) => {
+    const { intent, interacted, markInteracted } = useDemoIntent(external);
+    return (
+      <button type="button" onClick={markInteracted}>
+        {intent ? "intent" : "no-intent"}:{interacted ? "touched" : "untouched"}
+      </button>
+    );
+  };
+
+  it("combines the external signal with direct interaction", () => {
+    act(() => root?.render(<Probe />));
+    expect(container.textContent).toBe("no-intent:untouched");
+
+    act(() => root?.render(<Probe external />));
+    expect(container.textContent).toBe("intent:untouched");
+
+    act(() => container.querySelector("button")?.click());
+    expect(container.textContent).toBe("intent:touched");
+  });
+});

--- a/apps/site/src/shared/demoLifecycle.ts
+++ b/apps/site/src/shared/demoLifecycle.ts
@@ -1,0 +1,57 @@
+import { useCallback, useEffect, useState } from "react";
+
+/** Shape shared by every `prepare*()` lease across the SDK packages. */
+export interface CapabilityLease {
+  ready: Promise<void>;
+  release(): void;
+}
+
+/**
+ * Track demo intent. `external` carries an upstream signal (for example an
+ * explicit package-tab selection); `markInteracted` records direct
+ * interaction inside the demo (focus or pointer). `intent` is true when
+ * either signal fired. `interacted` stays limited to direct interaction so
+ * demos can prepare on intent but only run after the user touches them.
+ */
+export const useDemoIntent = (external?: boolean) => {
+  const [interacted, setInteracted] = useState(false);
+  const markInteracted = useCallback(() => setInteracted(true), []);
+  return {
+    intent: Boolean(external) || interacted,
+    interacted,
+    markInteracted,
+  };
+};
+
+/**
+ * Hold a prepared-session lease while `intent` is true. Acquires through
+ * `createLease` on the first intent signal and releases on unmount or when
+ * `createLease` changes identity (new session options). Keep `createLease`
+ * stable with `useCallback` so option edits, not renders, recycle the lease.
+ * `ready` rejections are swallowed here because unavailability already
+ * surfaces through each demo's availability probe and run path.
+ */
+export const useCapabilityLease = (
+  intent: boolean,
+  createLease: () => CapabilityLease,
+): void => {
+  useEffect(() => {
+    if (!intent) return;
+    const lease = createLease();
+    lease.ready.catch(() => {});
+    return () => lease.release();
+  }, [intent, createLease]);
+};
+
+/**
+ * Return `value` after it has stayed unchanged for `delayMs`. Demos use this
+ * to run inference after a typing pause instead of on every keystroke.
+ */
+export const useDebouncedValue = <T>(value: T, delayMs: number): T => {
+  const [debounced, setDebounced] = useState(value);
+  useEffect(() => {
+    const timer = setTimeout(() => setDebounced(value), delayMs);
+    return () => clearTimeout(timer);
+  }, [value, delayMs]);
+  return debounced;
+};

--- a/apps/site/src/shared/ui.ts
+++ b/apps/site/src/shared/ui.ts
@@ -26,6 +26,22 @@ export const btnSmGhost =
 export const demoControls =
   "flex flex-wrap items-center gap-2 max-[640px]:gap-2.5";
 
+// Icon-sized demo action with a custom hover/focus tooltip, mirroring the
+// playground's group + absolute tooltip pattern. The tooltip anchors to the
+// trigger's left edge because demo cards clip overflow.
+export const demoTooltipWrap = "group/tip relative inline-flex items-center";
+
+export const demoTooltip =
+  "pointer-events-none invisible absolute bottom-[calc(100%+0.5rem)] left-0 z-50 whitespace-nowrap rounded-md bg-surface-3 px-2.5 py-1.5 font-mono text-[10px] text-fg-2 opacity-0 shadow-card transition-opacity group-hover/tip:visible group-hover/tip:opacity-100 group-focus-within/tip:visible group-focus-within/tip:opacity-100";
+
+// Variant for triggers in a card's top row: opens below and right-aligned so
+// the card's overflow clipping never cuts it.
+export const demoTooltipBelow =
+  "pointer-events-none invisible absolute top-[calc(100%+0.5rem)] right-0 z-50 whitespace-nowrap rounded-md bg-surface-3 px-2.5 py-1.5 font-mono text-[10px] text-fg-2 opacity-0 shadow-card transition-opacity group-hover/tip:visible group-hover/tip:opacity-100 group-focus-within/tip:visible group-focus-within/tip:opacity-100";
+
+export const demoIconBtn =
+  "inline-flex size-8 cursor-pointer items-center justify-center rounded-full bg-transparent text-fg-3 transition-colors hover:bg-surface-3 hover:text-fg focus-visible:bg-surface-3 focus-visible:text-fg focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50";
+
 export const chipRow = "flex flex-wrap items-center gap-1.5";
 
 export const chipRowInline =

--- a/apps/site/src/styles/home.css
+++ b/apps/site/src/styles/home.css
@@ -142,6 +142,16 @@
     }
   }
 
+  /* Feedback pulse when a demo run serves from the result cache. */
+  @keyframes demo-cache-flash {
+    from {
+      opacity: 0.25;
+    }
+    to {
+      opacity: 1;
+    }
+  }
+
   @keyframes playground-enter {
     from {
       opacity: 0;


### PR DESCRIPTION
Closes #154.

Aligns the homepage package demos and docs live demos with Chrome's built-in AI production guidance. Builds on the prepared-session leases (#149), TTL result caches (#152), and the secured model-output renderer (#151).

## Homepage demos

- Package-tab selection, focus, or direct interaction prepares only that capability through `prepare*()` leases. Hydration alone prepares nothing.
- The first matching Run reuses the prepared session without a duplicate native create.
- Tab changes and unmounts abort active work and release preparation leases.
- Every manual demo shows a visible Stop control while busy.
- Edited input keeps the previous result visible and marked stale until a new run starts or the user dismisses it.
- Summarizer, Translator, and Proofreader cache results in sessionStorage with a ten minute TTL and expose an icon-only fresh-generation control.
- Prompt, Writer, and Rewriter no longer show unreachable cache indicators.
- Model downloads render as a small header donut with a hover tooltip. The old inline bar shifted the layout mid-click and could swallow the first Run press.
- The Prompt-backed WebMCP router now supplies a `responseConstraint`, parses the constrained reply directly, validates the selected tool against the registered set, validates its arguments against the tool input schema, and keeps the keyword fallback.

## Docs demos

- No demo invokes inference per keystroke. Detector and Translator debounce typing (600 ms, documented on their pages). Summarizer, Writer, Rewriter, and Proofreader use explicit Run and Stop controls with committed input.
- Deterministic demos cache with the TTL policy and share the same fresh-run icon control.
- Model Markdown renders through the secured `ModelMarkdown` renderer.
- AI output stays separate from source input; nothing overwrites user content without an explicit action.
- A `DemoSlot` placeholder reserves each demo's measured footprint while its client-only island hydrates, so docs content below the demos never shifts.

## Site polish

- Docs demo cards and code blocks share one surface treatment: 12px radius from the shared token scale, no borders, and elevation for separation. Code blocks use the same 28px padding as the demo cards.
- Demo internals are borderless too; inputs keep a crisp focus ring, and every radius comes from the token scale.
- Demo action buttons use the primary filled treatment in both themes, and demo cards span the full content column instead of a fixed width.
- The scroll-spy minimap activates the last section from the viewport center and deselects everything when the footer takes over, in sync with the floating Back-to-top button.
- The Prompt and WebMCP package cards describe SDK behavior instead of React-specific details.

## Tests and verification

- New coverage: intent-driven preparation, hydration no-op, tab-switch lease release, unmount abort, Stop cancellation, stale marking, cache refresh, structured routing with refusal paths, debounce, and committed-input runs.
- The Playground is unchanged.
- All Copilot review comments are addressed: the download monitor no longer schedules a timer inside a state updater, and the fresh-nonce cache comments describe the new-key behavior accurately.
- `pnpm gate` passes. Behavior verified in Chrome against a production preview with native `create()` and `destroy()` instrumentation, including zero-shift hydration checks on the docs pages.