### PR TITLE
feat(site): simplify hero CTA and drop install section

### DIFF
--- a/apps/site/src/features/home/components/ScrollSpy.tsx
+++ b/apps/site/src/features/home/components/ScrollSpy.tsx
@@ -8,7 +8,6 @@ const IDS = [
   "support",
   "how",
   "philosophy",
-  "start",
 ] as const;
 
 const scrollMarker = (): number => {

--- a/apps/site/src/pages/index.astro
+++ b/apps/site/src/pages/index.astro
@@ -5,7 +5,6 @@ import { InstallPill } from "../features/home/components/InstallPill.js";
 import { CityShader } from "../features/home/components/CityShader.js";
 import { PackageExplorer } from "../features/home/components/PackageExplorer.js";
 import { ScrollSpy } from "../features/home/components/ScrollSpy.js";
-import { StarWidget } from "../features/home/components/StarWidget.js";
 import { ThemeSwitcher } from "../features/home/components/ThemeSwitcher.js";
 import SiteNav from "../shared/components/SiteNav.astro";
 import * as ui from "../shared/ui.js";
@@ -89,12 +88,6 @@ const navItems = [
     id: "philosophy",
     label: "Why composable",
     summary: "SDK and application responsibilities.",
-    tick: "h-4",
-  },
-  {
-    id: "start",
-    label: "Get started",
-    summary: "Install everything or choose one package.",
     tick: "h-4",
   },
 ] as const;
@@ -490,7 +483,6 @@ const browserColumns = [
         </div>
         <div class={`${ui.container} ${ui.heroGrid}`}>
           <div class={`${ui.heroKicker} ${ui.heroTextBackdrop}`}>
-            <span class={ui.heroEyebrowDot}></span>
             <span>
               BROWSER-NATIVE AI · 0 RUNTIME DEPS ·
               <span class={ui.heroKickerDesktopLabel}> Open Source</span>
@@ -505,15 +497,9 @@ const browserColumns = [
             The TypeScript SDK for the Web AI surface.
           </p>
           <div class={ui.ctaRow}>
-            <a class={`${ui.btnPrimary} h-10`} href="#start">Get started</a>
-            <InstallPill pkg="@web-ai-sdk/all" client:idle />
-            <a class={`${ui.heroRepoLink} ${ui.heroTextBackdrop}`} href={repoUrl} target="_blank" rel="noreferrer">
-              <span>View on</span>
-              <svg class={ui.githubMark} viewBox="0 0 24 24" aria-hidden="true">
-                <path d="M10.226 17.284c-2.965-.36-5.054-2.493-5.054-5.256 0-1.123.404-2.336 1.078-3.144-.292-.741-.247-2.314.09-2.965.898-.112 2.111.36 2.83 1.01.853-.269 1.752-.404 2.853-.404 1.1 0 1.999.135 2.807.382.696-.629 1.932-1.1 2.83-.988.315.606.36 2.179.067 2.942.72.854 1.101 2 1.101 3.167 0 2.763-2.089 4.852-5.098 5.234.763.494 1.28 1.572 1.28 2.807v2.336c0 .674.561 1.056 1.235.786 4.066-1.55 7.255-5.615 7.255-10.646C23.5 6.188 18.334 1 11.978 1 5.62 1 .5 6.188.5 12.545c0 4.986 3.167 9.12 7.435 10.669.606.225 1.19-.18 1.19-.786V20.63a2.9 2.9 0 0 1-1.078.224c-1.483 0-2.359-.808-2.987-2.313-.247-.607-.517-.966-1.034-1.033-.27-.023-.359-.135-.359-.27 0-.27.45-.471.898-.471.652 0 1.213.404 1.797 1.235.45.651.921.943 1.483.943.561 0 .92-.202 1.437-.719.382-.381.674-.718.944-.943"></path>
-              </svg>
-              <span class={ui.srOnly}>GitHub</span>
-            </a>
+            <div class={ui.installGlow}>
+              <InstallPill pkg="@web-ai-sdk/all" client:idle />
+            </div>
           </div>
         </div>
       </header>
@@ -812,25 +798,6 @@ const browserColumns = [
         </div>
       </section>
 
-      <section class={ui.ctaSection} data-section="start">
-        <div class={ui.container}>
-          <div class={`${ui.ctaGlow} ${ui.sectionAnchor} ${ui.reveal}`} data-reveal id="start">
-            <div class={ui.ctaBlock}>
-              <div class={`${ui.sectionEyebrow} mb-5 justify-center`}>install</div>
-              <h2 class={`${ui.ctaBlockTitle} ${ui.gradientText}`}>Add it to your project.</h2>
-              <p class={ui.ctaBlockText}>
-                Install <code>@web-ai-sdk/all</code> or select an individual package. Each package includes ESM, CJS, and TypeScript declarations.
-              </p>
-              <InstallPill pkg="@web-ai-sdk/all" className="mx-auto" client:visible />
-              <div class={ui.ctaLinks}>
-                <a class={ui.ctaLink} href={docsUrl}>Read the docs <span>↗</span></a>
-                <a class={ui.ctaLink} href={repoUrl} target="_blank" rel="noreferrer">GitHub repo <span>↗</span></a>
-                <StarWidget repo={REPO} client:visible />
-              </div>
-            </div>
-          </div>
-        </div>
-      </section>
     </main>
 
     <footer class={ui.footer}>

--- a/apps/site/src/shared/ui.ts
+++ b/apps/site/src/shared/ui.ts
@@ -313,6 +313,11 @@ export const subhead =
 export const ctaRow =
   "mt-2 flex flex-wrap items-center gap-6 max-[640px]:w-full max-[640px]:flex-col max-[640px]:justify-center max-[640px]:gap-4";
 
+// Reduced cousin of ctaGlow behind the hero install pill: same drifting
+// gradient, but tighter and dimmer so it reads as an accent, not a spotlight.
+export const installGlow =
+  "relative z-0 isolate before:pointer-events-none before:absolute before:inset-0 before:-z-1 before:animate-rainbow-glow before:rounded-full before:bg-[linear-gradient(100deg,#d946ef_0%,#8b5cf6_24%,#3b82f6_48%,#06b6d4_70%,#22c55e_100%)] before:bg-[length:180%_100%] before:opacity-35 before:blur-[7px] before:will-change-[background-position] before:content-[''] max-[640px]:before:opacity-30 max-[640px]:before:blur-[5px]";
+
 const btnBase =
   "inline-flex cursor-pointer items-center gap-2.5 rounded-sm border px-5 py-3 font-mono text-[13px] tracking-[-0.005em] no-underline transition-all active:translate-y-px max-[640px]:px-4 max-[640px]:py-2.5 max-[640px]:text-[13px]";
 


### PR DESCRIPTION
## What

- Removes the hero **Get started** button and the `#start` install section it linked to, including its side-nav and scrollspy entries. The page now flows from "Why composable" straight into the footer; GitHub and docs links remain in the top nav and footer.
- Removes the redundant **View on GitHub** hero link and the kicker dot before "BROWSER-NATIVE AI".
- Adds `installGlow`, a reduced version of the removed section's `ctaGlow` rainbow halo, behind the hero install pill (tight blur, low opacity, same drifting gradient).

## Why

The hero already carries the install pill, so the button + bottom section duplicated the same action, and the GitHub link is covered by the nav and footer.

## Checks

- `astro check`: 0 errors / 0 warnings
- Verified locally in the dev server (desktop + narrow viewport)