### PR TITLE
fix(site): normalize nav chrome, demo tab scroll, and docs pagination

### DIFF
--- a/apps/site/src/content.config.ts
+++ b/apps/site/src/content.config.ts
@@ -1,6 +1,6 @@
 import { defineCollection } from "astro:content";
-import { docsLoader } from "@astrojs/starlight/loaders";
-import { docsSchema } from "@astrojs/starlight/schema";
+import { docsLoader, i18nLoader } from "@astrojs/starlight/loaders";
+import { docsSchema, i18nSchema } from "@astrojs/starlight/schema";
 
 export const collections: Record<string, unknown> = {
   docs: defineCollection({
@@ -11,5 +11,11 @@ export const collections: Record<string, unknown> = {
       },
     }),
     schema: docsSchema(),
+  }),
+  // Overrides for Starlight's built-in UI strings (src/content/i18n/en.json),
+  // e.g. the prev/next pagination labels.
+  i18n: defineCollection({
+    loader: i18nLoader(),
+    schema: i18nSchema(),
   }),
 };

--- a/apps/site/src/content/i18n/en.json
+++ b/apps/site/src/content/i18n/en.json
@@ -1,0 +1,4 @@
+{
+  "page.previousLink": "Back",
+  "page.nextLink": "Up next"
+}

--- a/apps/site/src/features/docs/components/SocialIcons.astro
+++ b/apps/site/src/features/docs/components/SocialIcons.astro
@@ -11,15 +11,14 @@ const repoHref = new URL(
 ---
 
 <a
-  class={ui.navIcon}
+  class={`${ui.navCta} docs-link`}
   href={docsHref}
   aria-label="Read the web-ai-sdk docs"
   title="Docs"
 >
+  <span class={ui.navDocsLabel}>Docs</span>
   <svg
-    xmlns="http://www.w3.org/2000/svg"
-    width="16"
-    height="16"
+    class={ui.navDocsMark}
     viewBox="0 0 24 24"
     fill="none"
     stroke="currentColor"
@@ -91,6 +90,8 @@ const repoHref = new URL(
     background: #000000;
   }
 
+  /* One uniform 0.5rem gap across the whole mobile cluster, matching the
+     Header's desktop rhythm and the 0.5rem reserved before the hamburger. */
   @media (max-width: 49.999rem) {
     :global(.right-group) {
       display: flex;
@@ -98,7 +99,7 @@ const repoHref = new URL(
     }
 
     :global(.right-group .social-icons) {
-      gap: 0.75rem;
+      gap: 0.5rem;
     }
   }
 </style>

--- a/apps/site/src/features/docs/styles/web-ai-sdk.css
+++ b/apps/site/src/features/docs/styles/web-ai-sdk.css
@@ -210,6 +210,10 @@
     transparent
   );
   backdrop-filter: blur(14px) saturate(1.2);
+  /* The inner header container owns the horizontal gutter (1.75rem desktop,
+     1.25rem below 55rem — the home shell's rhythm). Starlight's own pad-x here
+     would stack on top of it and push the brand/actions out of alignment. */
+  padding-inline: 0;
 }
 
 /* Use the same centered container rhythm as the home and playground shells.
@@ -272,6 +276,7 @@
 /* Below the wide desktop state, reduce the actions to the same icon-only
    treatment used on small screens. */
 @media (min-width: 50rem) and (max-width: 71.999rem) {
+  .page > .header .docs-link,
   .page > .header .playground-link,
   .page > .header .github-link {
     width: 2rem;
@@ -282,11 +287,13 @@
     box-sizing: border-box;
   }
 
+  .page > .header .docs-link > span:first-child,
   .page > .header .playground-link > span:first-child,
   .page > .header .github-link > span:first-child {
     display: none;
   }
 
+  .page > .header .docs-link > svg,
   .page > .header .playground-link > svg,
   .page > .header .github-link > svg {
     display: block;
@@ -310,9 +317,10 @@
     color: var(--sl-color-white);
   }
 
-  /* Normalize the Playground and GitHub buttons to the same 2rem square as
-     the neighboring controls (the base nav CTA otherwise keeps its taller
-     36px minimum on small screens). */
+  /* Normalize the Docs, Playground, and GitHub buttons to the same 2rem
+     square as the neighboring controls (the base nav CTA otherwise keeps its
+     taller 36px minimum on small screens). */
+  .page > .header .right-group .docs-link,
   .page > .header .right-group .playground-link,
   .page > .header .right-group .github-link {
     width: 2rem;
@@ -323,11 +331,13 @@
     box-sizing: border-box;
   }
 
+  .page > .header .right-group .docs-link > span:first-child,
   .page > .header .right-group .playground-link > span:first-child,
   .page > .header .right-group .github-link > span:first-child {
     display: none;
   }
 
+  .page > .header .right-group .docs-link > svg,
   .page > .header .right-group .playground-link > svg,
   .page > .header .right-group .github-link > svg {
     display: block;
@@ -336,19 +346,18 @@
   }
 }
 
-/* Preserve the complete header at the narrowest phone widths. The controls
-   stay discoverable, while the reduced gaps leave room for the brand. */
-@media (max-width: 23.999rem) {
+/* Preserve the complete header at the narrowest phone widths (below the
+   368px where the full 0.5rem rhythm plus the brand no longer fit). The
+   controls stay discoverable, while the reduced (but still uniform) gaps
+   leave room for the brand. */
+@media (max-width: 22.999rem) {
   .page > .header > .header {
     column-gap: 0.5rem;
   }
 
-  .page > .header .right-group {
-    gap: 0.25rem;
-  }
-
+  .page > .header .right-group,
   .page > .header .social-icons {
-    gap: 0.5rem;
+    gap: 0.25rem;
   }
 }
 
@@ -979,6 +988,26 @@ site-search .pagefind-ui__drawer:not(.pagefind-ui__hidden) {
   color: var(--sl-color-text);
 }
 
+/* Prev/next pagination: give the arrow more breathing room from the label
+   block (Starlight's 0.5rem reads cramped next to the card's 1rem padding). */
+.pagination-links a {
+  gap: 1rem;
+}
+
+/* Pin the grid to two fixed columns so a lone link keeps its half-width card
+   instead of stretching across the content column (Starlight's auto-fit
+   collapses to one full-width track). A lone "next" stays on the right,
+   where readers expect it. */
+@media (min-width: 40rem) {
+  .pagination-links {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .pagination-links > a[rel="next"]:only-child {
+    grid-column: 2;
+  }
+}
+
 /* Mobile: align the search sheet's Cancel button with the slimmer bar. */
 @media (max-width: 49.999rem) {
   site-search dialog button[data-close-modal] {
@@ -988,12 +1017,20 @@ site-search .pagefind-ui__drawer:not(.pagefind-ui__hidden) {
 }
 
 /* Mobile: Starlight reserves nav-gap + nav-pad + button width (4rem) of
-   header padding for the fixed hamburger, but the button only spans 1rem to
-   3rem from the edge — the extra nav-gap read as a dead zone between the
-   action cluster and the menu. Reserve just the button plus the cluster's
-   own 0.5rem rhythm. */
+   header padding for the fixed hamburger, but the button only spans
+   pad-x to pad-x + 2rem from the edge — the extra nav-gap read as a dead
+   zone between the action cluster and the menu. The inner container already
+   pads the content by the pad-x gutter, so reserve just the button plus the
+   cluster's own 0.5rem rhythm and every control sits one even gap apart. */
 @media (max-width: 49.999rem) {
   [data-has-sidebar] .page > .header {
-    padding-inline-end: calc(var(--sl-nav-pad-x) + var(--sl-menu-button-size) + 0.5rem);
+    padding-inline-end: calc(var(--sl-menu-button-size) + 0.5rem);
+  }
+}
+
+/* Track the tighter 0.25rem cluster rhythm of the narrowest phones. */
+@media (max-width: 21.999rem) {
+  [data-has-sidebar] .page > .header {
+    padding-inline-end: calc(var(--sl-menu-button-size) + 0.25rem);
   }
 }

--- a/apps/site/src/pages/index.astro
+++ b/apps/site/src/pages/index.astro
@@ -525,7 +525,6 @@ const browserColumns = [
               <div class={ui.sectionEyebrow}>purpose</div>
               <h2 class="mt-2">Why use a wrapper?</h2>
             </div>
-            <a class={ui.permalink} href="#why-raw"><span aria-hidden="true">↑</span><span class={ui.srOnly}>Link to the why-not-the-raw-APIs section</span></a>
           </div>
           <div class={`${ui.whyRawGrid} ${ui.reveal}`} data-reveal>
             <p class={ui.whyRawLead}>
@@ -550,7 +549,6 @@ const browserColumns = [
               <div class={ui.sectionEyebrow}>coverage</div>
               <h2 class="mt-2">Why one package per capability.</h2>
             </div>
-            <a class={ui.permalink} href="#why-sdk"><span aria-hidden="true">↑</span><span class={ui.srOnly}>Link to the why one package per capability section</span></a>
           </div>
           <div class={`${ui.twoCol} ${ui.reveal}`} data-reveal>
             <div>
@@ -590,7 +588,6 @@ const browserColumns = [
               <h2 class="mt-2">Lifecycle features by package.</h2>
               <p class="mt-3.5">Each package implements only the lifecycle features supported by its browser API.</p>
             </div>
-            <a class={ui.permalink} href="#matrix"><span aria-hidden="true">↑</span><span class={ui.srOnly}>Link to Capability matrix section</span></a>
           </div>
           <div class={ui.reveal} data-reveal>
             <div class={ui.supportWrap}>
@@ -635,7 +632,6 @@ const browserColumns = [
               <div class={ui.sectionEyebrow}>SDK catalog</div>
               <h2 class="mt-2">Packages.</h2>
             </div>
-            <a class={ui.permalink} href="#packages"><span aria-hidden="true">↑</span><span class={ui.srOnly}>Link to Packages section</span></a>
           </div>
 
           {/* client:idle, not client:visible: visible-hydration depends on
@@ -655,7 +651,6 @@ const browserColumns = [
               <h2 class="mt-2">Browser support.</h2>
               <p class="mt-3.5">Support differs by capability and browser. Each status links to a vendor source. The wrappers expose an unavailable state for fallback UI.</p>
             </div>
-            <a class={ui.permalink} href="#support"><span aria-hidden="true">↑</span><span class={ui.srOnly}>Link to Browser support section</span></a>
           </div>
           <div class={ui.reveal} data-reveal>
             <div class={ui.supportWrap}>
@@ -714,7 +709,6 @@ const browserColumns = [
               <h2 class="mt-2">Compare three API levels.</h2>
               <p class="mt-3.5">Each tab detects an article's language and creates a key-point summary. Compare the raw API, vanilla SDK, and React code.</p>
             </div>
-            <a class={ui.permalink} href="#how"><span aria-hidden="true">↑</span><span class={ui.srOnly}>Link to How it works section</span></a>
           </div>
           <div class={ui.reveal} data-reveal>
             <HowItWorks client:idle />
@@ -729,7 +723,6 @@ const browserColumns = [
               <div class={ui.sectionEyebrow}>scope</div>
               <h2 class="mt-2">Responsibilities.</h2>
             </div>
-            <a class={ui.permalink} href="#philosophy"><span aria-hidden="true">↑</span><span class={ui.srOnly}>Link to Philosophy section</span></a>
           </div>
           <div class={`${ui.twoCol} ${ui.reveal}`} data-reveal>
             <div>

--- a/apps/site/src/shared/components/SiteNav.astro
+++ b/apps/site/src/shared/components/SiteNav.astro
@@ -31,15 +31,14 @@ const {
 
     <div class={ui.navActions}>
       <a
-        class={ui.navIcon}
+        class={ui.navCta}
         href={docsHref}
         aria-label="Read the web-ai-sdk docs"
         title="Docs"
       >
+        <span class={ui.navDocsLabel}>Docs</span>
         <svg
-          xmlns="http://www.w3.org/2000/svg"
-          width="16"
-          height="16"
+          class={ui.navDocsMark}
           viewBox="0 0 24 24"
           fill="none"
           stroke="currentColor"

--- a/apps/site/src/shared/ui.ts
+++ b/apps/site/src/shared/ui.ts
@@ -93,8 +93,14 @@ export const chipSelectCaret =
 export const caret =
   "inline-block h-[0.08em] w-[0.5em] shrink-0 animate-blink rounded-[1px] bg-accent align-baseline ml-[0.06em]";
 
+// Mobile: overflow-y-hidden is required — with only overflow-x set, the spec
+// promotes overflow-y to auto, and the tabs' -1px bottom margin (see tabBase)
+// makes the content 1px taller than the scrollport, creating a phantom
+// vertical scroll. The hairline moves from border-b to an inset shadow there:
+// a border sits outside the scrollport, so the active tab's own border-b
+// could no longer overlay it once the strip scrolls.
 const tabsBase =
-  "flex gap-1 border-b border-hairline max-[880px]:flex-nowrap max-[880px]:overflow-x-auto max-[880px]:[scrollbar-width:thin]";
+  "flex gap-1 border-b border-hairline max-[880px]:flex-nowrap max-[880px]:overflow-x-auto max-[880px]:overflow-y-hidden max-[880px]:border-b-0 max-[880px]:shadow-[inset_0_-1px_0_var(--color-hairline)] max-[880px]:[scrollbar-width:thin]";
 
 export const tabs = `${tabsBase} px-2`;
 
@@ -105,8 +111,12 @@ export const tabs = `${tabsBase} px-2`;
 // merges.
 export const tabsFlush = `${tabsBase}`;
 
+// mb-[-1px] lets the active tab's border-b overlay the strip's hairline on
+// desktop; on mobile the strip scrolls and draws its hairline as an inset
+// shadow instead (see tabsBase), so the tab sits flush (mb-0) and its border-b
+// lands exactly on the shadow line.
 const tabBase =
-  "group/tab mb-[-1px] inline-flex shrink-0 cursor-pointer items-center gap-2 border-x-0 border-t-0 border-b border-solid border-transparent bg-transparent px-4 py-3 font-mono text-[12.5px] transition-colors focus-visible:relative focus-visible:z-1 focus-visible:outline-2 focus-visible:outline-offset-[-2px] focus-visible:outline-accent max-[880px]:px-3.5";
+  "group/tab mb-[-1px] inline-flex shrink-0 cursor-pointer items-center gap-2 border-x-0 border-t-0 border-b border-solid border-transparent bg-transparent px-4 py-3 font-mono text-[12.5px] transition-colors focus-visible:relative focus-visible:z-1 focus-visible:outline-2 focus-visible:outline-offset-[-2px] focus-visible:outline-accent max-[880px]:mb-0 max-[880px]:px-3.5";
 
 export const tab = `${tabBase} text-fg-3 hover:text-fg`;
 
@@ -207,9 +217,6 @@ export const sectionHead =
 export const sectionEyebrow =
   "inline-flex items-center gap-2.5 font-mono text-[11px] uppercase tracking-[0.14em] text-fg-4";
 
-export const permalink =
-  "inline-flex size-7 items-center justify-center rounded-sm border border-hairline font-mono text-[13px] leading-none text-fg-4 no-underline transition-[color,border-color] hover:border-[color-mix(in_oklch,var(--color-accent)_40%,var(--color-hairline))] hover:text-accent max-[880px]:size-auto max-[880px]:rounded-none max-[880px]:border-0 max-[880px]:p-1.5 max-[880px]:hover:border-transparent [&>span[aria-hidden=true]]:translate-y-[-0.9px] [&>span[aria-hidden=true]]:opacity-75";
-
 export const srOnly =
   "absolute m-[-1px] h-px w-px overflow-hidden border-0 p-0 whitespace-nowrap [clip:rect(0,0,0,0)]";
 
@@ -220,7 +227,7 @@ export const navInner =
   "grid h-14 grid-cols-[1fr_auto_1fr] items-center gap-4 max-[640px]:grid-cols-[1fr_auto]";
 
 export const navBrand =
-  "flex items-baseline gap-[0.1em] font-mono text-sm tracking-[-0.01em]";
+  "flex items-baseline gap-[0.1em] font-mono text-sm whitespace-nowrap tracking-[-0.01em]";
 
 export const navMinimap =
   "relative flex h-10 w-48 items-center justify-center justify-self-center [&_a.active>span:first-child]:!h-8 [&_a.active>span:first-child]:!w-[3px] [&_a.active>span:first-child]:!bg-accent [&_a.active>span:first-child]:!opacity-100 max-[640px]:hidden";
@@ -243,24 +250,28 @@ export const navMinimapSummary =
 export const navCenterPlaceholder =
   "h-10 w-48 justify-self-center max-[640px]:hidden";
 
+// Compact text CTAs: the same 2rem height as the docs search trigger and
+// theme toggle, sized to their label; on small screens they collapse to the
+// same 2rem square. transition-colors (not -all) so only hover tints animate —
+// with transition-all, any late-applied stylesheet rule that changes geometry
+// (a real hazard while dev-mode CSS streams in) animates as a height bounce.
 const navCtaBase =
-  "inline-flex min-h-9 items-center justify-center whitespace-nowrap rounded-sm border px-3 py-2 font-mono text-[12.5px] leading-[1.55] no-underline transition-all max-[640px]:size-9 max-[640px]:p-0";
+  "inline-flex min-h-8 items-center justify-center whitespace-nowrap rounded-sm border px-2.5 py-1 font-mono text-[12.5px] leading-[1.55] no-underline transition-colors max-[640px]:size-8 max-[640px]:p-0";
 
 export const navCta = `${navCtaBase} border-hairline-2 text-fg-2 hover:border-accent-line hover:text-fg`;
 
 export const navCtaPrimary = `${navCtaBase} border-accent bg-accent font-semibold text-brand-dark hover:border-accent-bright hover:bg-accent-bright`;
 
-// Right-aligned nav action group: the icon-only Docs link plus the GitHub CTA.
+// Right-aligned nav action group: the Docs, Playground, and GitHub CTAs.
 export const navActions = "flex items-center justify-self-end gap-2";
 
 export const navPlaygroundLabel = "max-[640px]:hidden";
 
 export const navPlaygroundMark = "hidden size-4 max-[640px]:block";
 
-// Borderless, icon-only nav button. Sits next to the GitHub CTA; a micro
-// scale + color lift on hover gives it a tactile affordance without a box.
-export const navIcon =
-  "inline-flex items-center justify-center rounded-sm p-2 text-fg-3 transition-all duration-200 ease-out hover:scale-110 hover:text-fg";
+export const navDocsLabel = "max-[640px]:hidden";
+
+export const navDocsMark = "hidden size-4 max-[640px]:block";
 
 export const navGitHubLabel = "max-[640px]:hidden";
 


### PR DESCRIPTION
## Summary

**Header / nav chrome**
- Docs header on mobile no longer double-pads: the inner container owns the gutter, so the brand and action cluster align with the home/playground shells, and the dead zone before the hamburger is gone — every control (theme, search, Docs, Playground, GitHub, hamburger) sits at the same level, one even gap apart. Very narrow phones fall back to a tighter uniform gap so the full header still fits.
- Header CTAs are compact 2rem text buttons (same height as the docs search trigger), natural width, normalized side padding; they collapse to matching 2rem squares on small screens. Transitions now cover colors only, so late-applied stylesheets can never animate button geometry (the height bounce seen between page loads in dev).
- The Docs link is a word button on desktop and icon-only on small screens, in both the shared nav and the docs header.

**Home page**
- Removed the per-section arrow permalinks — they linked each section to itself.
- Fixed the demo tab strip's phantom vertical scroll on mobile: with only `overflow-x` set, the spec promotes `overflow-y` to `auto`, and the tabs' `-1px` bottom overhang made content 1px taller than the scrollport. The strip now hides overflow-y and draws its hairline as an inset shadow, keeping the active-tab underline overlay without the scroll.

**Docs pagination**
- A lone prev/next link keeps its half-width column (lone next stays right) instead of stretching across the content column.
- Wider gap between the arrow and the label block.
- Labels read "Back" / "Up next" via a Starlight i18n string override.

## Testing
- `pnpm --filter @web-ai-sdk-apps/site test` — 119/119 passing
- Verified in the browser at desktop, mid (~1000px, ~660px), and mobile (375px, 360px) widths across home, docs, and playground
- Note: `astro check` reports 8 pre-existing errors about `prepare*` exports from stale local package builds, unrelated to this change