### PR TITLE
feat(site): surface model-download progress in docs demos

### DIFF
--- a/apps/site/src/features/docs/components/DetectorDemo.tsx
+++ b/apps/site/src/features/docs/components/DetectorDemo.tsx
@@ -1,6 +1,10 @@
 import { useDetector } from "@web-ai-sdk/detector/react";
 import { useState } from "react";
-import { useDebouncedValue } from "../../../shared/demoLifecycle.js";
+import {
+  useDebouncedValue,
+  useDownloadMonitor,
+} from "../../../shared/demoLifecycle.js";
+import { DownloadProgress } from "./DownloadProgress.js";
 import { UnavailableHint } from "./UnavailableHint.js";
 
 export interface DetectorDemoProps {
@@ -15,7 +19,8 @@ export const DetectorDemo = ({
 }: DetectorDemoProps) => {
   const [text, setText] = useState(initial);
   const debounced = useDebouncedValue(text, DETECT_DEBOUNCE_MS);
-  const { status, output, error } = useDetector({ input: debounced });
+  const { progress, monitor } = useDownloadMonitor();
+  const { status, output, error } = useDetector({ input: debounced, monitor });
   const language = output?.language ?? null;
   const confidence = output?.confidence ?? 0;
   const all = output?.all ?? [];
@@ -57,6 +62,7 @@ export const DetectorDemo = ({
               {language} · {Math.round(confidence * 100)}%
             </span>
           )}
+          <DownloadProgress progress={progress} />
         </header>
         {status === "done" && all.length > 0 ? (
           <ol className="demo-list">

--- a/apps/site/src/features/docs/components/DownloadProgress.tsx
+++ b/apps/site/src/features/docs/components/DownloadProgress.tsx
@@ -1,0 +1,51 @@
+const DONUT_RADIUS = 5.5;
+const DONUT_CIRCUMFERENCE = 2 * Math.PI * DONUT_RADIUS;
+
+/**
+ * Minimal donut progress indicator for on-device model downloads, matching
+ * the home demos' treatment. Sits inline next to a demo's action row, so a
+ * first run that triggers a model download is visibly in progress instead
+ * of looking stalled. A custom tooltip carries the detail on hover or focus.
+ */
+export const DownloadProgress = ({ progress }: { progress: number | null }) => {
+  if (progress === null) return null;
+  const pct = Math.round(progress * 100);
+  const filled = (
+    Math.min(Math.max(progress, 0), 1) * DONUT_CIRCUMFERENCE
+  ).toFixed(2);
+  return (
+    // The aria-label on the live region carries the detail for keyboard and
+    // screen-reader users; the tooltip is pointer-hover supplementary text.
+    <span className="demo-tip-wrap">
+      <svg
+        width="14"
+        height="14"
+        viewBox="0 0 15 15"
+        role="status"
+        aria-label={`Downloading on-device model ${pct}%`}
+        className="demo-donut"
+      >
+        <circle
+          cx="7.5"
+          cy="7.5"
+          r={DONUT_RADIUS}
+          fill="none"
+          stroke="var(--demo-input-border)"
+          strokeWidth="2.5"
+        />
+        <circle
+          cx="7.5"
+          cy="7.5"
+          r={DONUT_RADIUS}
+          fill="none"
+          stroke="var(--sl-color-text-accent)"
+          strokeWidth="2.5"
+          strokeLinecap="round"
+          strokeDasharray={`${filled} ${DONUT_CIRCUMFERENCE.toFixed(2)}`}
+          transform="rotate(-90 7.5 7.5)"
+        />
+      </svg>
+      <span className="demo-tooltip">Downloading on-device model {pct}%</span>
+    </span>
+  );
+};

--- a/apps/site/src/features/docs/components/DownloadProgress.tsx
+++ b/apps/site/src/features/docs/components/DownloadProgress.tsx
@@ -16,7 +16,7 @@ export const DownloadProgress = ({ progress }: { progress: number | null }) => {
   return (
     // The aria-label on the live region carries the detail for keyboard and
     // screen-reader users; the tooltip is pointer-hover supplementary text.
-    <span className="demo-tip-wrap">
+    <span className="demo-tip-wrap demo-download">
       <svg
         width="14"
         height="14"

--- a/apps/site/src/features/docs/components/PromptDemo.tsx
+++ b/apps/site/src/features/docs/components/PromptDemo.tsx
@@ -4,6 +4,8 @@ import {
 } from "@web-ai-sdk/prompt/react";
 import { type ComponentProps, useState } from "react";
 import { ModelMarkdown } from "../../../shared/components/ModelMarkdown.js";
+import { useDownloadMonitor } from "../../../shared/demoLifecycle.js";
+import { DownloadProgress } from "./DownloadProgress.js";
 import { UnavailableHint } from "./UnavailableHint.js";
 
 export interface PromptDemoProps {
@@ -16,9 +18,11 @@ export const PromptDemo = ({
   samplingMode = "balanced",
 }: PromptDemoProps) => {
   const [input, setInput] = useState("What is React.js, in one sentence?");
+  const { progress, monitor } = useDownloadMonitor();
   const { status, output, error, ask, abort, reset } = usePrompt({
     systemPrompt,
     samplingMode,
+    monitor,
   });
 
   const onSubmit: ComponentProps<"form">["onSubmit"] = (e) => {
@@ -70,6 +74,7 @@ export const PromptDemo = ({
             Ask
           </button>
         )}
+        <DownloadProgress progress={progress} />
       </form>
       {error && <p className="demo-error">{error.message}</p>}
       {(output || busy) && (

--- a/apps/site/src/features/docs/components/ProofreaderDemo.tsx
+++ b/apps/site/src/features/docs/components/ProofreaderDemo.tsx
@@ -1,5 +1,7 @@
 import { useProofreader } from "@web-ai-sdk/proofreader/react";
 import { useState } from "react";
+import { useDownloadMonitor } from "../../../shared/demoLifecycle.js";
+import { DownloadProgress } from "./DownloadProgress.js";
 import { FreshRunAction } from "./FreshRunAction.js";
 import { UnavailableHint } from "./UnavailableHint.js";
 
@@ -20,11 +22,13 @@ export const ProofreaderDemo = () => {
   // stored result and writes under a new key. Old entries expire via TTL.
   const [freshNonce, setFreshNonce] = useState(0);
 
+  const { progress, monitor } = useDownloadMonitor();
   const { status, output, error, fromCache } = useProofreader({
     input: committed ?? "",
     cache: "session",
     cacheTtl: RESULT_TTL_MS,
     cacheKey: `docs-proofreader:${freshNonce}:${committed ?? ""}`,
+    monitor,
     enabled: enabled && committed !== null,
   });
 
@@ -92,6 +96,7 @@ export const ProofreaderDemo = () => {
           </button>
         )}
         <FreshRunAction show={status === "done" && !busy} onClick={freshRun} />
+        <DownloadProgress progress={progress} />
       </div>
       {error && <p className="demo-error">{error.message}</p>}
       {stale && (

--- a/apps/site/src/features/docs/components/RewriterDemo.tsx
+++ b/apps/site/src/features/docs/components/RewriterDemo.tsx
@@ -1,6 +1,8 @@
 import { useRewriter } from "@web-ai-sdk/rewriter/react";
 import { useState } from "react";
 import { ModelMarkdown } from "../../../shared/components/ModelMarkdown.js";
+import { useDownloadMonitor } from "../../../shared/demoLifecycle.js";
+import { DownloadProgress } from "./DownloadProgress.js";
 import { UnavailableHint } from "./UnavailableHint.js";
 
 const SAMPLE = "hey, can u send me that doc when u get a sec? thx a bunch";
@@ -14,11 +16,13 @@ export const RewriterDemo = ({ language = "en" }: { language?: string }) => {
   const [stopped, setStopped] = useState(false);
   const [dismissed, setDismissed] = useState(false);
 
+  const { progress, monitor } = useDownloadMonitor();
   const { status, output, error } = useRewriter({
     input: committed ?? "",
     language,
     tone: "more-formal",
     length: "as-is",
+    monitor,
     enabled: enabled && committed !== null,
   });
 
@@ -87,6 +91,7 @@ export const RewriterDemo = ({ language = "en" }: { language?: string }) => {
             Rewrite
           </button>
         )}
+        <DownloadProgress progress={progress} />
       </div>
       {error && <p className="demo-error">{error.message}</p>}
       {stale && (

--- a/apps/site/src/features/docs/components/SessionDemo.tsx
+++ b/apps/site/src/features/docs/components/SessionDemo.tsx
@@ -1,5 +1,7 @@
 import { useSession } from "@web-ai-sdk/prompt/react";
 import { type ChangeEvent, useEffect, useState } from "react";
+import { useDownloadMonitor } from "../../../shared/demoLifecycle.js";
+import { DownloadProgress } from "./DownloadProgress.js";
 import { UnavailableHint } from "./UnavailableHint.js";
 
 // Stable reference: an inline literal would recreate the session every render.
@@ -12,9 +14,11 @@ const EXPECTED_INPUTS = [{ type: "text" as const }, { type: "image" as const }];
  * forwarded to the model as-is.
  */
 export const SessionDemo = () => {
+  const { progress, monitor } = useDownloadMonitor();
   const { status, session, error } = useSession({
     systemPrompt: "You describe images. Reply with one short sentence.",
     expectedInputs: EXPECTED_INPUTS,
+    monitor,
   });
 
   const [file, setFile] = useState<File | null>(null);
@@ -120,6 +124,7 @@ export const SessionDemo = () => {
             Describe
           </button>
         )}
+        <DownloadProgress progress={progress} />
       </div>
       {previewUrl && (
         <img src={previewUrl} alt="selected preview" className="demo-preview" />

--- a/apps/site/src/features/docs/components/SummarizerDemo.tsx
+++ b/apps/site/src/features/docs/components/SummarizerDemo.tsx
@@ -1,6 +1,8 @@
 import { useSummarizer } from "@web-ai-sdk/summarizer/react";
 import { useEffect, useRef, useState } from "react";
 import { ModelMarkdown } from "../../../shared/components/ModelMarkdown.js";
+import { useDownloadMonitor } from "../../../shared/demoLifecycle.js";
+import { DownloadProgress } from "./DownloadProgress.js";
 import { FreshRunAction } from "./FreshRunAction.js";
 import { UnavailableHint } from "./UnavailableHint.js";
 
@@ -38,12 +40,14 @@ export const SummarizerDemo = ({ language = "en" }: SummarizerDemoProps) => {
     setInput(articleRef.current?.innerText ?? "");
   }, []);
 
+  const { progress, monitor } = useDownloadMonitor();
   const { status, output, error, fromCache } = useSummarizer({
     language,
     input,
     cache: "session",
     cacheTtl: RESULT_TTL_MS,
     cacheKey: `docs-summarizer:${language}:${freshNonce}`,
+    monitor,
     enabled: enabled && input.trim().length > 0,
   });
 
@@ -93,6 +97,7 @@ export const SummarizerDemo = ({ language = "en" }: SummarizerDemoProps) => {
           show={status === "done" && !busy && !dismissed}
           onClick={freshRun}
         />
+        <DownloadProgress progress={progress} />
       </div>
       {output && !dismissed && (
         <aside className="demo-response">

--- a/apps/site/src/features/docs/components/TranslatorDemo.tsx
+++ b/apps/site/src/features/docs/components/TranslatorDemo.tsx
@@ -1,6 +1,10 @@
 import { useTranslator } from "@web-ai-sdk/translator/react";
 import { useState } from "react";
-import { useDebouncedValue } from "../../../shared/demoLifecycle.js";
+import {
+  useDebouncedValue,
+  useDownloadMonitor,
+} from "../../../shared/demoLifecycle.js";
+import { DownloadProgress } from "./DownloadProgress.js";
 import { FreshRunAction } from "./FreshRunAction.js";
 import { UnavailableHint } from "./UnavailableHint.js";
 
@@ -25,6 +29,7 @@ export const TranslatorDemo = ({
   // Bumping the nonce changes the cache key, so a fresh generation skips the
   // stored result and writes under a new key. Old entries expire via TTL.
   const [freshNonce, setFreshNonce] = useState(0);
+  const { progress, monitor } = useDownloadMonitor();
   const { status, output, error, fromCache } = useTranslator({
     input: debounced,
     sourceLanguage,
@@ -32,6 +37,7 @@ export const TranslatorDemo = ({
     cache: "session",
     cacheTtl: RESULT_TTL_MS,
     cacheKey: `docs-translator:${sourceLanguage}:${targetLanguage}:${freshNonce}:${debounced}`,
+    monitor,
   });
   const pending = input !== debounced;
 
@@ -69,11 +75,14 @@ export const TranslatorDemo = ({
                     : `Translation (${targetLanguage})`}{" "}
             {status === "streaming" && <em>(streaming…)</em>}
           </span>
-          <FreshRunAction
-            show={status === "done" && !pending}
-            onClick={() => setFreshNonce((n) => n + 1)}
-            tooltipSide="right"
-          />
+          <span className="demo-response__actions">
+            <DownloadProgress progress={progress} />
+            <FreshRunAction
+              show={status === "done" && !pending}
+              onClick={() => setFreshNonce((n) => n + 1)}
+              tooltipSide="right"
+            />
+          </span>
         </header>
         <p className="demo-response__body">
           {output ?? (

--- a/apps/site/src/features/docs/components/WriterDemo.tsx
+++ b/apps/site/src/features/docs/components/WriterDemo.tsx
@@ -1,6 +1,8 @@
 import { useWriter } from "@web-ai-sdk/writer/react";
 import { useState } from "react";
 import { ModelMarkdown } from "../../../shared/components/ModelMarkdown.js";
+import { useDownloadMonitor } from "../../../shared/demoLifecycle.js";
+import { DownloadProgress } from "./DownloadProgress.js";
 import { UnavailableHint } from "./UnavailableHint.js";
 
 const SAMPLE =
@@ -15,11 +17,13 @@ export const WriterDemo = ({ language = "en" }: { language?: string }) => {
   const [stopped, setStopped] = useState(false);
   const [dismissed, setDismissed] = useState(false);
 
+  const { progress, monitor } = useDownloadMonitor();
   const { status, output, error } = useWriter({
     input: committed ?? "",
     language,
     tone: "casual",
     length: "short",
+    monitor,
     enabled: enabled && committed !== null,
   });
 
@@ -88,6 +92,7 @@ export const WriterDemo = ({ language = "en" }: { language?: string }) => {
             Write
           </button>
         )}
+        <DownloadProgress progress={progress} />
       </div>
       {error && <p className="demo-error">{error.message}</p>}
       {stale && (

--- a/apps/site/src/features/docs/styles/demos.css
+++ b/apps/site/src/features/docs/styles/demos.css
@@ -33,6 +33,7 @@
   --demo-muted-fg: var(--sl-color-gray-3);
   --demo-hint-bg: var(--sl-color-gray-7);
 
+
   /* Warn hint (unavailable APIs): amber tint matching the home page's
      UnavailableNotice. fg darkens in light mode for contrast (see dark block). */
   --demo-warn-bg: color-mix(in oklch, var(--color-warn) 14%, var(--sl-color-bg));
@@ -80,6 +81,7 @@
   --demo-panel-bg: color-mix(in oklch, var(--sl-color-gray-6) 50%, var(--sl-color-bg));
   --demo-error-fg: oklch(0.72 0.18 25);
   --demo-warn-fg: var(--color-warn);
+
 }
 
 /* ---------- shared building blocks ---------- */
@@ -329,6 +331,17 @@
   color: var(--sl-color-text);
 }
 
+/* Starlight sets `isolation: isolate` on `.main-pane`, so its later sibling
+   (the right sidebar) paints over floating tooltips no matter their z-index.
+   Raise the pane one level: the pane's box never overlaps the sidebar column,
+   so only overhanging tooltips (pointer-events: none) are affected. */
+.main-pane {
+  position: relative;
+  z-index: 1;
+}
+
+/* Surface matches `.inline-code-tip` (web-ai-sdk.css) exactly, so every
+   floating tooltip in the docs reads as the same chip. */
 .demo-tooltip {
   pointer-events: none;
   position: absolute;
@@ -336,11 +349,14 @@
   left: 0;
   z-index: 50;
   white-space: nowrap;
-  border-radius: var(--radius-sm);
-  background: var(--demo-hint-bg);
-  padding: 6px 10px;
-  font-size: 11px;
-  color: var(--sl-color-text);
+  padding: 0.2rem 0.5rem;
+  border: 1px solid var(--sl-color-hairline-light);
+  border-radius: 0.375rem;
+  background: var(--sl-color-black);
+  color: var(--sl-color-gray-2);
+  font-family: var(--sl-font-sans);
+  font-size: 0.75rem;
+  line-height: 1.4;
   opacity: 0;
   visibility: hidden;
   transition: opacity 0.15s ease;
@@ -349,6 +365,13 @@
 .demo-tooltip--right {
   left: auto;
   right: 0;
+}
+
+/* Icon buttons pad a 16px glyph inside a 32px hit-area, which pushes their
+   tooltip visibly farther from the glyph than the download donut's. Pull the
+   tooltip in so the visual gap from the glyph matches the donut's 8px. */
+.demo-tip-wrap:has(> .demo-icon-button) .demo-tooltip {
+  bottom: 100%;
 }
 
 .demo-tip-wrap:hover .demo-tooltip,
@@ -361,6 +384,12 @@
    model. The dasharray transition smooths progress-event jumps. */
 .demo-donut {
   flex-shrink: 0;
+}
+
+/* Breathing room between the donut and whatever control precedes it (the
+   demo-row gap alone reads too tight next to a filled CTA). */
+.demo-download:not(:first-child) {
+  margin-inline-start: 6px;
 }
 
 .demo-donut circle:last-child {

--- a/apps/site/src/features/docs/styles/demos.css
+++ b/apps/site/src/features/docs/styles/demos.css
@@ -229,6 +229,12 @@
   margin-bottom: 6px;
 }
 
+.demo-response__actions {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+}
+
 .demo-response__body {
   margin: 0;
   white-space: pre-wrap;
@@ -349,6 +355,16 @@
 .demo-tip-wrap:focus-within .demo-tooltip {
   opacity: 1;
   visibility: visible;
+}
+
+/* Model-download donut shown while a demo's first run pulls the on-device
+   model. The dasharray transition smooths progress-event jumps. */
+.demo-donut {
+  flex-shrink: 0;
+}
+
+.demo-donut circle:last-child {
+  transition: stroke-dasharray 0.2s ease-out;
 }
 
 /* Reserved footprint for a client-only demo island. The slot keeps the

--- a/apps/site/src/features/home/components/shared.tsx
+++ b/apps/site/src/features/home/components/shared.tsx
@@ -1,4 +1,4 @@
-import { type ReactNode, useCallback, useRef, useState } from "react";
+import { type ReactNode, useRef, useState } from "react";
 import { ModelMarkdown } from "../../../shared/components/ModelMarkdown.js";
 import {
   caret,
@@ -25,53 +25,9 @@ export interface DemoIntentProps {
   intent?: boolean;
 }
 
-interface DownloadProgressEvent extends Event {
-  readonly loaded: number;
-}
-interface CreateMonitor {
-  addEventListener(
-    type: "downloadprogress",
-    listener: (event: DownloadProgressEvent) => void,
-  ): void;
-}
-
-/**
- * Wire a Built-in AI `monitor` callback to React state. Returns the
- * monitor function to pass into `createOptions.monitor`, plus the current
- * progress (a fraction from 0..1) or `null` when no download is in flight.
- * Warm-model creations emit `downloadprogress` with loaded 0 and 1 only;
- * those events are ignored so the indicator surfaces for real downloads.
- */
-export const useDownloadMonitor = () => {
-  const [progress, setProgress] = useState<number | null>(null);
-  // Tracked outside React state so completion can schedule its clear timer
-  // without side effects inside a state updater.
-  const visibleRef = useRef(false);
-
-  const monitor = useCallback((m: CreateMonitor) => {
-    m.addEventListener("downloadprogress", (e) => {
-      if (e.loaded <= 0) return;
-      if (e.loaded >= 1) {
-        // Settle to "complete" briefly, then clear; stay hidden when no
-        // fractional progress ever showed (warm start).
-        if (!visibleRef.current) return;
-        visibleRef.current = false;
-        setProgress(1);
-        setTimeout(() => setProgress(null), 900);
-        return;
-      }
-      visibleRef.current = true;
-      setProgress(e.loaded);
-    });
-  }, []);
-
-  const clear = useCallback(() => {
-    visibleRef.current = false;
-    setProgress(null);
-  }, []);
-
-  return { progress, monitor, clear };
-};
+// The download monitor lives in the shared lifecycle module so docs demos
+// can reuse it; re-exported here to keep the home demos' import surface.
+export { useDownloadMonitor } from "../../../shared/demoLifecycle.js";
 
 export const ErrorNotice = ({ error }: { error: string | null }) => {
   if (!error) return null;

--- a/apps/site/src/shared/demoLifecycle.ts
+++ b/apps/site/src/shared/demoLifecycle.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 
 /** Shape shared by every `prepare*()` lease across the SDK packages. */
 export interface CapabilityLease {
@@ -41,6 +41,54 @@ export const useCapabilityLease = (
     lease.ready.catch(() => {});
     return () => lease.release();
   }, [intent, createLease]);
+};
+
+interface DownloadProgressEvent extends Event {
+  readonly loaded: number;
+}
+interface CreateMonitor {
+  addEventListener(
+    type: "downloadprogress",
+    listener: (event: DownloadProgressEvent) => void,
+  ): void;
+}
+
+/**
+ * Wire a Built-in AI `monitor` callback to React state. Returns the
+ * monitor function to pass into `createOptions.monitor`, plus the current
+ * progress (a fraction from 0..1) or `null` when no download is in flight.
+ * Warm-model creations emit `downloadprogress` with loaded 0 and 1 only;
+ * those events are ignored so the indicator surfaces for real downloads.
+ */
+export const useDownloadMonitor = () => {
+  const [progress, setProgress] = useState<number | null>(null);
+  // Tracked outside React state so completion can schedule its clear timer
+  // without side effects inside a state updater.
+  const visibleRef = useRef(false);
+
+  const monitor = useCallback((m: CreateMonitor) => {
+    m.addEventListener("downloadprogress", (e) => {
+      if (e.loaded <= 0) return;
+      if (e.loaded >= 1) {
+        // Settle to "complete" briefly, then clear; stay hidden when no
+        // fractional progress ever showed (warm start).
+        if (!visibleRef.current) return;
+        visibleRef.current = false;
+        setProgress(1);
+        setTimeout(() => setProgress(null), 900);
+        return;
+      }
+      visibleRef.current = true;
+      setProgress(e.loaded);
+    });
+  }, []);
+
+  const clear = useCallback(() => {
+    visibleRef.current = false;
+    setProgress(null);
+  }, []);
+
+  return { progress, monitor, clear };
 };
 
 /**


### PR DESCRIPTION
## What

The docs demos were the only surface with no feedback while a first run pulls the on-device model — the hook sits in `loading` and the demo looks stalled (home shows a download donut; the playground shows a readiness notice). This wires the same donut treatment into the docs demos.

- Moved `useDownloadMonitor` from the home demos' shared module into `shared/demoLifecycle.ts` so both surfaces reuse it; the home module re-exports it, so home demo imports are unchanged.
- Added `DownloadProgress`, a docs-side donut matching the home `DownloadDonut`, styled with the Starlight-aware demo CSS variables (`--demo-input-border` track, `--sl-color-text-accent` fill) and the existing `demo-tip-wrap`/`demo-tooltip` tooltip, with an `aria-label` live region carrying the percent.
- Passed the `monitor` option into all eight model-backed docs demos: Prompt, Session, Writer, Rewriter, Proofreader, Summarizer, Translator, and Detector (WebMCP registers tools and creates no model). Button-row demos render the donut inline next to the action; the auto-run Translator and Detector demos render it in the response header.

Warm-start creations that emit only 0/1 progress events stay hidden, so the donut appears only for real downloads — same behavior as home.

## Testing

- `pnpm test` (site): 119 tests pass
- `astro check`: 0 errors
- `biome check`: clean
- Verified in the browser: docs demo pages render with no console errors, the donut's CSS variables resolve in the Starlight theme (checked via an injected probe in the Translator response header), and the home demos still work through the re-export.