### PR TITLE
feat(site): unify nav chrome and add docs page actions

### DIFF
--- a/apps/site/astro.config.mjs
+++ b/apps/site/astro.config.mjs
@@ -56,7 +56,9 @@ export default defineConfig({
         "web-ai-sdk is a TypeScript SDK for the Web AI surface: Prompt, Writer, Rewriter, Proofreader, Translator, Summarizer, Language Detector, and WebMCP. Composable, zero runtime deps.",
       disable404Route: true,
       components: {
+        EditLink: "./src/features/docs/components/EditLink.astro",
         Head: "./src/features/docs/components/Head.astro",
+        Header: "./src/features/docs/components/Header.astro",
         SiteTitle: "./src/features/docs/components/SiteTitle.astro",
         SocialIcons: "./src/features/docs/components/SocialIcons.astro",
         ThemeSelect: "./src/features/docs/components/ThemeToggle.astro",

--- a/apps/site/src/features/docs/components/EditLink.astro
+++ b/apps/site/src/features/docs/components/EditLink.astro
@@ -1,0 +1,4 @@
+---
+// Intentionally empty: the "Edit page" link renders in the right sidebar's
+// page actions (TableOfContents.astro) instead of Starlight's footer.
+---

--- a/apps/site/src/features/docs/components/Head.astro
+++ b/apps/site/src/features/docs/components/Head.astro
@@ -59,4 +59,6 @@ const ld = {
 {data && <script is:inline type="application/ld+json" set:html={JSON.stringify(ld)} />}
 <script>
   import "../scripts/table-scroll.js";
+  import "../scripts/type-union-pills.js";
+  import "../scripts/inline-code-copy.js";
 </script>

--- a/apps/site/src/features/docs/components/Header.astro
+++ b/apps/site/src/features/docs/components/Header.astro
@@ -1,0 +1,52 @@
+---
+// Custom Starlight Header: the search lives inside the right action cluster
+// (theme toggle → search → Playground → Docs → GitHub) instead of Starlight's
+// centered middle column. Class names (.title-wrapper, .right-group,
+// .social-icons) mirror Starlight's defaults so the shared header CSS in
+// web-ai-sdk.css and the mobile rules in SocialIcons.astro keep applying.
+import Search from "@astrojs/starlight/components/Search.astro";
+import SiteTitle from "./SiteTitle.astro";
+import SocialIcons from "./SocialIcons.astro";
+import ThemeToggle from "./ThemeToggle.astro";
+---
+
+<div class="header sl-flex">
+  <div class="title-wrapper sl-flex">
+    <SiteTitle />
+  </div>
+  <div class="sl-hidden md:sl-flex print:hidden right-group">
+    <ThemeToggle />
+    <Search />
+    <div class="sl-flex social-icons">
+      <SocialIcons />
+    </div>
+  </div>
+</div>
+
+<style>
+  .header {
+    gap: var(--sl-nav-gap);
+    justify-content: space-between;
+    align-items: center;
+    height: 100%;
+  }
+
+  .title-wrapper {
+    /* Prevent long titles overflowing and covering the controls on narrow
+       viewports, while leaving room for the focus ring around the link. */
+    overflow: clip;
+    padding: 0.25rem;
+    margin: -0.25rem;
+    min-width: 0;
+  }
+
+  /* One uniform gap across the whole cluster — the same rhythm as the home
+     nav's action group. The borderless controls (theme toggle, docs icon)
+     contribute their own inner padding, which reads as the wider breathing
+     room around glyph-only items, exactly like on the home page. */
+  .right-group,
+  .social-icons {
+    align-items: center;
+    gap: 0.5rem;
+  }
+</style>

--- a/apps/site/src/features/docs/components/SocialIcons.astro
+++ b/apps/site/src/features/docs/components/SocialIcons.astro
@@ -11,29 +11,6 @@ const repoHref = new URL(
 ---
 
 <a
-  class={`${ui.navCtaPrimary} playground-link`}
-  href={playgroundHref}
-  aria-label="Open Playground"
-  title="Playground"
->
-  <span class={ui.navPlaygroundLabel}>Playground</span>
-  <svg
-    class={ui.navPlaygroundMark}
-    viewBox="0 0 24 24"
-    fill="none"
-    stroke="currentColor"
-    stroke-width="2"
-    stroke-linecap="round"
-    stroke-linejoin="round"
-    aria-hidden="true"
-  >
-    <rect x="3" y="4" width="18" height="16" rx="2"></rect>
-    <path d="m7 9 3 3-3 3"></path>
-    <path d="M13 15h4"></path>
-  </svg>
-</a>
-
-<a
   class={ui.navIcon}
   href={docsHref}
   aria-label="Read the web-ai-sdk docs"
@@ -53,6 +30,29 @@ const repoHref = new URL(
   >
     <path d="M12 7v14"></path>
     <path d="M3 18a1 1 0 0 1-1-1V4a1 1 0 0 1 1-1h5a4 4 0 0 1 4 4 4 4 0 0 1 4-4h5a1 1 0 0 1 1 1v13a1 1 0 0 1-1 1h-6a3 3 0 0 0-3 3 3 3 0 0 0-3-3z"></path>
+  </svg>
+</a>
+
+<a
+  class={`${ui.navCtaPrimary} playground-link`}
+  href={playgroundHref}
+  aria-label="Open Playground"
+  title="Playground"
+>
+  <span class={ui.navPlaygroundLabel}>Playground</span>
+  <svg
+    class={ui.navPlaygroundMark}
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    stroke-width="2"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+    aria-hidden="true"
+  >
+    <rect x="3" y="4" width="18" height="16" rx="2"></rect>
+    <path d="m7 9 3 3-3 3"></path>
+    <path d="M13 15h4"></path>
   </svg>
 </a>
 

--- a/apps/site/src/features/docs/components/TableOfContents.astro
+++ b/apps/site/src/features/docs/components/TableOfContents.astro
@@ -3,9 +3,33 @@
 // active-link highlighting comes from the proportional scroll spy in
 // `toc-scroll-spy.ts` instead of Starlight's IntersectionObserver, which never
 // activates short sections near the end of a page.
+//
+// Below the section list the sidebar carries the page actions: "Copy page"
+// (page link to the clipboard), "Open in chat" (hands the page to an AI chat),
+// "Edit page on GitHub" (moved here from Starlight's footer — see the
+// EditLink override), and "Back to top".
 import TocList from "./TocList.astro";
 
-const { toc } = Astro.locals.starlightRoute;
+const { toc, editUrl } = Astro.locals.starlightRoute;
+
+const pageUrl = new URL(Astro.url.pathname, "https://web-ai-sdk.dev").href;
+const chatQuery = encodeURIComponent(
+  `Read ${pageUrl} and help me with questions about it.`,
+);
+// Gemini's web app has no native URL-prompt support (only via third-party
+// extensions), so Google is represented by AI Mode instead: `udm=50` triggers
+// the conversational AI response with the query prefilled.
+const chatProviders = [
+  { name: "ChatGPT", href: `https://chatgpt.com/?q=${chatQuery}` },
+  { name: "Claude", href: `https://claude.ai/new?q=${chatQuery}` },
+  { name: "Perplexity", href: `https://www.perplexity.ai/search?q=${chatQuery}` },
+  { name: "Scira", href: `https://scira.ai/?q=${chatQuery}` },
+  { name: "T3 Chat", href: `https://t3.chat/new?q=${chatQuery}` },
+  {
+    name: "Google AI Mode",
+    href: `https://www.google.com/search?q=${chatQuery}&udm=50`,
+  },
+];
 ---
 
 {
@@ -15,8 +39,297 @@ const { toc } = Astro.locals.starlightRoute;
         <h2 id="starlight__on-this-page">{Astro.locals.t("tableOfContents.onThisPage")}</h2>
         <TocList toc={toc.items} />
       </nav>
+      <div class="toc-page-actions">
+        <button type="button" class="toc-page-action" data-copy-page>
+          <svg
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            aria-hidden="true"
+          >
+            <rect x="9" y="9" width="13" height="13" rx="2"></rect>
+            <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path>
+          </svg>
+          <span data-copy-page-label>Copy page</span>
+        </button>
+        <details class="toc-chat">
+          <summary class="toc-page-action">
+            <svg
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              aria-hidden="true"
+            >
+              <path d="M7.9 20A9 9 0 1 0 4 16.1L2 22Z"></path>
+            </svg>
+            Open in chat
+            <svg
+              class="toc-chat-caret"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              aria-hidden="true"
+            >
+              <path d="m6 9 6 6 6-6"></path>
+            </svg>
+          </summary>
+          <div class="toc-chat-menu">
+            {chatProviders.map((provider) => (
+              <a
+                class="toc-chat-item"
+                href={provider.href}
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                Open in {provider.name}
+                <svg
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="2"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  aria-hidden="true"
+                >
+                  <path d="M15 3h6v6"></path>
+                  <path d="M10 14 21 3"></path>
+                  <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"></path>
+                </svg>
+              </a>
+            ))}
+          </div>
+        </details>
+        {editUrl && (
+          <a
+            class="toc-page-action"
+            href={editUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            <svg
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              aria-hidden="true"
+            >
+              <path d="M17 3a2.85 2.83 0 1 1 4 4L7.5 20.5 2 22l1.5-5.5Z"></path>
+              <path d="m15 5 4 4"></path>
+            </svg>
+            Edit page on GitHub
+          </a>
+        )}
+        <button type="button" class="toc-page-action" data-back-to-top>
+          <svg
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            aria-hidden="true"
+          >
+            <path d="m5 12 7-7 7 7"></path>
+            <path d="M12 19V5"></path>
+          </svg>
+          Back to top
+        </button>
+      </div>
     </waisdk-toc>
   )
 }
+
+<style>
+  .toc-page-actions {
+    display: flex;
+    flex-direction: column;
+    gap: 0.125rem;
+    margin-top: 0.875rem;
+    padding-top: 0.875rem;
+    border-top: 1px solid var(--sl-color-hairline);
+  }
+
+  .toc-page-action {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.25rem 0.5rem;
+    border: 0;
+    border-radius: 0.25rem;
+    background: transparent;
+    color: var(--sl-color-gray-3);
+    font-size: var(--sl-text-xs);
+    line-height: 1.25;
+    text-decoration: none;
+    cursor: pointer;
+    transition: color 0.2s ease;
+  }
+
+  .toc-page-action:hover {
+    color: var(--sl-color-white);
+  }
+
+  .toc-page-action:focus-visible {
+    outline: 2px solid var(--sl-color-text-accent);
+    outline-offset: 2px;
+  }
+
+  .toc-page-action svg {
+    width: 0.875rem;
+    height: 0.875rem;
+    flex-shrink: 0;
+  }
+
+  .toc-chat {
+    position: relative;
+  }
+
+  .toc-chat summary {
+    list-style: none;
+    user-select: none;
+    width: 100%;
+  }
+
+  .toc-chat summary::-webkit-details-marker {
+    display: none;
+  }
+
+  .toc-chat-caret {
+    margin-inline-start: auto;
+    transition: transform 0.15s ease;
+  }
+
+  .toc-chat[open] .toc-chat-caret {
+    transform: rotate(180deg);
+  }
+
+  /* The menu spans the exact width of its trigger row, so the popover reads
+     as an extension of the "Open in chat" action instead of a floating box. */
+  .toc-chat-menu {
+    position: absolute;
+    inset-inline: 0;
+    top: calc(100% + 0.25rem);
+    z-index: 50;
+    display: flex;
+    flex-direction: column;
+    gap: 0.125rem;
+    padding: 0.25rem;
+    border: 1px solid var(--sl-color-hairline-light);
+    border-radius: 0.5rem;
+    background: var(--sl-color-black);
+    box-shadow: 0 8px 24px rgb(0 0 0 / 0.35);
+  }
+
+  .toc-chat-item {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.75rem;
+    padding: 0.375rem 0.5rem;
+    border-radius: 0.375rem;
+    color: var(--sl-color-gray-3);
+    font-size: var(--sl-text-xs);
+    line-height: 1.25;
+    text-decoration: none;
+    white-space: nowrap;
+  }
+
+  .toc-chat-item:hover {
+    color: var(--sl-color-white);
+    background: var(--sl-color-gray-6);
+  }
+
+  .toc-chat-item:focus-visible {
+    outline: 2px solid var(--sl-color-text-accent);
+    outline-offset: -2px;
+  }
+
+  .toc-chat-item svg {
+    width: 0.75rem;
+    height: 0.75rem;
+    flex-shrink: 0;
+    opacity: 0.7;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .toc-chat-caret {
+      transition: none;
+    }
+  }
+</style>
+
+<script>
+  const copyButton = document.querySelector<HTMLButtonElement>(
+    "[data-copy-page]",
+  );
+  const copyLabel = document.querySelector<HTMLElement>(
+    "[data-copy-page-label]",
+  );
+
+  let resetTimer: ReturnType<typeof setTimeout> | undefined;
+
+  copyButton?.addEventListener("click", async () => {
+    if (!copyLabel) return;
+
+    const text = window.location.origin + window.location.pathname;
+
+    let copied = false;
+    try {
+      await navigator.clipboard.writeText(text);
+      copied = true;
+    } catch {
+      // Clipboard API unavailable (permission or insecure context): fall back
+      // to a transient textarea and the legacy copy command.
+      const textarea = document.createElement("textarea");
+      textarea.value = text;
+      textarea.setAttribute("readonly", "");
+      textarea.style.position = "fixed";
+      textarea.style.opacity = "0";
+      document.body.append(textarea);
+      textarea.select();
+      copied = document.execCommand("copy");
+      textarea.remove();
+    }
+
+    copyLabel.textContent = copied ? "Copied!" : "Copy failed";
+
+    clearTimeout(resetTimer);
+    resetTimer = setTimeout(() => {
+      copyLabel.textContent = "Copy page";
+    }, 2000);
+  });
+
+  document
+    .querySelector<HTMLButtonElement>("[data-back-to-top]")
+    ?.addEventListener("click", () => {
+      const reduceMotion = window.matchMedia(
+        "(prefers-reduced-motion: reduce)",
+      ).matches;
+      window.scrollTo({ top: 0, behavior: reduceMotion ? "auto" : "smooth" });
+    });
+
+  // The chat menu is a <details> popover: close it when the pointer leaves
+  // for elsewhere on the page or when a provider is chosen.
+  const chatMenu = document.querySelector<HTMLDetailsElement>(".toc-chat");
+
+  document.addEventListener("click", (event) => {
+    if (!chatMenu?.open) return;
+    const target = event.target as Node;
+    if (!chatMenu.contains(target) || (target as HTMLElement).closest?.("a")) {
+      chatMenu.open = false;
+    }
+  });
+</script>
 
 <script src="./toc-scroll-spy.ts"></script>

--- a/apps/site/src/features/docs/components/ThemeToggle.astro
+++ b/apps/site/src/features/docs/components/ThemeToggle.astro
@@ -7,29 +7,39 @@
     aria-pressed="false"
     title="Switch to light theme"
   >
+    <!-- Lucide "sun" and "moon", matching the stroke weight of the other
+         header icons. -->
     <svg
       class="docs-theme-icon docs-theme-icon-sun"
       viewBox="0 0 24 24"
       fill="none"
       stroke="currentColor"
-      stroke-width="1.8"
+      stroke-width="2"
       stroke-linecap="round"
+      stroke-linejoin="round"
       aria-hidden="true"
     >
-      <circle cx="12" cy="12" r="3.5"></circle>
-      <path d="M12 2v2.5M12 19.5V22M4.93 4.93l1.77 1.77M17.3 17.3l1.77 1.77M2 12h2.5M19.5 12H22M4.93 19.07l1.77-1.77M17.3 6.7l1.77-1.77"></path>
+      <circle cx="12" cy="12" r="4"></circle>
+      <path d="M12 2v2"></path>
+      <path d="M12 20v2"></path>
+      <path d="m4.93 4.93 1.41 1.41"></path>
+      <path d="m17.66 17.66 1.41 1.41"></path>
+      <path d="M2 12h2"></path>
+      <path d="M20 12h2"></path>
+      <path d="m6.34 17.66-1.41 1.41"></path>
+      <path d="m19.07 4.93-1.41 1.41"></path>
     </svg>
     <svg
       class="docs-theme-icon docs-theme-icon-moon"
       viewBox="0 0 24 24"
       fill="none"
       stroke="currentColor"
-      stroke-width="1.8"
+      stroke-width="2"
       stroke-linecap="round"
       stroke-linejoin="round"
       aria-hidden="true"
     >
-      <path d="M20.5 15.2A8.5 8.5 0 0 1 8.8 3.5 8.5 8.5 0 1 0 20.5 15.2Z"></path>
+      <path d="M12 3a6 6 0 0 0 9 9 9 9 0 1 1-9-9Z"></path>
     </svg>
   </button>
 </starlight-theme-select>

--- a/apps/site/src/features/docs/scripts/inline-code-copy.ts
+++ b/apps/site/src/features/docs/scripts/inline-code-copy.ts
@@ -1,0 +1,87 @@
+// Click-to-copy for inline code in the docs content. Hovering an inline
+// `code` span shows a minimal "Copy" tooltip; clicking copies the code text
+// and flashes "Copied!". Fenced code blocks keep expressive-code's own copy
+// button, and code rendered inside links keeps its navigation behavior.
+const CODE_SELECTOR = ".sl-markdown-content code";
+const RESET_DELAY = 1200;
+
+let tip: HTMLDivElement | undefined;
+let hideTimer: ReturnType<typeof setTimeout> | undefined;
+
+function getTip(): HTMLDivElement {
+  if (!tip) {
+    tip = document.createElement("div");
+    tip.className = "inline-code-tip";
+    tip.setAttribute("role", "status");
+    document.body.append(tip);
+  }
+  return tip;
+}
+
+function showTip(code: HTMLElement, label: string) {
+  const el = getTip();
+  const rect = code.getBoundingClientRect();
+  el.textContent = label;
+  el.style.left = `${rect.left + rect.width / 2}px`;
+  el.style.top = `${rect.top}px`;
+  el.setAttribute("data-show", "");
+}
+
+function hideTip() {
+  tip?.removeAttribute("data-show");
+}
+
+async function copyText(text: string): Promise<boolean> {
+  try {
+    await navigator.clipboard.writeText(text);
+    return true;
+  } catch {
+    // Clipboard API unavailable (permission or insecure context): fall back
+    // to a transient textarea and the legacy copy command.
+    const textarea = document.createElement("textarea");
+    textarea.value = text;
+    textarea.setAttribute("readonly", "");
+    textarea.style.position = "fixed";
+    textarea.style.opacity = "0";
+    document.body.append(textarea);
+    textarea.select();
+    const copied = document.execCommand("copy");
+    textarea.remove();
+    return copied;
+  }
+}
+
+function enhanceInlineCode() {
+  for (const code of document.querySelectorAll<HTMLElement>(CODE_SELECTOR)) {
+    if (code.closest("pre") || code.closest("a") || code.closest(".expressive-code")) {
+      continue;
+    }
+
+    code.classList.add("inline-code-copy");
+
+    code.addEventListener("mouseenter", () => {
+      clearTimeout(hideTimer);
+      showTip(code, "Copy");
+    });
+
+    code.addEventListener("mouseleave", hideTip);
+
+    code.addEventListener("click", async () => {
+      const copied = await copyText(code.textContent ?? "");
+      showTip(code, copied ? "Copied!" : "Copy failed");
+      clearTimeout(hideTimer);
+      hideTimer = setTimeout(hideTip, RESET_DELAY);
+    });
+  }
+}
+
+// A fixed-position tooltip drifts away from its anchor once the page scrolls.
+window.addEventListener("scroll", hideTip, { passive: true, capture: true });
+
+if (document.readyState === "loading") {
+  document.addEventListener("DOMContentLoaded", enhanceInlineCode, {
+    once: true,
+  });
+} else {
+  enhanceInlineCode();
+}

--- a/apps/site/src/features/docs/scripts/inline-code-copy.ts
+++ b/apps/site/src/features/docs/scripts/inline-code-copy.ts
@@ -53,7 +53,11 @@ async function copyText(text: string): Promise<boolean> {
 
 function enhanceInlineCode() {
   for (const code of document.querySelectorAll<HTMLElement>(CODE_SELECTOR)) {
-    if (code.closest("pre") || code.closest("a") || code.closest(".expressive-code")) {
+    if (
+      code.closest("pre") ||
+      code.closest("a") ||
+      code.closest(".expressive-code")
+    ) {
       continue;
     }
 

--- a/apps/site/src/features/docs/scripts/type-union-pills.ts
+++ b/apps/site/src/features/docs/scripts/type-union-pills.ts
@@ -1,0 +1,41 @@
+// String-literal type unions in inline code — `"a" | "b" | "c"` — render as
+// one long chip that wraps mid-token inside option tables. Split them into
+// one pill per union member; the wrapper flex-wraps between pills, so long
+// unions break cleanly. Runs before inline-code-copy.ts (import order in
+// Head.astro), so each pill gets its own copy affordance.
+const UNION_CODE_SELECTOR = ".sl-markdown-content code";
+const STRING_UNION = /^"[^"]*"(?:\s*\|\s*"[^"]*")+$/;
+
+function splitUnionPills() {
+  for (const code of document.querySelectorAll<HTMLElement>(
+    UNION_CODE_SELECTOR,
+  )) {
+    if (
+      code.closest("pre") ||
+      code.closest("a") ||
+      code.closest(".expressive-code")
+    ) {
+      continue;
+    }
+
+    const text = code.textContent?.trim() ?? "";
+    if (!STRING_UNION.test(text)) continue;
+
+    const wrap = document.createElement("span");
+    wrap.className = "type-union";
+    for (const member of text.split("|")) {
+      const pill = document.createElement("code");
+      pill.textContent = member.trim();
+      wrap.append(pill);
+    }
+    code.replaceWith(wrap);
+  }
+}
+
+if (document.readyState === "loading") {
+  document.addEventListener("DOMContentLoaded", splitUnionPills, {
+    once: true,
+  });
+} else {
+  splitUnionPills();
+}

--- a/apps/site/src/features/docs/styles/web-ai-sdk.css
+++ b/apps/site/src/features/docs/styles/web-ai-sdk.css
@@ -182,10 +182,13 @@
    screens a growing gap opens between the sidebar and the content while the
    right TOC hugs it. Cap the shell and shift the fixed sidebar and the main
    frame together so both sidenavs stay tight to the content. The header
-   container below shares the same cap. */
+   container uses the narrower home/playground cap instead so the brand and
+   actions land at the same viewport positions on every page. */
 :root {
   --docs-shell-max: 87.5rem;
   --docs-shell-offset: max(0rem, calc((100vw - var(--docs-shell-max)) / 2));
+  /* Mirrors --container-site (1180px) from the home shell. */
+  --docs-header-max: 73.75rem;
 }
 @media (min-width: 50rem) {
   .sidebar-pane {
@@ -209,8 +212,10 @@
   backdrop-filter: blur(14px) saturate(1.2);
 }
 
-/* Use the same centered container and three-column rhythm as the home and
-   playground shells. The search sits in the shared center of the viewport. */
+/* Use the same centered container rhythm as the home and playground shells.
+   The custom Header override keeps the search inside the right action
+   cluster, so the header reads brand | theme → search → Playground → Docs →
+   GitHub with no center column. */
 @media (min-width: 50rem) {
   .page > .header {
     --sl-nav-height: calc(3.5rem + 1px);
@@ -219,33 +224,13 @@
   }
 
   .page > .header > .header {
-    grid-template-columns: minmax(0, 1fr) minmax(0, 27.5rem) minmax(0, 1fr);
-    max-width: var(--docs-shell-max);
+    max-width: var(--docs-header-max);
     margin-inline: auto;
     padding-inline: 1.75rem;
-    gap: 1rem;
-  }
-
-  .page > .header .title-wrapper {
-    padding: 0.25rem;
-    margin: -0.25rem;
   }
 
   .page > .header .docs-site-title {
     font-weight: 400;
-  }
-
-  .page > .header .sl-flex.print\:hidden {
-    justify-content: flex-start;
-  }
-
-  .page > .header .right-group {
-    justify-content: flex-end;
-    gap: 0.5rem;
-  }
-
-  .page > .header .social-icons {
-    gap: 0.5rem;
   }
 
   .page > .header .social-icons a {
@@ -253,26 +238,39 @@
     font-feature-settings: "ss01", "cv11", "tnum";
   }
 
+  /* Ultra-compact search trigger: magnifier, label, and ⌘K hint sized to
+     their content instead of stretching to a fixed field width. */
   .page > .header site-search button[data-open-modal] {
-    width: min(27.5rem, 100%);
+    width: auto;
     max-width: none;
-    height: 2.375rem;
+    height: 2rem;
+    gap: 0.375rem;
     border-color: var(--sl-color-hairline-light);
     border-radius: var(--radius-sm, 0.5rem);
-    padding: 0 0.625rem 0 0.875rem;
+    padding: 0 0.5rem 0 0.625rem;
     background-color: var(--sl-color-black);
     font-family: var(--sl-font-sans);
-    font-size: 0.875rem;
+    font-size: 0.8125rem;
     line-height: 1.5;
-  }
-
-  .page > .header site-search button[data-open-modal] > :last-child {
-    margin-inline-start: auto;
   }
 }
 
-/* Below the wide desktop state, keep the three-column header centered while
-   reducing the actions to the same icon-only treatment used on small screens. */
+/* The home shell tightens its gutter from 28px to 20px at 880px. Track it so
+   the brand and actions keep the same inset on every page; setting the
+   Starlight pad var at root keeps the mobile menu toggle and sidebar pane
+   aligned with the header. */
+@media (max-width: 55rem) {
+  :root {
+    --sl-nav-pad-x: 1.25rem;
+  }
+
+  .page > .header > .header {
+    padding-inline: 1.25rem;
+  }
+}
+
+/* Below the wide desktop state, reduce the actions to the same icon-only
+   treatment used on small screens. */
 @media (min-width: 50rem) and (max-width: 71.999rem) {
   .page > .header .playground-link,
   .page > .header .github-link {
@@ -297,32 +295,44 @@
   }
 }
 
-/* The full search field has no room beside the compact actions at this width.
-   Keep its magnifier as the discoverable control and preserve its label in the
-   button's accessible name. */
-@media (min-width: 50rem) and (max-width: 54.999rem) {
-  .page > .header > .header {
-    grid-template-columns: minmax(0, 1fr) 2.375rem minmax(0, 1fr);
-  }
-
-  .page > .header site-search button[data-open-modal] {
-    width: 2.375rem;
-    padding: 0;
-    justify-content: center;
-  }
-
-  .page > .header site-search button[data-open-modal] > span,
-  .page > .header site-search button[data-open-modal] > kbd {
-    display: none;
-  }
-}
-
 @media (max-width: 49.999rem) {
+  /* Icon-only magnifier: same resting/hover tone as the neighboring theme
+     toggle and docs icons (Starlight's default renders it brighter). */
   .page > .header site-search button[data-open-modal] {
     width: 2rem;
     height: 2rem;
     padding: 0;
     justify-content: center;
+    color: var(--sl-color-gray-3);
+  }
+
+  .page > .header site-search button[data-open-modal]:hover {
+    color: var(--sl-color-white);
+  }
+
+  /* Normalize the Playground and GitHub buttons to the same 2rem square as
+     the neighboring controls (the base nav CTA otherwise keeps its taller
+     36px minimum on small screens). */
+  .page > .header .right-group .playground-link,
+  .page > .header .right-group .github-link {
+    width: 2rem;
+    height: 2rem;
+    min-width: 2rem;
+    min-height: 2rem;
+    padding: 0.5rem;
+    box-sizing: border-box;
+  }
+
+  .page > .header .right-group .playground-link > span:first-child,
+  .page > .header .right-group .github-link > span:first-child {
+    display: none;
+  }
+
+  .page > .header .right-group .playground-link > svg,
+  .page > .header .right-group .github-link > svg {
+    display: block;
+    width: 1rem;
+    height: 1rem;
   }
 }
 
@@ -339,16 +349,6 @@
 
   .page > .header .social-icons {
     gap: 0.5rem;
-  }
-
-  .page > .header .playground-link,
-  .page > .header .github-link {
-    width: 2rem;
-    height: 2rem;
-    min-width: 2rem;
-    min-height: 2rem;
-    padding: 0.5rem;
-    box-sizing: border-box;
   }
 }
 
@@ -700,6 +700,57 @@ footer:has(> .pagination-links) {
 @media (min-width: 50rem) {
   site-search dialog {
     min-height: 0;
+    /* Compact box: Starlight's 40rem dialog dwarfs the slimmed header field. */
+    max-width: 32rem;
+  }
+}
+
+/* Inline-code click-to-copy (see scripts/inline-code-copy.ts): the enhanced
+   spans invite the click, and the shared tooltip floats above the hovered
+   code in a minimal hairline chip. */
+.inline-code-copy {
+  cursor: copy;
+}
+
+/* Union pills (see scripts/type-union-pills.ts): string-literal unions break
+   between whole members instead of wrapping mid-token inside one long chip. */
+.type-union {
+  display: inline-flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: 0.25rem 0.375rem;
+  vertical-align: baseline;
+}
+
+.type-union > code {
+  white-space: nowrap;
+}
+
+.inline-code-tip {
+  position: fixed;
+  z-index: 100;
+  transform: translate(-50%, calc(-100% - 0.375rem));
+  padding: 0.2rem 0.5rem;
+  border: 1px solid var(--sl-color-hairline-light);
+  border-radius: 0.375rem;
+  background: var(--sl-color-black);
+  color: var(--sl-color-gray-2);
+  font-family: var(--sl-font-sans);
+  font-size: 0.75rem;
+  line-height: 1.4;
+  white-space: nowrap;
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 0.12s ease;
+}
+
+.inline-code-tip[data-show] {
+  opacity: 1;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .inline-code-tip {
+    transition: none;
   }
 }
 

--- a/apps/site/src/features/home/components/PackageExplorer.test.tsx
+++ b/apps/site/src/features/home/components/PackageExplorer.test.tsx
@@ -169,3 +169,69 @@ describe("PackageExplorer preparation intent", () => {
     expect(mocks.prepareTranslator).toHaveBeenCalledTimes(1);
   });
 });
+
+describe("PackageExplorer install command", () => {
+  const getInstallButton = () => {
+    const button = [
+      ...container.querySelectorAll<HTMLButtonElement>(
+        '[role="tabpanel"]:not([hidden]) button',
+      ),
+    ].find((candidate) => candidate.textContent?.includes("npm install"));
+    expect(button).toBeDefined();
+    return button as HTMLButtonElement;
+  };
+
+  const stubClipboard = (writeText: ReturnType<typeof vi.fn>) => {
+    Object.defineProperty(navigator, "clipboard", {
+      value: { writeText },
+      configurable: true,
+    });
+  };
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("copies the command and flips the cue until the timeout", async () => {
+    vi.useFakeTimers();
+    const writeText = vi.fn(async () => undefined);
+    stubClipboard(writeText);
+
+    act(() => root?.render(<PackageExplorer />));
+    const button = getInstallButton();
+    expect(button.textContent).toContain("copy");
+
+    await act(async () => {
+      button.click();
+      await Promise.resolve();
+    });
+
+    expect(writeText).toHaveBeenCalledWith("npm install @web-ai-sdk/prompt");
+    expect(button.textContent).toContain("copied");
+
+    act(() => {
+      vi.advanceTimersByTime(1400);
+    });
+    expect(button.textContent).not.toContain("copied");
+    expect(button.textContent).toContain("copy");
+  });
+
+  it("keeps the resting cue when the clipboard write fails", async () => {
+    const writeText = vi.fn(async () => {
+      throw new Error("denied");
+    });
+    stubClipboard(writeText);
+
+    act(() => root?.render(<PackageExplorer />));
+    const button = getInstallButton();
+
+    await act(async () => {
+      button.click();
+      await Promise.resolve();
+    });
+
+    expect(writeText).toHaveBeenCalledTimes(1);
+    expect(button.textContent).not.toContain("copied");
+    expect(button.textContent).toContain("copy");
+  });
+});

--- a/apps/site/src/features/home/components/PackageExplorer.tsx
+++ b/apps/site/src/features/home/components/PackageExplorer.tsx
@@ -240,7 +240,9 @@ const InstallCommand = ({ pkg }: { pkg: string }) => {
     try {
       await navigator.clipboard.writeText(`npm install ${pkg}`);
     } catch {
-      // Clipboard unavailable in some browsers / contexts; silently no-op.
+      // Clipboard unavailable in some browsers / contexts; keep the resting
+      // cue rather than claiming a copy happened.
+      return;
     }
     setCopied(true);
     setTimeout(() => setCopied(false), 1400);

--- a/apps/site/src/features/home/components/PackageExplorer.tsx
+++ b/apps/site/src/features/home/components/PackageExplorer.tsx
@@ -250,9 +250,7 @@ const InstallCommand = ({ pkg }: { pkg: string }) => {
     <button type="button" className={pkgInstall} onClick={copy}>
       <span className={pkgInstallPrompt}>$</span> npm install{" "}
       <span className={pkgInstallPkg}>{pkg}</span>
-      <span
-        className={`${pkgInstallCopy} ${copied ? "text-ok" : "text-fg-3"}`}
-      >
+      <span className={`${pkgInstallCopy} ${copied ? "text-ok" : "text-fg-3"}`}>
         {copied ? "copied" : "copy"}
       </span>
     </button>

--- a/apps/site/src/features/home/components/PackageExplorer.tsx
+++ b/apps/site/src/features/home/components/PackageExplorer.tsx
@@ -9,6 +9,7 @@ import {
   pkgBullets,
   pkgDocs,
   pkgInstall,
+  pkgInstallCopy,
   pkgInstallPkg,
   pkgInstallPrompt,
   pkgLeft,
@@ -227,6 +228,37 @@ const FIRST_PKG =
   PACKAGE_ROWS[0] ??
   raise("PackageExplorer: PACKAGE_ROWS must contain at least one entry");
 
+/**
+ * Per-demo install command with a click-to-copy CTA, the compact sibling of
+ * the hero InstallPill: the whole command is one button, and the trailing
+ * cue flips to "copied" for a beat after a successful copy.
+ */
+const InstallCommand = ({ pkg }: { pkg: string }) => {
+  const [copied, setCopied] = useState(false);
+
+  const copy = async () => {
+    try {
+      await navigator.clipboard.writeText(`npm install ${pkg}`);
+    } catch {
+      // Clipboard unavailable in some browsers / contexts; silently no-op.
+    }
+    setCopied(true);
+    setTimeout(() => setCopied(false), 1400);
+  };
+
+  return (
+    <button type="button" className={pkgInstall} onClick={copy}>
+      <span className={pkgInstallPrompt}>$</span> npm install{" "}
+      <span className={pkgInstallPkg}>{pkg}</span>
+      <span
+        className={`${pkgInstallCopy} ${copied ? "text-ok" : "text-fg-3"}`}
+      >
+        {copied ? "copied" : "copy"}
+      </span>
+    </button>
+  );
+};
+
 function raise(message: string): never {
   throw new Error(message);
 }
@@ -362,10 +394,7 @@ export const PackageExplorer = () => {
                 ))}
               </ul>
               <div className={pkgActions}>
-                <code className={pkgInstall}>
-                  <span className={pkgInstallPrompt}>$</span> npm install{" "}
-                  <span className={pkgInstallPkg}>@web-ai-sdk/{p.title}</span>
-                </code>
+                <InstallCommand pkg={`@web-ai-sdk/${p.title}`} />
                 <a className={pkgDocs} href={guideLink(p.slug)}>
                   <span className={silverText}>
                     {PACKAGE_DOCS_LABELS[p.slug] ?? "Read the docs"}

--- a/apps/site/src/shared/components/SiteNav.astro
+++ b/apps/site/src/shared/components/SiteNav.astro
@@ -31,6 +31,28 @@ const {
 
     <div class={ui.navActions}>
       <a
+        class={ui.navIcon}
+        href={docsHref}
+        aria-label="Read the web-ai-sdk docs"
+        title="Docs"
+      >
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          width="16"
+          height="16"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          aria-hidden="true"
+        >
+          <path d="M12 7v14"></path>
+          <path d="M3 18a1 1 0 0 1-1-1V4a1 1 0 0 1 1-1h5a4 4 0 0 1 4 4 4 4 0 0 1 4-4h5a1 1 0 0 1 1 1v13a1 1 0 0 1-1 1h-6a3 3 0 0 0-3 3 3 3 0 0 0-3-3z"></path>
+        </svg>
+      </a>
+      <a
         class={ui.navCtaPrimary}
         href={playgroundHref}
         aria-current={activePage === "playground" ? "page" : undefined}
@@ -51,28 +73,6 @@ const {
           <rect x="3" y="4" width="18" height="16" rx="2"></rect>
           <path d="m7 9 3 3-3 3"></path>
           <path d="M13 15h4"></path>
-        </svg>
-      </a>
-      <a
-        class={ui.navIcon}
-        href={docsHref}
-        aria-label="Read the web-ai-sdk docs"
-        title="Docs"
-      >
-        <svg
-          xmlns="http://www.w3.org/2000/svg"
-          width="16"
-          height="16"
-          viewBox="0 0 24 24"
-          fill="none"
-          stroke="currentColor"
-          stroke-width="2"
-          stroke-linecap="round"
-          stroke-linejoin="round"
-          aria-hidden="true"
-        >
-          <path d="M12 7v14"></path>
-          <path d="M3 18a1 1 0 0 1-1-1V4a1 1 0 0 1 1-1h5a4 4 0 0 1 4 4 4 4 0 0 1 4-4h5a1 1 0 0 1 1 1v13a1 1 0 0 1-1 1h-6a3 3 0 0 0-3 3 3 3 0 0 0-3-3z"></path>
         </svg>
       </a>
       <a

--- a/apps/site/src/shared/ui.ts
+++ b/apps/site/src/shared/ui.ts
@@ -333,12 +333,17 @@ export const pkgBullets =
 
 export const pkgActions = "flex w-fit max-w-full flex-col items-start gap-4";
 
+// Rendered as a button: the whole command is a click-to-copy target, with a
+// trailing "copy"/"copied" cue mirroring the hero InstallPill.
 export const pkgInstall =
-  "w-fit max-w-full whitespace-nowrap rounded-sm border border-hairline bg-surface px-3.5 py-2.5 font-mono text-[12.5px] text-fg-2";
+  "inline-flex w-fit max-w-full items-center whitespace-nowrap rounded-sm border border-hairline bg-surface py-2.5 pl-3.5 pr-0 font-mono text-[12.5px] text-fg-2 transition-colors hover:border-accent-line";
 
 export const pkgInstallPrompt = "mr-2 text-fg-4";
 
 export const pkgInstallPkg = "text-accent";
+
+export const pkgInstallCopy =
+  "ml-3.5 border-l border-hairline px-3.5 font-mono text-[11px] uppercase tracking-[0.08em] transition-colors";
 
 export const pkgDocs =
   "inline-flex items-center font-mono text-[12.5px] text-fg-3 hover:text-accent";
@@ -542,8 +547,10 @@ const playgroundToolCardErrorBase =
 
 /** Playground route: dense, responsive instrument-panel compositions. */
 export const playground = {
+  // Carries the same silver shimmer as the home link labels (see silverText);
+  // under prefers-reduced-motion it settles to the resting silver tone.
   navTrail:
-    "justify-self-center font-mono text-[11px] uppercase tracking-[0.12em] text-fg-2 max-[640px]:hidden",
+    "justify-self-center font-mono text-[11px] uppercase tracking-[0.12em] bg-[image:var(--gradient-silver)] bg-[length:200%_100%] bg-clip-text text-transparent animate-silver motion-reduce:animate-none max-[640px]:hidden",
   bootStack:
     "grid h-[calc(100svh-var(--nav-height))] min-h-0 [&>*]:col-start-1 [&>*]:row-start-1",
   bootLayer: "h-full min-h-0",


### PR DESCRIPTION
## Summary

### Header / nav (docs, home, playground)
- Docs header now shares the home/playground container rhythm: 1180px cap, 28px gutter (20px at and below 880px), identical brand and action positions at every width.
- Custom Starlight `Header` override moves search into the action cluster with a unified order everywhere: **theme → search → docs → Playground → GitHub** (docs) and **docs → Playground → GitHub** (home/playground).
- Ultra-compact search trigger (magnifier + label + ⌘K, content-sized) and a 32rem search modal.
- Lucide sun/moon for the theme toggle, matching the stroke weight of the other header icons.
- Small screens: all header controls normalized to 2rem squares, uniform 0.5rem gaps, magnifier tone matched to its neighbors.

### Docs right sidebar — page actions (below the TOC scroll spy)
- **Copy page** — copies the page link.
- **Open in chat** — popover menu (ChatGPT, Claude, Perplexity, Scira, T3 Chat, Google AI Mode) opening the provider with a prefilled prompt for the current page. Google is represented by AI Mode (`udm=50`) because the Gemini app has no native URL-prompt support.
- **Edit page on GitHub** — moved out of Starlight's footer (EditLink override left intentionally empty).
- **Back to top** — smooth scroll, instant under reduced motion.

### Docs content
- Inline code gets a minimal hover tooltip with click-to-copy (skips code blocks and links).
- String-literal type unions (`"a" | "b" | …`) render as separate wrapping pills instead of one long chip that breaks mid-token.

### Home
- `PLAYGROUND` nav trail carries the same silver shimmer as the home link labels.
- Each package demo's install command is now a click-to-copy button with a `copy`/`copied` cue, mirroring the hero install pill.

## Testing
- `astro check`: 0 errors (2 hints from the intentional `execCommand` clipboard fallbacks).
- `vitest`: 23 files, 117 tests passing.
- Verified in the browser: header geometry parity between docs/home/playground at 1280px, 2rem control sizing at 375px, copy/tooltip/menu interactions, both theme modes.