### PR TITLE
feat(site): revamp home hero backdrop with city shader and smooth intro

### DIFF
--- a/apps/site/src/features/home/components/CityShader.tsx
+++ b/apps/site/src/features/home/components/CityShader.tsx
@@ -1,0 +1,136 @@
+import { ShaderBackdrop } from "./ShaderBackdrop.js";
+
+/**
+ * City look: a dense night megacity, deliberately under-defined. Five stacked
+ * skyline layers give the crowded-silhouette depth of concept-art cityscapes:
+ * the far layers melt into horizon haze, the middle distance carries the
+ * light — a dense speckle field of lit windows — and the foreground towers
+ * are near-black masses that cut everything behind them. Neon rooflines glow
+ * with a soft bloom; vertical strips are rare and faint. Below the skyline,
+ * elevated freeways carry long-exposure light trails (hot comet heads, cooling
+ * tails, a rare full-speed streaker). Overhead, a faint perspective grid
+ * converges toward the horizon. All motion is slow continuous drift at
+ * depth-dependent speeds — no jitter, no pointer interaction (static camera).
+ * Colored entirely by the design tokens: bg is the sky, the dim accent is
+ * haze/grid/dim neon, the bright accent is hot neon, windows and cars. A
+ * drop-in alternative to SpectralShader / MeshShader / StreamShader (swap the
+ * island import in the Astro page).
+ */
+
+const FRAG = [
+  "#ifdef GL_FRAGMENT_PRECISION_HIGH",
+  "precision highp float;",
+  "#else",
+  "precision mediump float;",
+  "#endif",
+  "uniform float u_time;uniform vec2 u_res;",
+  "uniform vec3 u_c1;uniform vec3 u_c2;uniform vec3 u_bg;",
+  "uniform float u_cells;uniform float u_intro;",
+  "float hash(vec2 p){p=fract(p*vec2(123.34,345.45));p+=dot(p,p+34.345);return fract(p.x*p.y);}",
+  // one skyline layer: soft dark silhouette + sparse neon + window speckles.
+  // freq = columns per unit, hmax = tallest tower, soft = silhouette blur,
+  // amt = layer presence, drift = slide speed, lit = how much light this
+  // depth carries (the middle distance glows, far fades, front goes dark),
+  // seed = layer id
+  "vec3 city(vec3 col,vec2 p,float freq,float hmax,float soft,float amt,float drift,float lit,float seed){",
+  "  float xx=p.x*freq+u_time*drift+seed*7.3;",
+  "  float ci=floor(xx);float fx=fract(xx);",
+  "  float h=hmax*(0.25+0.75*hash(vec2(ci,seed)));",
+  "  float y=p.y+0.16;",
+  "  float up=step(0.0,y);",
+  // tower width: each building occupies part of its column with soft x-edges
+  // and a gap to its neighbor, so deeper layers show through — no full-column
+  // slab, no hard vertical seams
+  "  float bw=0.28+0.34*hash(vec2(ci,seed+21.0));",
+  "  float xm=smoothstep(bw+0.10,bw-0.05,abs(fx-0.5));",
+  // silhouette: a soft dark mass, edges left vague on purpose
+  "  float inside=smoothstep(h+soft,h-soft,y)*up*xm;",
+  // depth shadow: a wider, softer dark halo hugs the tower and dims whatever
+  // glows behind it — the contact shadow that separates the depth planes
+  "  float xmw=smoothstep(bw+0.24,bw-0.05,abs(fx-0.5));",
+  "  float halo=clamp(smoothstep(h+0.10,h-0.02,y)*up*xmw-inside,0.0,1.0);",
+  "  col=mix(col,u_bg*0.30,halo*amt*0.35);",
+  // near-opaque fill: towers are solid cutouts, the city does not shine
+  // through them
+  "  col=mix(col,u_bg*0.40,inside*clamp(amt*1.15,0.0,1.0));",
+  // per-building neon personality: on/off, dim-or-hot color
+  "  float non=step(0.35,hash(vec2(ci,seed+5.0)));",
+  "  vec3 nc=mix(u_c1,u_c2,step(0.55,hash(vec2(ci,seed+9.0))));",
+  // roofline: thin core wrapped in a soft bloom, spanning only the tower
+  "  float d=abs(y-h);",
+  "  float roof=(smoothstep(0.006,0.0,d)*0.6+smoothstep(0.10,0.0,d)*0.18)*up*xm;",
+  "  col=mix(col,nc,roof*non*amt*lit);",
+  // windows: screen-space speckles (constant size at every depth), gated to
+  // tower interiors, slow flicker
+  "  float wxf=p.x*30.0+seed*11.0;float wyf=y*34.0;",
+  "  float wdot=smoothstep(0.38,0.24,abs(fract(wxf)-0.5))*smoothstep(0.44,0.30,abs(fract(wyf)-0.5));",
+  "  float w=step(0.60,hash(vec2(floor(wxf)+seed*7.0,floor(wyf)+seed*3.0)));",
+  "  float fl=0.6+0.4*sin(u_time*0.7+hash(vec2(floor(wxf),floor(wyf)))*6.28);",
+  "  col=mix(col,u_c2,inside*step(y,h-0.03)*w*wdot*fl*amt*lit*0.42);",
+  "  return col;",
+  "}",
+  // one traffic lane: long-exposure light trails on a gently swooping elevated
+  // freeway. Returns vec2(heads, tails) — hot comet heads and the fading tail
+  // streaked behind each one (opposite to travel direction). w scales the
+  // beam thickness so near lanes read closer. sparse controls car density.
+  "vec2 lane(vec2 p,float ly,float speed,float dens,float w,float sparse,float seed){",
+  "  float yy=ly+0.018*sin(p.x*1.6+seed*3.1);",
+  "  float d=abs(p.y-yy);",
+  "  float xr=p.x*dens+speed*u_time+seed*17.0;",
+  "  float car=step(sparse,hash(vec2(floor(xr),seed)));",
+  "  float f=fract(xr)-0.5;",
+  // cars travel toward -x for positive speed; the tail streaks the other way
+  "  float behind=step(0.0,f*sign(speed));",
+  "  float head=smoothstep(0.10,0.0,abs(f));",
+  "  float tail=behind*smoothstep(0.48,0.02,abs(f));",
+  "  float coreY=smoothstep(0.0045*w,0.0008*w,d);",
+  "  float glowY=smoothstep(0.020*w,0.004*w,d)*0.35;",
+  "  return vec2(head*(coreY+glowY),tail*(coreY*0.55+glowY))*car;",
+  "}",
+  "void main(){",
+  "  vec2 uv=gl_FragCoord.xy/u_res.xy;",
+  "  vec2 p=(gl_FragCoord.xy-0.5*u_res.xy)/u_res.y;",
+  "  float fs=clamp(u_cells*0.021,0.6,1.2);",
+  "  vec3 col=u_bg;",
+  // haze: the sky glows toward the horizon, dim accent with a hot tinge
+  "  float gy=p.y+0.16;",
+  "  col=mix(col,u_c1,0.22*smoothstep(0.38,0.0,abs(gy)));",
+  "  col=mix(col,u_c2,0.05*smoothstep(0.14,0.0,abs(gy)));",
+  // sky dome: faint perspective grid converging at the horizon, slow drift
+  "  if(gy>0.02){",
+  "    float pr=1.0/(0.06+gy*1.1);",
+  "    vec2 g=vec2(p.x*pr*0.8,pr*0.9+u_time*0.015);",
+  "    float grid=max(smoothstep(0.44,0.5,abs(fract(g.x)-0.5)),smoothstep(0.44,0.5,abs(fract(g.y)-0.5)));",
+  "    float fade=smoothstep(10.0,2.5,pr)*smoothstep(0.02,0.20,gy);",
+  "    col=mix(col,u_c1,grid*fade*0.10);",
+  "  }",
+  // skyline, back to front: five depths. Light lives in the middle distance;
+  // the far city is haze, the foreground is near-black cutout mass
+  "  col=city(col,p,16.0*fs,0.30,0.035,0.30,0.003,0.50,1.0);",
+  "  col=city(col,p,12.0*fs,0.40,0.020,0.50,0.005,1.00,2.0);",
+  "  col=city(col,p, 9.0*fs,0.48,0.010,0.70,0.007,1.00,3.0);",
+  // light pollution: the massed glow of the mid-city rising off the streets —
+  // this is what the dark foreground towers cut their silhouettes against
+  "  col=mix(col,mix(u_c1,u_c2,0.35),0.16*smoothstep(0.35,0.02,gy)*step(0.02,gy));",
+  "  col=city(col,p, 6.5*fs,0.55,0.005,0.90,0.009,0.55,4.0);",
+  "  col=city(col,p, 4.5*fs,0.62,0.003,1.00,0.012,0.25,5.0);",
+  // elevated freeways below the horizon: far -> near lanes get thicker,
+  // brighter and faster, opposing directions; plus a rare full-speed streaker
+  "  vec2 tr=lane(p,-0.195, 0.05,3.6,0.7,0.55,1.0)*0.5",
+  "         +lane(p,-0.245,-0.075,2.8,1.0,0.55,2.0)*0.8",
+  "         +lane(p,-0.300, 0.10,2.2,1.5,0.60,3.0)",
+  "         +lane(p,-0.300, 0.30,2.2,1.5,0.93,4.0)*1.2;",
+  // heads burn in the hot accent, tails cool toward the dim one
+  "  col=mix(col,u_c2,clamp(tr.x,0.0,1.0)*0.75);",
+  "  col=mix(col,mix(u_c1,u_c2,0.35),clamp(tr.y,0.0,1.0)*0.55);",
+  // materialize, then vignette + film grain
+  "  col=mix(u_bg,col,u_intro);",
+  "  col*=1.0-0.3*smoothstep(0.5,1.4,length(p));",
+  "  col+=(hash(uv*u_res.xy+u_time)-0.5)*0.012;",
+  "  gl_FragColor=vec4(col,1.0);",
+  "}",
+].join("\n");
+
+export function CityShader({ className }: { className?: string }) {
+  return <ShaderBackdrop frag={FRAG} className={className} />;
+}

--- a/apps/site/src/features/home/components/MeshShader.tsx
+++ b/apps/site/src/features/home/components/MeshShader.tsx
@@ -18,6 +18,7 @@ const FRAG = [
   "#endif",
   "uniform float u_time;uniform vec2 u_res;uniform vec2 u_mouse;",
   "uniform vec3 u_c1;uniform vec3 u_c2;uniform vec3 u_bg;uniform float u_cells;",
+  "uniform float u_intro;",
   "vec2 hash2(vec2 p){p=vec2(dot(p,vec2(127.1,311.7)),dot(p,vec2(269.5,183.3)));return fract(sin(p)*43758.5453);}",
   "float hash1(vec2 p){return fract(sin(dot(p,vec2(127.1,311.7)))*43758.5453);}",
   // module position + activation for a given cell (drifts slowly)
@@ -65,8 +66,8 @@ const FRAG = [
   "  }}",
   "  float mb=1.0+smoothstep(0.55,0.0,length(p-mp))*0.6;",
   "  vec3 col=u_bg;",
-  "  col=mix(col,u_c1,clamp(wireI*0.28*mb,0.0,1.0));",
-  "  col=mix(col,u_c2,clamp(max(streamI,nodeI)*mb,0.0,1.0));",
+  "  col=mix(col,u_c1,clamp(wireI*0.28*mb,0.0,1.0)*u_intro);",
+  "  col=mix(col,u_c2,clamp(max(streamI,nodeI)*mb,0.0,1.0)*u_intro);",
   "  col*=1.0-0.3*smoothstep(0.5,1.4,length(p));",
   "  col+=(hash1(uv*u_res.xy+u_time)-0.5)*0.012;",
   "  gl_FragColor=vec4(col,1.0);",

--- a/apps/site/src/features/home/components/ShaderBackdrop.tsx
+++ b/apps/site/src/features/home/components/ShaderBackdrop.tsx
@@ -16,8 +16,10 @@ import {
  * off-screen, caps DPR, reacts to the pointer, and no-ops on no-WebGL /
  * reduced-motion so it never blocks the hero from rendering.
  *
- * Shader contract (uniforms the engine feeds every frame):
- *   float u_time, vec2 u_res, vec2 u_mouse, float u_cells,
+ * Shader contract (uniforms the engine can feed every frame — all optional;
+ * declare only what the look uses, the engine no-ops missing locations):
+ *   float u_time, vec2 u_res, vec2 u_mouse (pointer tracking is only wired
+ *   when the shader declares it), float u_cells,
  *   float u_intro (0->1 ease-out over the first ~2.2s; gate effect intensity
  *   on it — as a plain multiplier for a fade, or as the radius of a spatial
  *   reveal — so the look materializes out of the bg instead of popping),
@@ -156,7 +158,9 @@ export function ShaderBackdrop({
       target[0] = (e.clientX - r.left) / r.width;
       target[1] = 1 - (e.clientY - r.top) / r.height;
     };
-    window.addEventListener("pointermove", onMove);
+    // Pointer tracking costs a layout read per move; skip it entirely for
+    // shaders that don't declare u_mouse (e.g. the static-camera city look).
+    if (uMouse) window.addEventListener("pointermove", onMove);
 
     let raf = 0;
     let visible = true;
@@ -166,13 +170,15 @@ export function ShaderBackdrop({
       // Note: do NOT reset raf to 0 here. Keeping the live id non-zero during the
       // frame prevents the IntersectionObserver from starting a second, parallel
       // rAF loop (stacked loops made the shader flicker badly on mobile).
-      mouse[0] += (target[0] - mouse[0]) * 0.05;
-      mouse[1] += (target[1] - mouse[1]) * 0.05;
+      if (uMouse) {
+        mouse[0] += (target[0] - mouse[0]) * 0.05;
+        mouse[1] += (target[1] - mouse[1]) * 0.05;
+        gl.uniform2f(uMouse, mouse[0], mouse[1]);
+      }
       const t = Math.min(1, (now - start) / INTRO_MS);
       gl.uniform1f(uIntro, 1 - (1 - t) * (1 - t) * (1 - t));
       gl.uniform1f(uTime, (now - start) / 1000);
       gl.uniform2f(uRes, canvas.width, canvas.height);
-      gl.uniform2f(uMouse, mouse[0], mouse[1]);
       gl.uniform1f(uCells, cells);
       gl.drawArrays(gl.TRIANGLES, 0, 3);
       if (!ready) {

--- a/apps/site/src/features/home/components/ShaderBackdrop.tsx
+++ b/apps/site/src/features/home/components/ShaderBackdrop.tsx
@@ -18,8 +18,14 @@ import {
  *
  * Shader contract (uniforms the engine feeds every frame):
  *   float u_time, vec2 u_res, vec2 u_mouse, float u_cells,
+ *   float u_intro (0->1 ease-out over the first ~2.2s; gate effect intensity
+ *   on it — as a plain multiplier for a fade, or as the radius of a spatial
+ *   reveal — so the look materializes out of the bg instead of popping),
  *   vec3 u_bg (=--color-bg), u_c1 (=--color-accent-dim), u_c2 (=--color-accent)
  */
+
+// How long the in-shader materialize ramp (u_intro) takes to reach 1.
+const INTRO_MS = 2200;
 
 const VERT = "attribute vec2 p;void main(){gl_Position=vec4(p,0.0,1.0);}";
 
@@ -103,6 +109,8 @@ export function ShaderBackdrop({
     const uC2 = gl.getUniformLocation(prog, "u_c2");
     const uBg = gl.getUniformLocation(prog, "u_bg");
     const uCells = gl.getUniformLocation(prog, "u_cells");
+    // Null for shaders that don't declare it; uniform1f(null, ...) is a no-op.
+    const uIntro = gl.getUniformLocation(prog, "u_intro");
 
     // Colors come from the live design tokens: bg matches the page (no seam),
     // the dimmer accent is the flow, the bright accent is the heads.
@@ -160,6 +168,8 @@ export function ShaderBackdrop({
       // rAF loop (stacked loops made the shader flicker badly on mobile).
       mouse[0] += (target[0] - mouse[0]) * 0.05;
       mouse[1] += (target[1] - mouse[1]) * 0.05;
+      const t = Math.min(1, (now - start) / INTRO_MS);
+      gl.uniform1f(uIntro, 1 - (1 - t) * (1 - t) * (1 - t));
       gl.uniform1f(uTime, (now - start) / 1000);
       gl.uniform2f(uRes, canvas.width, canvas.height);
       gl.uniform2f(uMouse, mouse[0], mouse[1]);

--- a/apps/site/src/features/home/components/SpectralShader.tsx
+++ b/apps/site/src/features/home/components/SpectralShader.tsx
@@ -1,0 +1,114 @@
+import { ShaderBackdrop } from "./ShaderBackdrop.js";
+
+/**
+ * Spectral look: slow domain-warped smoke — dark veils drifting upward with
+ * faint phantom highlights where the folds compress — and a *presence* behind
+ * it: a soft head-and-shoulders occluder that wanders slowly through the fog,
+ * swallowing the smoke's light where it passes and betraying itself only as a
+ * faint rim. Its edges are eroded by the same noise as the smoke so it never
+ * reads as a crisp cutout, just something moving back there. Colored entirely
+ * by the design tokens: bg is the void, the dim accent is the smoke body, the
+ * bright accent surfaces as spectral edges. The pointer stirs the fog locally.
+ * A drop-in alternative to MeshShader / StreamShader (swap the island import
+ * in the Astro page).
+ */
+
+const FRAG = [
+  "#ifdef GL_FRAGMENT_PRECISION_HIGH",
+  "precision highp float;",
+  "#else",
+  "precision mediump float;",
+  "#endif",
+  "uniform float u_time;uniform vec2 u_res;uniform vec2 u_mouse;",
+  "uniform vec3 u_c1;uniform vec3 u_c2;uniform vec3 u_bg;",
+  "uniform float u_cells;uniform float u_intro;",
+  "float hash(vec2 p){p=fract(p*vec2(123.34,345.45));p+=dot(p,p+34.345);return fract(p.x*p.y);}",
+  "float vnoise(vec2 p){",
+  "  vec2 i=floor(p);vec2 f=fract(p);f=f*f*(3.0-2.0*f);",
+  "  float a=hash(i),b=hash(i+vec2(1.0,0.0)),c=hash(i+vec2(0.0,1.0)),d=hash(i+vec2(1.0,1.0));",
+  "  return mix(mix(a,b,f.x),mix(c,d,f.x),f.y);",
+  "}",
+  "float fbm(vec2 p){",
+  "  float v=0.0,a=0.5;",
+  "  mat2 r=mat2(0.8,0.6,-0.6,0.8);",
+  "  for(int i=0;i<5;i++){v+=a*vnoise(p);p=r*p*2.03+11.5;a*=0.5;}",
+  "  return v;",
+  "}",
+  // polynomial smooth-min: blends head and shoulders through a neck instead of
+  // a hard union seam
+  "float smin(float a,float b,float k){",
+  "  float h=clamp(0.5+0.5*(b-a)/k,0.0,1.0);return mix(b,a,h)-k*h*(1.0-h);",
+  "}",
+  "void main(){",
+  "  vec2 uv=gl_FragCoord.xy/u_res.xy;",
+  "  float asp=u_res.x/u_res.y;",
+  "  vec2 p=(gl_FragCoord.xy-0.5*u_res.xy)/u_res.y;",
+  "  vec2 mp=vec2((u_mouse.x-0.5)*asp,u_mouse.y-0.5);",
+  "  p+=0.04*mp;",
+  // smoke rises: sample space slides slowly downward over time
+  "  vec2 sp=p*1.9+vec2(0.0,-u_time*0.05);",
+  // fbm-of-fbm domain warp: q bends space, r bends it again -> curling veils
+  "  vec2 q=vec2(fbm(sp+vec2(0.0,0.0)),fbm(sp+vec2(5.2,1.3)));",
+  "  vec2 r=vec2(fbm(sp+3.2*q+vec2(1.7,9.2)+0.10*u_time),",
+  "              fbm(sp+3.2*q+vec2(8.3,2.8)+0.08*u_time));",
+  // pointer stirs the fog: extra warp falling off with distance to the cursor
+  "  float stir=smoothstep(0.65,0.0,length(p-mp));",
+  "  float s=fbm(sp+3.0*r+0.35*stir*vec2(mp.y,-mp.x));",
+  // smoke body: mid-tones of the warped field, kept dim
+  "  float body=smoothstep(0.28,0.85,s);",
+  // spectral edges: narrow ridge where the warp folds compress
+  "  float ridge=smoothstep(0.42,0.5,s)*smoothstep(0.58,0.5,s);",
+  "  float depth=clamp(length(r)*0.9,0.0,1.0);",
+  // the presence: a bust — wide sloping shoulders + a head that slowly turns,
+  // blended through a neck dip (the head/neck/shoulder curve is what makes a
+  // silhouette read as *someone*, no face needed). The wander path is pinned
+  // inside the smoky right zone (the left ~55% of the hero sits under an
+  // opaque bg gradient where the figure could never show); drift is slow so it
+  // hovers rather than paces
+  "  vec2 fp=vec2(0.55+0.25*sin(u_time*0.13)+0.08*sin(u_time*0.31+1.7),",
+  "               -0.02+0.06*sin(u_time*0.21+0.6));",
+  "  vec2 fd=p-fp;",
+  // shoulders: wide flat ellipse below; half-width ~0.32, ~2.9x head radius
+  "  float sh=length((fd+vec2(0.0,0.24))*vec2(0.62,1.30))-0.20;",
+  // head: drifts sideways relative to the shoulders, someone looking around
+  "  vec2 hoff=vec2(0.05*sin(u_time*0.33+2.1),0.17+0.012*sin(u_time*0.7));",
+  "  float head=length(fd-hoff)-0.095;",
+  "  float dfig=smin(sh,head,0.055);",
+  // breathe: the whole bust presses toward the veil, then recedes
+  "  dfig-=0.025*sin(u_time*0.15+4.0);",
+  // erode the silhouette with the warped smoke noise: ragged, half-dissolved
+  // (kept mild so the head/shoulder line stays recognizable)
+  "  dfig+=0.09*(fbm(p*3.5+r+vec2(0.0,u_time*0.10))-0.5);",
+  "  float figure=smoothstep(0.09,-0.07,dfig);",
+  // rim: thin band around the silhouette edge, only visible through the fog
+  "  float rim=smoothstep(0.05,0.0,abs(dfig));",
+  // halo: fog just outside the silhouette catches light, so the dark core has
+  // contrast to read against even where the smoke is thin
+  "  float halo=smoothstep(0.30,0.02,dfig)*(1.0-figure);",
+  // spread-in: a dissolve keyed to the smoke's own warp field (q), not to
+  // geometry — as u_intro rises, more of the field passes the threshold, so
+  // the fog condenses in liquid patches that grow and merge along the noise
+  // contours, with no discernible origin (only a trace of distance bias keeps
+  // the presence's neighborhood slightly ahead). The wide soft band keeps the
+  // front misty. Saturates to 1 everywhere by the end of the ramp, then
+  // continues as-is.
+  "  float rn=0.5*(q.x+q.y);",
+  "  float rev=smoothstep(0.45,0.0,0.9*rn+0.15*length(p-fp)+0.35-u_intro*1.6);",
+  "  vec3 col=u_bg;",
+  // shadow first: the presence soaks light out of the bg where it stands
+  "  col*=1.0-0.30*figure*rev;",
+  // smoke over it: brightened in the halo, swallowed where the figure occludes
+  "  float fog=body*(0.16+0.22*depth)*(1.0+1.1*halo)*(1.0-0.85*figure);",
+  "  col=mix(col,u_c1,fog*rev);",
+  "  col=mix(col,u_c2,ridge*(0.10+0.25*depth)*(0.7+0.5*stir)*(1.0-0.7*figure)*rev);",
+  // faint spectral outline: you sense the shape more than you see it
+  "  col=mix(col,u_c2,rim*body*0.16*rev);",
+  "  col*=1.0-0.3*smoothstep(0.5,1.4,length(p));",
+  "  col+=(hash(uv*u_res.xy+u_time)-0.5)*0.012;",
+  "  gl_FragColor=vec4(col,1.0);",
+  "}",
+].join("\n");
+
+export function SpectralShader({ className }: { className?: string }) {
+  return <ShaderBackdrop frag={FRAG} className={className} />;
+}

--- a/apps/site/src/pages/index.astro
+++ b/apps/site/src/pages/index.astro
@@ -2,7 +2,7 @@
 import { BackToTop } from "../features/home/components/BackToTop.js";
 import { HowItWorks } from "../features/home/components/HowItWorks.js";
 import { InstallPill } from "../features/home/components/InstallPill.js";
-import { MeshShader } from "../features/home/components/MeshShader.js";
+import { CityShader } from "../features/home/components/CityShader.js";
 import { PackageExplorer } from "../features/home/components/PackageExplorer.js";
 import { ScrollSpy } from "../features/home/components/ScrollSpy.js";
 import { StarWidget } from "../features/home/components/StarWidget.js";
@@ -480,7 +480,9 @@ const browserColumns = [
 
     <main>
       <header class={`${ui.hero} relative overflow-hidden`} id="top">
-        <MeshShader client:visible />
+        {/* client:load, not client:visible: the hero is above the fold, and
+            deferring hydration is what made the backdrop pop in late. */}
+        <CityShader client:load />
         <div
           aria-hidden="true"
           class="pointer-events-none absolute inset-0 bg-[linear-gradient(100deg,var(--color-bg)_0%,var(--color-bg)_34%,color-mix(in_oklch,var(--color-bg)_50%,transparent)_60%,transparent_88%)] max-[880px]:bg-[linear-gradient(180deg,color-mix(in_oklch,var(--color-bg)_64%,transparent)_0%,color-mix(in_oklch,var(--color-bg)_52%,transparent)_100%)]"
@@ -636,7 +638,12 @@ const browserColumns = [
             <a class={ui.permalink} href="#packages"><span aria-hidden="true">↑</span><span class={ui.srOnly}>Link to Packages section</span></a>
           </div>
 
-          <PackageExplorer client:visible />
+          {/* client:idle, not client:visible: visible-hydration depends on
+              IntersectionObserver, which is suspended while a page is hidden
+              (embedded previews, background tabs) — leaving the demo tabs
+              rendered but inert until the page is foregrounded. idle hydrates
+              during load regardless of visibility. */}
+          <PackageExplorer client:idle />
         </div>
       </section>
 
@@ -710,7 +717,7 @@ const browserColumns = [
             <a class={ui.permalink} href="#how"><span aria-hidden="true">↑</span><span class={ui.srOnly}>Link to How it works section</span></a>
           </div>
           <div class={ui.reveal} data-reveal>
-            <HowItWorks client:visible />
+            <HowItWorks client:idle />
           </div>
         </div>
       </section>

--- a/apps/site/src/shared/ui.ts
+++ b/apps/site/src/shared/ui.ts
@@ -349,8 +349,10 @@ export const heroRepoLink =
 export const shaderBackdrop =
   "pointer-events-none absolute inset-0 overflow-hidden bg-[radial-gradient(circle_at_78%_42%,color-mix(in_oklch,var(--color-surface-3)_24%,transparent),transparent_58%)]";
 
+// Short opacity fade only masks the first compiled frame; the visible
+// materialize is the in-shader u_intro ramp (see ShaderBackdrop).
 export const shaderCanvas =
-  "block h-full w-full opacity-0 transition-opacity duration-700 ease-out data-[ready=true]:opacity-100 motion-reduce:transition-none";
+  "block h-full w-full opacity-0 transition-opacity duration-300 ease-out data-[ready=true]:opacity-100 motion-reduce:transition-none";
 
 export const shaderFade =
   "absolute inset-x-0 bottom-0 h-1/3 bg-[linear-gradient(to_top,var(--color-bg)_0%,var(--color-bg)_18%,transparent_100%)]";

--- a/apps/site/src/shared/ui.ts
+++ b/apps/site/src/shared/ui.ts
@@ -349,8 +349,8 @@ export const heroRepoLink =
 export const shaderBackdrop =
   "pointer-events-none absolute inset-0 overflow-hidden bg-[radial-gradient(circle_at_78%_42%,color-mix(in_oklch,var(--color-surface-3)_24%,transparent),transparent_58%)]";
 
-// Short opacity fade only masks the first compiled frame; the visible
-// materialize is the in-shader u_intro ramp (see ShaderBackdrop).
+// The brief opacity fade only hides the first rendered frame; the visible
+// entrance is the in-shader u_intro ramp (see ShaderBackdrop).
 export const shaderCanvas =
   "block h-full w-full opacity-0 transition-opacity duration-300 ease-out data-[ready=true]:opacity-100 motion-reduce:transition-none";
 


### PR DESCRIPTION
## What

Reworks the home hero backdrop and fixes hydration of the hero and demo islands.

### Hero backdrop
- **New `CityShader` (default)**: a synthwave night megacity — five parallax skyline layers with depth shadows and contact halos, screen-space window speckles, neon rooflines with soft bloom, a faint perspective sky grid, horizon light pollution, and long-exposure traffic trails (comet heads, cooling tails, a rare streaker). All motion is slow continuous drift; no pointer interaction.
- **New `SpectralShader` (alternate)**: domain-warped fbm smoke with a head-and-shoulders presence lurking behind the fog and a noise-keyed dissolve intro. Kept as a drop-in swap alongside `MeshShader` / `StreamShader` (one import change in `index.astro`).
- Both looks stay fully token-driven (`--color-bg` / `--color-accent-dim` / `--color-accent`) and adapt to theme changes at runtime.

### Loading behavior
- `ShaderBackdrop` now feeds a `u_intro` ease-out ramp (~2.2s) so a look materializes out of the page background instead of popping in fully formed. The CSS opacity transition drops 700ms → 300ms and only masks the first compiled frame; the first drawn frame is pixel-identical to the page background.

### Hydration fixes
- Hero island: `client:visible` → `client:load`. It is above the fold; deferring hydration was the main cause of the backdrop appearing late.
- `PackageExplorer` / `HowItWorks`: `client:visible` → `client:idle`. Visible-hydration relies on IntersectionObserver, which is suspended while a page is hidden (embedded previews, background tabs), leaving the demo tabs rendered but inert until foregrounded.

## Verification
- `pnpm check` green: Biome lint, package builds, `astro check` (0 errors), full test suite (site: 23 files / 117 tests).
- Verified in a live preview: no white flash on load (canvas stays hidden until the first frame, which matches the page bg), intro spread behaves at real speed, demo tabs hydrate and switch correctly, reduced-motion no-ops the shader, and the mid-edit dev-server 504s (`Outdated Optimize Dep`) were confirmed to be a stale Vite cache, not a code issue.