### PR TITLE
feat(site): normalize docs home and navigation chrome

### DIFF
--- a/apps/site/astro.config.mjs
+++ b/apps/site/astro.config.mjs
@@ -61,6 +61,10 @@ export default defineConfig({
         SocialIcons: "./src/features/docs/components/SocialIcons.astro",
         ThemeSelect: "./src/features/docs/components/ThemeToggle.astro",
         TableOfContents: "./src/features/docs/components/TableOfContents.astro",
+        MobileTableOfContents:
+          "./src/features/docs/components/MobileTableOfContents.astro",
+        MobileMenuFooter:
+          "./src/features/docs/components/MobileMenuFooter.astro",
       },
       favicon: "/favicon.svg",
       head: [

--- a/apps/site/astro.config.mjs
+++ b/apps/site/astro.config.mjs
@@ -60,6 +60,7 @@ export default defineConfig({
         SiteTitle: "./src/features/docs/components/SiteTitle.astro",
         SocialIcons: "./src/features/docs/components/SocialIcons.astro",
         ThemeSelect: "./src/features/docs/components/ThemeToggle.astro",
+        TableOfContents: "./src/features/docs/components/TableOfContents.astro",
       },
       favicon: "/favicon.svg",
       head: [
@@ -162,6 +163,7 @@ export default defineConfig({
         {
           label: "Start",
           items: [
+            { label: "Introduction", slug: "docs" },
             { label: "Why web-ai-sdk", slug: "docs/why-web-ai-sdk" },
             { label: "Browser support", slug: "docs/browser-support" },
             {

--- a/apps/site/src/content/docs/index.mdx
+++ b/apps/site/src/content/docs/index.mdx
@@ -1,35 +1,45 @@
 ---
-title: Documentation
-description: TypeScript lifecycle wrappers for browser AI APIs.
-template: splash
-hero:
-  title: web-ai-sdk
-  tagline: TypeScript lifecycle wrappers for browser AI APIs. No runtime dependencies.
-  actions:
-    - text: Browser support
-      link: /docs/browser-support/
-    - text: Prompt guide
-      link: /docs/guides/prompt/
-      variant: minimal
+title: Introduction
+description: TypeScript lifecycle wrappers for browser AI APIs. No runtime dependencies.
 ---
 
 import PackageIndex from "../../features/docs/components/PackageIndex.astro";
 
-## What it is
+`web-ai-sdk` provides one TypeScript package for each supported browser AI capability: Prompt, Writer, Rewriter, Proofreader, Translator, Summarizer, Language Detector, and WebMCP. The packages have no runtime dependencies.
 
-`web-ai-sdk` provides one TypeScript package for each supported browser capability. The packages have no runtime dependencies. See [Architecture](/docs/architecture/) for the package boundaries.
+The SDK does not replace the browser APIs. It manages session reuse, streaming, abort signals, cleanup, and unavailable states. It does not compose capabilities or walk the DOM — application code owns tasks such as article extraction and detect-then-summarize flows.
 
-The SDK does not replace the browser APIs. It manages session reuse, streaming, abort signals, cleanup, and unavailable states.
+## How to use these docs
 
-Before shipping a feature, use the [Production checklist](/docs/production-checklist/) to cover user intent, input selection, safe rendering, progress, reversible edits, and cache freshness.
+The sidebar on the left is organized into three sections:
 
-The SDK does not compose capabilities or walk the DOM. Application code owns tasks such as article extraction and detect-then-summarize flows.
+- **Start** — the concepts that apply to every package: [why the SDK exists](/docs/why-web-ai-sdk/), [which browsers support each API](/docs/browser-support/), the [production checklist](/docs/production-checklist/), and the [architecture](/docs/architecture/) behind the package boundaries.
+- **Guides** — one guide per capability, covering the vanilla API surface, streaming, and lifecycle patterns. Start with the guide for the capability you need; they do not depend on each other.
+- **React Hooks** — the `@web-ai-sdk/<pkg>/react` hooks that wrap each vanilla API for React applications.
 
-## One capability per package
+If you are new, read [Browser support](/docs/browser-support/) first to confirm the capability you want is available where you ship, then jump to that capability's guide.
 
-Only Prompt uses the general `LanguageModel` API. The other capabilities have different inputs and results. WebMCP exposes page tools instead of generating text.
+## Installation
 
-See [Why web-ai-sdk](/docs/why-web-ai-sdk/) for a detailed comparison.
+Install one package or the full set:
+
+```sh
+pnpm add @web-ai-sdk/prompt        # one block
+pnpm add @web-ai-sdk/all           # all eight blocks
+```
+
+Each package ships two entry points:
+
+- **Vanilla** (`@web-ai-sdk/<pkg>`): TypeScript and DOM APIs with no framework dependency.
+- **React** (`@web-ai-sdk/<pkg>/react`): hooks over the vanilla API. `react` is an optional peer dependency.
+
+The [meta-package guide](/docs/guides/meta-package/) documents subpath and namespaced imports for `@web-ai-sdk/all`.
+
+## Packages
+
+Each package owns one browser capability. Only Prompt uses the general `LanguageModel` API; the other capabilities have different inputs and results, and WebMCP exposes page tools instead of generating text. UI, polyfills, DOM traversal, and cross-capability workflows remain outside the core wrappers.
+
+<PackageIndex />
 
 ## Why use a wrapper?
 
@@ -40,28 +50,10 @@ You can use the browser APIs directly. The SDK handles lifecycle code that appli
 - delta and cumulative stream normalization;
 - `AbortSignal` wiring.
 
-[Architecture guide](/docs/architecture/)
+See [Why web-ai-sdk](/docs/why-web-ai-sdk/) for a detailed comparison and the [Architecture guide](/docs/architecture/) for how the packages are structured.
 
-## Packages
+## Next steps
 
-<PackageIndex />
-
-## Install
-
-Install one package or the full set:
-
-```sh
-pnpm add @web-ai-sdk/prompt        # one block
-pnpm add @web-ai-sdk/all           # all eight blocks
-```
-
-The [meta-package guide](/docs/guides/meta-package/) documents subpath and namespaced imports.
-
-Each package ships:
-
-- **Vanilla** (`@web-ai-sdk/<pkg>`): TypeScript and DOM APIs with no framework dependency.
-- **React** (`@web-ai-sdk/<pkg>/react`): hooks over the vanilla API. `react` is an optional peer dependency.
-
-## Package scope
-
-Each package owns one browser capability. UI, polyfills, DOM traversal, and cross-capability workflows remain outside the core wrappers.
+- [Browser support](/docs/browser-support/) — availability matrix per API and browser.
+- [Prompt guide](/docs/guides/prompt/) — the most general capability, a good first read.
+- [Production checklist](/docs/production-checklist/) — user intent, input selection, safe rendering, progress, reversible edits, and cache freshness before you ship.

--- a/apps/site/src/features/docs/components/MobileMenuFooter.astro
+++ b/apps/site/src/features/docs/components/MobileMenuFooter.astro
@@ -1,0 +1,6 @@
+---
+// Override of Starlight's `MobileMenuFooter`, intentionally empty: the docs
+// header keeps the Playground, docs, GitHub, and theme controls visible at
+// every viewport width, so repeating them at the bottom of the mobile menu
+// drawer only duplicated the row.
+---

--- a/apps/site/src/features/docs/components/MobileTableOfContents.astro
+++ b/apps/site/src/features/docs/components/MobileTableOfContents.astro
@@ -1,0 +1,166 @@
+---
+// Override of Starlight's `MobileTableOfContents`: same markup and element
+// name (so existing `mobile-starlight-toc` styling keeps applying), but the
+// active-link tracking comes from the shared proportional scroll spy in
+// `toc-scroll-spy.ts` instead of Starlight's IntersectionObserver, which never
+// activates short sections near the end of a page.
+import { Icon } from "@astrojs/starlight/components";
+import TocList from "./TocList.astro";
+
+const { toc } = Astro.locals.starlightRoute;
+---
+
+{
+  toc && (
+    <mobile-starlight-toc>
+      <nav aria-labelledby="starlight__on-this-page--mobile">
+        <details id="starlight__mobile-toc">
+          <summary id="starlight__on-this-page--mobile" class="sl-flex">
+            <span class="progress-ring" aria-hidden="true" />
+            <span class="toggle sl-flex">
+              {Astro.locals.t("tableOfContents.onThisPage")}
+              <Icon name={"right-caret"} class="caret" size="1rem" />
+            </span>
+            <span class="display-current" />
+          </summary>
+          <div class="dropdown">
+            <TocList toc={toc.items} isMobile />
+          </div>
+        </details>
+      </nav>
+    </mobile-starlight-toc>
+  )
+}
+
+<style>
+  @layer starlight.core {
+    nav {
+      position: fixed;
+      z-index: var(--sl-z-index-toc);
+      top: calc(var(--sl-nav-height) - 1px);
+      inset-inline: 0;
+      background-color: var(--sl-color-bg-nav);
+    }
+    @media (min-width: 50rem) {
+      nav {
+        inset-inline-start: var(--sl-content-inline-start, 0);
+      }
+    }
+
+    summary {
+      gap: 0.5rem;
+      align-items: center;
+      height: var(--sl-mobile-toc-height);
+      border-bottom: 1px solid var(--sl-color-hairline-shade);
+      padding: 0.5rem 1rem;
+      font-size: var(--sl-text-xs);
+      outline-offset: var(--sl-outline-offset-inside);
+    }
+    summary::marker,
+    summary::-webkit-details-marker {
+      display: none;
+    }
+
+    .toggle {
+      flex-shrink: 0;
+      gap: 1rem;
+      align-items: center;
+      justify-content: space-between;
+      border: 1px solid var(--sl-color-gray-5);
+      border-radius: 0.5rem;
+      padding-block: 0.5rem;
+      padding-inline-start: 0.75rem;
+      padding-inline-end: 0.5rem;
+      line-height: 1;
+      background-color: var(--sl-color-black);
+      user-select: none;
+      cursor: pointer;
+    }
+    details[open] .toggle {
+      color: var(--sl-color-white);
+      border-color: var(--sl-color-accent);
+    }
+    details .toggle:hover {
+      color: var(--sl-color-white);
+      border-color: var(--sl-color-gray-2);
+    }
+
+    :global([dir="rtl"]) .caret {
+      transform: rotateZ(180deg);
+    }
+    details[open] .caret {
+      transform: rotateZ(90deg);
+    }
+
+    .display-current {
+      white-space: nowrap;
+      text-overflow: ellipsis;
+      overflow: hidden;
+      color: var(--sl-color-white);
+    }
+
+    .dropdown {
+      --border-top: 1px;
+      margin-top: calc(-1 * var(--border-top));
+      border: var(--border-top) solid var(--sl-color-gray-6);
+      border-top-color: var(--sl-color-hairline-shade);
+      padding: 0.75rem 1rem;
+      max-height: calc(85vh - var(--sl-nav-height) - var(--sl-mobile-toc-height));
+      overflow-y: auto;
+      background-color: var(--sl-color-black);
+      box-shadow: var(--sl-shadow-md);
+      overscroll-behavior: contain;
+    }
+  }
+</style>
+
+<script>
+  import { WebAiSdkToc } from "./toc-scroll-spy";
+
+  class MobileWebAiSdkToc extends WebAiSdkToc {
+    protected override set current(link: HTMLAnchorElement) {
+      super.current = link;
+      const display = this.querySelector(".display-current") as HTMLSpanElement;
+      if (display) display.textContent = link.textContent;
+      // Mark everything above the current entry so the dropdown list can
+      // paint its progress rail.
+      const links = [...this.querySelectorAll("a")];
+      const index = links.indexOf(link);
+      links.forEach((a, i) => {
+        a.toggleAttribute("data-passed", i < index);
+      });
+    }
+
+    constructor() {
+      super();
+      const details = this.querySelector("details");
+      if (!details) return;
+      const closeToC = () => {
+        details.open = false;
+      };
+      // Close the table of contents whenever a link is clicked.
+      details.querySelectorAll("a").forEach((a) => {
+        a.addEventListener("click", closeToC);
+      });
+      // Close the table of contents when a user clicks outside of it.
+      window.addEventListener("click", (e) => {
+        if (!details.contains(e.target as Node)) closeToC();
+      });
+      // Or when they press the escape key.
+      window.addEventListener("keydown", (e) => {
+        if (e.key === "Escape" && details.open) {
+          const hasFocus = details.contains(document.activeElement);
+          closeToC();
+          if (hasFocus) {
+            const summary = details.querySelector("summary");
+            if (summary) summary.focus();
+          }
+        }
+      });
+    }
+  }
+
+  if (!customElements.get("mobile-starlight-toc")) {
+    customElements.define("mobile-starlight-toc", MobileWebAiSdkToc);
+  }
+</script>

--- a/apps/site/src/features/docs/components/TableOfContents.astro
+++ b/apps/site/src/features/docs/components/TableOfContents.astro
@@ -1,0 +1,23 @@
+---
+// Override of Starlight's desktop `TableOfContents`: same markup, but the
+// active-link highlighting comes from the proportional scroll spy in
+// `toc-scroll-spy.ts` instead of Starlight's IntersectionObserver, which never
+// activates short sections near the end of a page. The mobile TOC keeps
+// Starlight's default component.
+import TocList from './TocList.astro';
+
+const { toc } = Astro.locals.starlightRoute;
+---
+
+{
+	toc && (
+		<waisdk-toc>
+			<nav aria-labelledby="starlight__on-this-page">
+				<h2 id="starlight__on-this-page">{Astro.locals.t('tableOfContents.onThisPage')}</h2>
+				<TocList toc={toc.items} />
+			</nav>
+		</waisdk-toc>
+	)
+}
+
+<script src="./toc-scroll-spy.ts"></script>

--- a/apps/site/src/features/docs/components/TableOfContents.astro
+++ b/apps/site/src/features/docs/components/TableOfContents.astro
@@ -2,22 +2,21 @@
 // Override of Starlight's desktop `TableOfContents`: same markup, but the
 // active-link highlighting comes from the proportional scroll spy in
 // `toc-scroll-spy.ts` instead of Starlight's IntersectionObserver, which never
-// activates short sections near the end of a page. The mobile TOC keeps
-// Starlight's default component.
-import TocList from './TocList.astro';
+// activates short sections near the end of a page.
+import TocList from "./TocList.astro";
 
 const { toc } = Astro.locals.starlightRoute;
 ---
 
 {
-	toc && (
-		<waisdk-toc>
-			<nav aria-labelledby="starlight__on-this-page">
-				<h2 id="starlight__on-this-page">{Astro.locals.t('tableOfContents.onThisPage')}</h2>
-				<TocList toc={toc.items} />
-			</nav>
-		</waisdk-toc>
-	)
+  toc && (
+    <waisdk-toc>
+      <nav aria-labelledby="starlight__on-this-page">
+        <h2 id="starlight__on-this-page">{Astro.locals.t("tableOfContents.onThisPage")}</h2>
+        <TocList toc={toc.items} />
+      </nav>
+    </waisdk-toc>
+  )
 }
 
 <script src="./toc-scroll-spy.ts"></script>

--- a/apps/site/src/features/docs/components/TocList.astro
+++ b/apps/site/src/features/docs/components/TocList.astro
@@ -1,51 +1,77 @@
 ---
-// Copy of Starlight's internal `TableOfContentsList` markup and styles
-// (desktop variant only), rendered by the `TableOfContents` override so the
-// custom scroll spy in `toc-scroll-spy.ts` can own the highlighting.
+// Copy of Starlight's internal `TableOfContentsList` markup and styles,
+// rendered by the `TableOfContents` and `MobileTableOfContents` overrides so
+// the custom scroll spy in `toc-scroll-spy.ts` can own the highlighting.
 interface TocItem {
-	depth: number;
-	slug: string;
-	text: string;
-	children: TocItem[];
+  depth: number;
+  slug: string;
+  text: string;
+  children: TocItem[];
 }
 
 interface Props {
-	toc: TocItem[];
-	depth?: number;
+  toc: TocItem[];
+  depth?: number;
+  isMobile?: boolean;
 }
 
-const { toc, depth = 0 } = Astro.props;
+const { toc, isMobile = false, depth = 0 } = Astro.props;
 ---
 
-<ul>
-	{
-		toc.map((heading) => (
-			<li>
-				<a href={'#' + heading.slug}>
-					<span>{heading.text}</span>
-				</a>
-				{heading.children.length > 0 && <Astro.self toc={heading.children} depth={depth + 1} />}
-			</li>
-		))
-	}
+<ul class:list={{ isMobile }}>
+  {
+    toc.map((heading) => (
+      <li>
+        <a href={"#" + heading.slug}>
+          <span>{heading.text}</span>
+        </a>
+        {heading.children.length > 0 && (
+          <Astro.self toc={heading.children} depth={depth + 1} isMobile={isMobile} />
+        )}
+      </li>
+    ))
+  }
 </ul>
 
 <style define:vars={{ depth }}>
-	@layer starlight.core {
-		ul {
-			padding: 0;
-			list-style: none;
-		}
-		a {
-			--pad-inline: 0.5rem;
-			display: block;
-			border-radius: 0.25rem;
-			padding-block: 0.25rem;
-			padding-inline: calc(1rem * var(--depth) + var(--pad-inline)) var(--pad-inline);
-			line-height: 1.25;
-		}
-		a[aria-current='true'] {
-			color: var(--sl-color-text-accent);
-		}
-	}
+  @layer starlight.core {
+    ul {
+      padding: 0;
+      list-style: none;
+    }
+    a {
+      --pad-inline: 0.5rem;
+      display: block;
+      border-radius: 0.25rem;
+      padding-block: 0.25rem;
+      padding-inline: calc(1rem * var(--depth) + var(--pad-inline)) var(--pad-inline);
+      line-height: 1.25;
+    }
+    a[aria-current="true"] {
+      color: var(--sl-color-text-accent);
+    }
+    /* Dropdown list rows carry a per-row segment of the progress rail on
+       their left edge: rows above the current one (`data-passed`, set by the
+       scroll spy) and the current row paint it in the accent color, like a
+       reading-progress track. */
+    .isMobile a {
+      --pad-inline: 1rem;
+      display: block;
+      border-inline-start: 2px solid var(--sl-color-gray-6);
+      border-radius: 0;
+      padding-block: 0.5rem;
+      color: var(--sl-color-gray-3);
+      font-size: var(--sl-text-sm);
+      text-decoration: none;
+      outline-offset: var(--sl-outline-offset-inside);
+    }
+    .isMobile a[data-passed],
+    .isMobile a[aria-current="true"],
+    .isMobile a[aria-current="true"]:hover,
+    .isMobile a[aria-current="true"]:focus {
+      color: var(--sl-color-text-accent);
+      border-inline-start-color: var(--sl-color-text-accent);
+      background-color: unset;
+    }
+  }
 </style>

--- a/apps/site/src/features/docs/components/TocList.astro
+++ b/apps/site/src/features/docs/components/TocList.astro
@@ -1,0 +1,51 @@
+---
+// Copy of Starlight's internal `TableOfContentsList` markup and styles
+// (desktop variant only), rendered by the `TableOfContents` override so the
+// custom scroll spy in `toc-scroll-spy.ts` can own the highlighting.
+interface TocItem {
+	depth: number;
+	slug: string;
+	text: string;
+	children: TocItem[];
+}
+
+interface Props {
+	toc: TocItem[];
+	depth?: number;
+}
+
+const { toc, depth = 0 } = Astro.props;
+---
+
+<ul>
+	{
+		toc.map((heading) => (
+			<li>
+				<a href={'#' + heading.slug}>
+					<span>{heading.text}</span>
+				</a>
+				{heading.children.length > 0 && <Astro.self toc={heading.children} depth={depth + 1} />}
+			</li>
+		))
+	}
+</ul>
+
+<style define:vars={{ depth }}>
+	@layer starlight.core {
+		ul {
+			padding: 0;
+			list-style: none;
+		}
+		a {
+			--pad-inline: 0.5rem;
+			display: block;
+			border-radius: 0.25rem;
+			padding-block: 0.25rem;
+			padding-inline: calc(1rem * var(--depth) + var(--pad-inline)) var(--pad-inline);
+			line-height: 1.25;
+		}
+		a[aria-current='true'] {
+			color: var(--sl-color-text-accent);
+		}
+	}
+</style>

--- a/apps/site/src/features/docs/components/toc-scroll-spy.ts
+++ b/apps/site/src/features/docs/components/toc-scroll-spy.ts
@@ -1,6 +1,7 @@
 /**
- * Replacement for Starlight's IntersectionObserver-based TOC highlighting on
- * the desktop right sidebar.
+ * Replacement for Starlight's IntersectionObserver-based TOC highlighting,
+ * shared by the desktop sidebar (`waisdk-toc`) and the mobile dropdown
+ * (`mobile-starlight-toc`, subclassed in `MobileTableOfContents.astro`).
  *
  * Starlight marks a heading as current only while it crosses a ~53px band just
  * below the header, so short sections near the end of a page never activate:
@@ -9,19 +10,17 @@
  * just below the header at the top of the page and sweeps down to the bottom
  * edge of the viewport as scroll progress approaches 100% — so the last entry
  * becomes current exactly when the page bottom is reached.
- *
- * The element name is intentionally not `starlight-toc`: Starlight's mobile
- * TOC (left untouched) still registers that name on every page.
  */
-class WebAiSdkToc extends HTMLElement {
+export class WebAiSdkToc extends HTMLElement {
   private _current = this.querySelector<HTMLAnchorElement>(
     'a[aria-current="true"]',
   );
   private links: HTMLAnchorElement[] = [];
   private headings: (HTMLElement | null)[] = [];
   private frame = 0;
+  private controller = new AbortController();
 
-  private set current(link: HTMLAnchorElement) {
+  protected set current(link: HTMLAnchorElement) {
     if (link === this._current) return;
     if (this._current) this._current.removeAttribute("aria-current");
     link.setAttribute("aria-current", "true");
@@ -48,19 +47,31 @@ class WebAiSdkToc extends HTMLElement {
         this.update();
       });
     };
-    window.addEventListener("scroll", schedule, { passive: true });
-    window.addEventListener("resize", schedule);
+    const { signal } = this.controller;
+    window.addEventListener("scroll", schedule, { passive: true, signal });
+    window.addEventListener("resize", schedule, { signal });
     this.update();
   };
+
+  disconnectedCallback(): void {
+    this.controller.abort();
+    cancelAnimationFrame(this.frame);
+    this.frame = 0;
+  }
 
   private update = (): void => {
     if (!this.links.length) return;
     const doc = document.documentElement;
     const maxScroll = doc.scrollHeight - doc.clientHeight;
     const progress = maxScroll > 0 ? Math.min(doc.scrollTop / maxScroll, 1) : 0;
+    // Expose overall page progress for the dropdown bar's progress ring.
+    this.style.setProperty("--waisdk-toc-progress", String(progress));
     const navBarHeight =
       document.querySelector("header")?.getBoundingClientRect().height || 0;
-    const offsetTop = navBarHeight + 32;
+    // `<summary>` only exists in the mobile dropdown variant; 0 on desktop.
+    const barHeight =
+      this.querySelector("summary")?.getBoundingClientRect().height || 0;
+    const offsetTop = navBarHeight + barHeight + 32;
     const line = offsetTop + progress * (doc.clientHeight - offsetTop);
     let current = this.links[0];
     for (const [i, link] of this.links.entries()) {
@@ -73,4 +84,6 @@ class WebAiSdkToc extends HTMLElement {
   };
 }
 
-customElements.define("waisdk-toc", WebAiSdkToc);
+if (!customElements.get("waisdk-toc")) {
+  customElements.define("waisdk-toc", WebAiSdkToc);
+}

--- a/apps/site/src/features/docs/components/toc-scroll-spy.ts
+++ b/apps/site/src/features/docs/components/toc-scroll-spy.ts
@@ -1,0 +1,76 @@
+/**
+ * Replacement for Starlight's IntersectionObserver-based TOC highlighting on
+ * the desktop right sidebar.
+ *
+ * Starlight marks a heading as current only while it crosses a ~53px band just
+ * below the header, so short sections near the end of a page never activate:
+ * their headings sit below the band even when the page is scrolled to the
+ * bottom. This spy uses a proportional "reading line" instead — the line sits
+ * just below the header at the top of the page and sweeps down to the bottom
+ * edge of the viewport as scroll progress approaches 100% — so the last entry
+ * becomes current exactly when the page bottom is reached.
+ *
+ * The element name is intentionally not `starlight-toc`: Starlight's mobile
+ * TOC (left untouched) still registers that name on every page.
+ */
+class WebAiSdkToc extends HTMLElement {
+  private _current = this.querySelector<HTMLAnchorElement>(
+    'a[aria-current="true"]',
+  );
+  private links: HTMLAnchorElement[] = [];
+  private headings: (HTMLElement | null)[] = [];
+  private frame = 0;
+
+  private set current(link: HTMLAnchorElement) {
+    if (link === this._current) return;
+    if (this._current) this._current.removeAttribute("aria-current");
+    link.setAttribute("aria-current", "true");
+    this._current = link;
+  }
+
+  constructor() {
+    super();
+    const onIdle =
+      window.requestIdleCallback ||
+      ((cb: IdleRequestCallback) => setTimeout(cb, 1));
+    onIdle(() => this.init());
+  }
+
+  private init = (): void => {
+    this.links = [...this.querySelectorAll("a")];
+    this.headings = this.links.map((link) =>
+      document.getElementById(decodeURIComponent(link.hash.slice(1))),
+    );
+    const schedule = () => {
+      if (this.frame) return;
+      this.frame = requestAnimationFrame(() => {
+        this.frame = 0;
+        this.update();
+      });
+    };
+    window.addEventListener("scroll", schedule, { passive: true });
+    window.addEventListener("resize", schedule);
+    this.update();
+  };
+
+  private update = (): void => {
+    if (!this.links.length) return;
+    const doc = document.documentElement;
+    const maxScroll = doc.scrollHeight - doc.clientHeight;
+    const progress = maxScroll > 0 ? Math.min(doc.scrollTop / maxScroll, 1) : 0;
+    const navBarHeight =
+      document.querySelector("header")?.getBoundingClientRect().height || 0;
+    const offsetTop = navBarHeight + 32;
+    const line = offsetTop + progress * (doc.clientHeight - offsetTop);
+    let current = this.links[0];
+    for (const [i, link] of this.links.entries()) {
+      const heading = this.headings[i];
+      if (!heading) continue;
+      if (heading.getBoundingClientRect().top > line) break;
+      current = link;
+    }
+    if (current) this.current = current;
+  };
+}
+
+customElements.define("waisdk-toc", WebAiSdkToc);

--- a/apps/site/src/features/docs/styles/web-ai-sdk.css
+++ b/apps/site/src/features/docs/styles/web-ai-sdk.css
@@ -358,31 +358,70 @@
   outline-offset: 2px;
 }
 
-/* Keep the mobile table of contents compact and give its two labels a clear
-   hierarchy: the toggle is a control; the adjacent text is page context. */
-@media (max-width: 49.999rem) {
-  mobile-starlight-toc summary {
-    gap: 0.75rem;
-    height: 2.75rem;
-    padding: 0.375rem 1rem;
-    font-size: 0.75rem;
-  }
+/* Slim reader-bar treatment for the dropdown table of contents (any width
+   below the 72rem desktop TOC breakpoint): the header's own hairline
+   separates it on top, the current section reads as the label on the left,
+   and the caret sits alone at the far end as the affordance. */
 
-  mobile-starlight-toc .toggle {
-    gap: 0.5rem;
-    padding: 0.4375rem 0.5rem 0.4375rem 0.625rem;
-    border-color: var(--sl-color-hairline);
-    border-radius: 0.375rem;
-    font-family: var(--sl-font-mono);
-    font-size: 0.75rem;
-    letter-spacing: -0.01em;
+/* The docs header is slimmer than Starlight's default at this range
+   (3.5rem + 1px vs the global 4rem --sl-nav-height), so re-anchor the fixed
+   bar to the real header height or a strip of content shows in between. */
+@media (min-width: 50rem) {
+  mobile-starlight-toc nav {
+    top: 3.5rem;
   }
+}
 
-  mobile-starlight-toc .display-current {
-    color: var(--sl-color-gray-3);
-    font-size: 0.75rem;
-    line-height: 1.4;
-  }
+mobile-starlight-toc summary {
+  justify-content: space-between;
+  gap: 0.75rem;
+  height: 2.75rem;
+  padding: 0.375rem 1rem;
+  font-size: 0.75rem;
+}
+
+/* The toggle keeps its hit target and caret but drops the chip frame and
+   hides its "On this page" text (font-size: 0 keeps it readable to screen
+   readers); the section name carries the meaning. The caret is sized in
+   rem, so it survives the zeroed font size. */
+mobile-starlight-toc .toggle {
+  order: 2;
+  border: 0;
+  padding: 0;
+  background: transparent;
+  font-size: 0;
+}
+
+mobile-starlight-toc .display-current {
+  order: 1;
+  flex: 1;
+  color: var(--sl-color-white);
+  font-size: 0.75rem;
+  line-height: 1.4;
+}
+
+/* Scroll-progress ring ahead of the section label. The spy writes the page
+   progress (0–1) to `--waisdk-toc-progress` on the host element; the ring is
+   a conic sweep hollowed into a donut by the radial mask. */
+mobile-starlight-toc .progress-ring {
+  width: 1rem;
+  height: 1rem;
+  border-radius: 50%;
+  flex-shrink: 0;
+  background: conic-gradient(
+    var(--sl-color-text-accent) calc(var(--waisdk-toc-progress, 0) * 1turn),
+    var(--sl-color-gray-5) 0
+  );
+  -webkit-mask: radial-gradient(
+    farthest-side,
+    transparent calc(100% - 2.5px),
+    #000 calc(100% - 2px)
+  );
+  mask: radial-gradient(
+    farthest-side,
+    transparent calc(100% - 2.5px),
+    #000 calc(100% - 2px)
+  );
 }
 
 @keyframes docs-caret-blink {

--- a/apps/site/src/features/docs/styles/web-ai-sdk.css
+++ b/apps/site/src/features/docs/styles/web-ai-sdk.css
@@ -153,12 +153,12 @@
   text-decoration-color: currentColor;
 }
 
-/* Minor tightening: monospaced inline code with hairline border so it
-   reads as a chip, not just colored text. Matches the site demos. */
+/* Minor tightening: monospaced inline code as a borderless chip — its
+   background alone carries the shape, on the shared radius scale. */
 .sl-markdown-content :not(pre) > code {
-  border: 1px solid var(--sl-color-hairline);
+  border: 0;
   padding: 0.05rem 0.4rem;
-  border-radius: 4px;
+  border-radius: var(--radius-md);
   font-size: 0.85em;
 }
 
@@ -175,6 +175,28 @@
 .sidebar-pane,
 .right-sidebar {
   border: 0;
+}
+
+/* Center the docs shell. Starlight pins the fixed left sidebar to the viewport
+   edge and centers only the content column in the leftover space, so on wide
+   screens a growing gap opens between the sidebar and the content while the
+   right TOC hugs it. Cap the shell and shift the fixed sidebar and the main
+   frame together so both sidenavs stay tight to the content. The header
+   container below shares the same cap. */
+:root {
+  --docs-shell-max: 87.5rem;
+  --docs-shell-offset: max(0rem, calc((100vw - var(--docs-shell-max)) / 2));
+}
+@media (min-width: 50rem) {
+  .sidebar-pane {
+    inset-inline-start: var(--docs-shell-offset);
+  }
+  .main-frame {
+    padding-inline-start: calc(
+      var(--sl-content-inline-start, 0rem) + var(--docs-shell-offset)
+    );
+    padding-inline-end: var(--docs-shell-offset);
+  }
 }
 
 .page > .header {
@@ -198,7 +220,7 @@
 
   .page > .header > .header {
     grid-template-columns: minmax(0, 1fr) minmax(0, 27.5rem) minmax(0, 1fr);
-    max-width: 1180px;
+    max-width: var(--docs-shell-max);
     margin-inline: auto;
     padding-inline: 1.75rem;
     gap: 1rem;
@@ -502,8 +524,9 @@
   font-size: 0.75em;
   font-weight: 500;
   vertical-align: baseline;
-  border: 1px solid var(--sl-color-hairline);
-  border-radius: 4px;
+  border: 0;
+  border-radius: var(--radius-md);
+  background: color-mix(in oklch, var(--sl-color-text-accent) 6%, transparent);
   color: var(--sl-color-text-accent);
   white-space: nowrap;
 }
@@ -533,7 +556,7 @@
   width: 100%;
   margin: 0.5rem 0 1.25rem;
   border: 1px solid var(--sl-color-hairline);
-  border-radius: 8px;
+  border-radius: var(--radius-md);
   overflow: hidden;
   border-collapse: collapse;
 }
@@ -576,7 +599,7 @@
    identifier chip in cell 1. Same shape, different mood. Long union
    types (e.g. `"tldr" | "key-points" | "teaser" | "headline"`) are
    allowed to wrap at the spaces between `|` separators so the chip
-   never overflows the card on narrow viewports — the border wraps with
+   never overflows the card on narrow viewports — the chip wraps with
    the content. */
 .sl-markdown-content .options-table tr td:nth-child(2) code {
   display: inline-block;
@@ -584,11 +607,6 @@
   white-space: normal;
   word-break: break-word;
   color: var(--sl-color-text-accent);
-  border-color: color-mix(
-    in oklch,
-    var(--sl-color-text-accent) 35%,
-    var(--sl-color-hairline)
-  );
   background: color-mix(
     in oklch,
     var(--sl-color-text-accent) 6%,
@@ -647,10 +665,13 @@ footer:has(> .pagination-links) {
 }
 
 /* Copy button on code blocks: ship a sensible size and don't dominate the
-   block on mobile. Starlight's default is too large at narrow viewports. */
+   block on mobile. Starlight's default is too large at narrow viewports.
+   Radius matches the code-block frame (`--ec-brdRad`); the button's inner
+   layers inherit it. */
 .expressive-code .copy button {
   width: 1.75rem;
   height: 1.75rem;
+  border-radius: var(--radius-md);
 }
 @media (max-width: 600px) {
   .expressive-code .copy button {

--- a/apps/site/tsconfig.json
+++ b/apps/site/tsconfig.json
@@ -6,7 +6,7 @@
     "noEmit": true,
     "allowImportingTsExtensions": true,
     "lib": ["DOM", "DOM.Iterable", "ESNext"],
-    "types": ["astro/client"]
+    "types": ["astro/client", "@astrojs/starlight/locals"]
   },
   "include": [".astro/types.d.ts", "astro.config.mjs", "src"]
 }


### PR DESCRIPTION
## Summary

- **Docs home as a regular page** — `/docs/` drops the `splash` hero template and becomes a standard *Introduction* doc page (sidebar, on-this-page TOC, pagination), Next.js-docs style. It is now the first entry in the **Start** sidebar group, so Starlight emits "Next → Why web-ai-sdk" pagination from it. The marketing landing at `/` already covers the hero role.
- **TOC scroll spy** — Starlight's IntersectionObserver only marks a heading current while it crosses a ~53px band under the header, so short trailing sections never highlighted at page bottom. The desktop TOC is now overridden (via Starlight's `components` mechanism) with a proportional reading line that sweeps from the header to the viewport bottom as scroll progress approaches 100%, so the last entry activates exactly at the bottom. The mobile dropdown keeps Starlight's default to minimize forked code.
- **Centered docs shell** — Starlight pins the fixed left sidebar to the viewport edge and centers only the content in the leftover space, opening a growing gap on wide screens. The shell is now capped at `--docs-shell-max` (87.5rem) and the sidebar, main frame, and header container shift together, so both sidenavs hug the content column. No change below 1400px.
- **Radius + chip normalization** — code-block copy buttons, options-table cards, inline code chips, and the `required`/type markers all use `var(--radius-md)` to match code-block frames; chips drop their hairline borders and lean on their backgrounds (the required marker gains the type chip's 6% accent tint).
- **Types** — `@astrojs/starlight/locals` added to the site tsconfig so component overrides using `Astro.locals.starlightRoute` typecheck.

## Test plan

- `pnpm build:site` (35 pages), `pnpm docs:check`, `astro check`, and `biome check` all pass.
- Verified in a production preview (`astro preview`): sidebar shows Introduction highlighted on `/docs/`, pagination renders, no console errors; at 1800px the sidebar starts at exactly \((1800px − 1400px) / 2 = 200px\) with symmetric margins; chips report `border: 0`, `radius: 12px` via computed styles; TOC highlight tracks real scrolling.
- Worth a manual pass: scroll a long guide (e.g. `/docs/guides/prompt/`) to the bottom and confirm the last TOC entry highlights; check chip look in light theme.