### PR TITLE
fix(deps): bump nanoid override to patched version

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,7 @@ settings:
 overrides:
   yaml@<2.8.3: '>=2.8.3 <3.0.0'
   postcss@^8.0.0: 8.5.23
+  nanoid@^3.0.0: 3.3.17
   js-yaml@^4.0.0: 4.3.1
   read-yaml-file>js-yaml: 3.15.1
   fast-uri@^3.0.0: 3.1.5
@@ -3230,8 +3231,8 @@ packages:
   mz@2.7.0:
     resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
 
-  nanoid@3.3.16:
-    resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
+  nanoid@3.3.17:
+    resolution: {integrity: sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -7427,7 +7428,7 @@ snapshots:
       object-assign: 4.1.1
       thenify-all: 1.6.0
 
-  nanoid@3.3.16: {}
+  nanoid@3.3.17: {}
 
   neotraverse@1.0.1: {}
 
@@ -7585,7 +7586,7 @@ snapshots:
 
   postcss@8.5.23:
     dependencies:
-      nanoid: 3.3.16
+      nanoid: 3.3.17
       picocolors: 1.1.1
       source-map-js: 1.2.1
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -5,6 +5,7 @@ packages:
 overrides:
   yaml@<2.8.3: ">=2.8.3 <3.0.0"
   postcss@^8.0.0: "8.5.23"
+  nanoid@^3.0.0: "3.3.17"
   js-yaml@^4.0.0: "4.3.1"
   read-yaml-file>js-yaml: 3.15.1
   fast-uri@^3.0.0: "3.1.5"


### PR DESCRIPTION
Fixes [Dependabot alert #71](https://github.com/obetomuniz/web-ai-sdk/security/dependabot/71) — nanoid < 3.3.17 infinite-loop DoS ([GHSA-2v37-7h3g-55p8](https://github.com/advisories/GHSA-2v37-7h3g-55p8) / CVE-2026-67213, high severity).

- Adds a `nanoid@^3.0.0: 3.3.17` override in `pnpm-workspace.yaml`, following the same pattern as #191
- nanoid is a transitive runtime dependency pulled in via postcss; the lockfile now resolves it to 3.3.17 everywhere
- Full workspace build passes after the bump