### PR TITLE
feat(site): improve playground layout

### DIFF
--- a/apps/site/src/features/playground/Playground.tsx
+++ b/apps/site/src/features/playground/Playground.tsx
@@ -194,9 +194,6 @@ export function Playground() {
           liveThought={liveThought}
           stopReason={stopReason}
           busy={busy}
-          conversationsOpen={layout.conversationsOpen}
-          runtimeOpen={layout.runtimeOpen}
-          onShowRuntime={layout.showRuntime}
           composer={{
             draft,
             promptOn,

--- a/apps/site/src/features/playground/PlaygroundFallback.astro
+++ b/apps/site/src/features/playground/PlaygroundFallback.astro
@@ -39,7 +39,6 @@ const truncateExample = (value: string, limit = 60) =>
   data-markdown-inline-code-class={ui.markdownInlineCode}
   data-boot-message-class={ui.bootMessage}
   data-main-header-scrolled-class={ui.mainHeaderScrolled}
-  data-main-header-left-restore-class={ui.mainHeaderWithLeftRestore}
   data-layout-mobile-with-sidebar-class={ui.shellMobileWithSidebar}
   data-layout-mobile-without-sidebar-class={ui.shellMobileWithoutSidebar}
   data-panel-slot-open-class={ui.panelSlotOpen}
@@ -162,73 +161,45 @@ const truncateExample = (value: string, limit = 60) =>
       <header
         class:list={[ui.mainHeader, ui.mainHeaderBoot]}
         data-playground-main-header
-      >
-        <div class={ui.mainHeaderInner}>
-          <h2 class={ui.title} data-playground-title>New conversation</h2>
-          <span
-            class={ui.panelRestoreRightMobile}
-            data-playground-right-restore-mobile
-            hidden
-          >
-            <span class={ui.panelToggle}>
-              <svg
-                class={ui.panelToggleIcon}
-                viewBox="0 0 18 18"
-                fill="none"
-                aria-hidden="true"
-              >
-                <rect
-                  x="2.25"
-                  y="2.75"
-                  width="13.5"
-                  height="12.5"
-                  rx="2.25"
-                  stroke="currentColor"
-                  stroke-width="1.25"></rect>
-                <path
-                  d="M11.5 3.25v11.5"
-                  stroke="currentColor"
-                  stroke-width="1.25"></path>
-              </svg>
-            </span>
-          </span>
-        </div>
-      </header>
+      />
 
-      <div class={ui.mainBody}>
-        <section class={ui.transcriptPanel}>
-          <div class={ui.answer} data-playground-transcript>
-            <div class={ui.emptyConversation}>
-              <h2 class={ui.emptyConversationTitle}>Start a conversation</h2>
-              <p class={ui.emptyConversationText}>
-                Messages, tool calls, and answers will appear here.
-              </p>
-            </div>
-          </div>
-        </section>
-
+      <div class={ui.mainBodyCentered}>
         <div class={ui.composerDock}>
+          <div class={ui.exampleFloat}>
+            <div class={ui.examples} data-playground-examples>
+              {
+                defaultMode.examples.slice(0, 3).map((example) => (
+                  <span class={ui.example} title={example}>
+                    {truncateExample(example)}
+                  </span>
+                ))
+              }
+            </div>
+            <span class={ui.exampleRegenerateWrap}>
+              <span class={ui.exampleRegenerate} aria-hidden="true">+</span>
+            </span>
+          </div>
           <div class={ui.composer}>
             <div class={ui.modeSelector}>
-              <span class={ui.modeTrigger} data-playground-mode-trigger data-accent="warn">
-                <span
-                  class={ui.modeTriggerName}
-                  data-playground-mode-name
-                  data-accent="warn"
-                >
-                  Platform reach
-                </span>
+              <span
+                class={ui.modeTrigger}
+                data-playground-mode-trigger
+                data-accent="warn"
+                aria-label="Mode: Platform reach"
+              >
                 <svg
-                  class={ui.modeTriggerChevron}
+                  class={ui.modeTriggerIcon}
+                  data-playground-mode-icon
+                  data-accent="warn"
                   viewBox="0 0 16 16"
                   fill="none"
                   aria-hidden="true"
                 >
+                  <circle cx="8" cy="8" r="5.75" stroke="currentColor" stroke-width="1.2"></circle>
                   <path
-                    d="m4.5 6 3.5 3.5L11.5 6"
+                    d="M2.5 8h11M8 2.25c1.7 1.6 2.65 3.6 2.65 5.75S9.7 12.15 8 13.75c-1.7-1.6-2.65-3.6-2.65-5.75S6.3 3.85 8 2.25Z"
                     stroke="currentColor"
-                    stroke-width="1.4"
-                    stroke-linecap="round"
+                    stroke-width="1.1"
                     stroke-linejoin="round"></path>
                 </svg>
               </span>
@@ -249,20 +220,6 @@ const truncateExample = (value: string, limit = 60) =>
                 ↑
               </button>
             </div>
-          </div>
-          <div class={ui.exampleFloat}>
-            <div class={ui.examples} data-playground-examples>
-              {
-                defaultMode.examples.slice(0, 3).map((example) => (
-                  <span class={ui.example} title={example}>
-                    {truncateExample(example)}
-                  </span>
-                ))
-              }
-            </div>
-            <span class={ui.exampleRegenerateWrap}>
-              <span class={ui.exampleRegenerate} aria-hidden="true">+</span>
-            </span>
           </div>
         </div>
       </div>
@@ -624,6 +581,7 @@ const truncateExample = (value: string, limit = 60) =>
 
       try {
         const desktopRuntime = matchMedia("(min-width: 1181px)").matches;
+        const mobileLayout = matchMedia("(max-width: 760px)").matches;
         let conversationsOpen = true;
         let runtimeOpen = desktopRuntime;
         try {
@@ -642,6 +600,7 @@ const truncateExample = (value: string, limit = 60) =>
         } catch {
           // Invalid layout state falls back to the responsive defaults.
         }
+        if (mobileLayout) conversationsOpen = true;
 
         const sidebarWidth = Number(
           localStorage.getItem(fallback.dataset.sidebarStorageKey ?? ""),
@@ -668,9 +627,6 @@ const truncateExample = (value: string, limit = 60) =>
           const sidebar = fallback.querySelector("[data-playground-sidebar]");
           const workspaceSlot = fallback.querySelector(
             "[data-playground-workspace-slot]",
-          );
-          const mainHeader = fallback.querySelector(
-            "[data-playground-main-header]",
           );
           layoutGrid?.classList.remove(
             ...(fallback.dataset.layoutMobileWithSidebarClass ?? "")
@@ -704,11 +660,6 @@ const truncateExample = (value: string, limit = 60) =>
           );
           workspaceSlot?.classList.remove(
             ...(fallback.dataset.workspaceBelowMobileSidebarClass ?? "")
-              .split(" ")
-              .filter(Boolean),
-          );
-          mainHeader?.classList.add(
-            ...(fallback.dataset.mainHeaderLeftRestoreClass ?? "")
               .split(" ")
               .filter(Boolean),
           );
@@ -746,13 +697,7 @@ const truncateExample = (value: string, limit = 60) =>
           const rightRestore = fallback.querySelector(
             "[data-playground-right-restore]",
           );
-          const rightRestoreMobile = fallback.querySelector(
-            "[data-playground-right-restore-mobile]",
-          );
           if (rightRestore instanceof HTMLElement) rightRestore.hidden = false;
-          if (rightRestoreMobile instanceof HTMLElement) {
-            rightRestoreMobile.hidden = false;
-          }
         }
 
         const raw = localStorage.getItem(fallback.dataset.storageKey ?? "");
@@ -789,20 +734,17 @@ const truncateExample = (value: string, limit = 60) =>
         const mode = modes[modeId] ?? modes.platform;
         if (!mode) return;
 
-        const title = fallback.querySelector("[data-playground-title]");
-        if (title) title.textContent = active.name;
-
         const modeTrigger = fallback.querySelector(
           "[data-playground-mode-trigger]",
         );
-        const modeName = fallback.querySelector("[data-playground-mode-name]");
+        const modeIcon = fallback.querySelector("[data-playground-mode-icon]");
         const toolCount = fallback.querySelector("[data-playground-tool-count]");
         if (modeTrigger instanceof HTMLElement) {
           modeTrigger.dataset.accent = mode.accent;
+          modeTrigger.setAttribute("aria-label", `Mode: ${mode.name}`);
         }
-        if (modeName instanceof HTMLElement) {
-          modeName.textContent = mode.name;
-          modeName.dataset.accent = mode.accent;
+        if (modeIcon instanceof HTMLElement) {
+          modeIcon.dataset.accent = mode.accent;
         }
         if (toolCount) {
           toolCount.textContent =

--- a/apps/site/src/features/playground/components/Composer.test.tsx
+++ b/apps/site/src/features/playground/components/Composer.test.tsx
@@ -137,7 +137,7 @@ describe("Composer", () => {
     expect(link?.getAttribute("href")).toContain("docs/browser-support");
   });
 
-  it("floats example suggestions only while the draft is empty and idle", () => {
+  it("shows example suggestions only while the draft is empty and idle", () => {
     const typed = renderComposer({ draft: "hello" });
     expect(typed.container.querySelector("[title*='Summarize']")).toBeNull();
 
@@ -152,6 +152,18 @@ describe("Composer", () => {
 
     const idle = renderComposer();
     expect(idle.container.querySelector("[title*='Summarize']")).not.toBeNull();
+  });
+
+  it("keeps examples in flow without adding top spacing", () => {
+    const { container } = renderComposer();
+    const example = container.querySelector("[title*='Summarize']");
+    const suggestionRow = example?.parentElement?.parentElement;
+    expect(suggestionRow?.className).toContain(
+      "bg-[linear-gradient(to_top,var(--color-bg)_62%,transparent)]",
+    );
+    expect(suggestionRow?.className).not.toContain("absolute");
+    expect(suggestionRow?.className).not.toContain("shadow-");
+    expect(suggestionRow?.className).not.toContain(" pt-");
   });
 
   it("keeps primary controls before example suggestions in tab order", () => {

--- a/apps/site/src/features/playground/components/Composer.tsx
+++ b/apps/site/src/features/playground/components/Composer.tsx
@@ -7,6 +7,7 @@ import {
   type PromptReadiness,
   promptReadinessMessage,
 } from "../lib/promptReadiness.js";
+import { ModeIcon } from "./ModeIcon.js";
 
 const browserSupportHref = `${import.meta.env.BASE_URL}docs/browser-support/`;
 
@@ -84,6 +85,39 @@ export function Composer({
         )}
       </div>
 
+      {promptOn && !busy && !error && !draft.trim() && (
+        <div className={ui.exampleFloat}>
+          <div className={ui.examples}>
+            {examples.map((example) => (
+              <button
+                key={example}
+                type="button"
+                className={ui.example}
+                onClick={() => onSubmitExample(example)}
+                title={example}
+              >
+                {truncate(example)}
+              </button>
+            ))}
+          </div>
+          <span className={ui.exampleRegenerateWrap}>
+            <button
+              type="button"
+              className={ui.exampleRegenerate}
+              onClick={onRegenerateExamples}
+              disabled={generatingExamples || !canRegenerateExamples}
+              aria-label="Generate new examples"
+              aria-busy={generatingExamples}
+            >
+              <span aria-hidden="true">+</span>
+            </button>
+            <span role="tooltip" className={ui.exampleRegenerateTooltip}>
+              Generate new examples
+            </span>
+          </span>
+        </div>
+      )}
+
       <form className={ui.composer} onSubmit={submit}>
         <div className={ui.modeSelector} ref={modeMenuRef}>
           <button
@@ -96,28 +130,11 @@ export function Composer({
             aria-expanded={modeMenuOpen}
             aria-controls="playground-mode-menu"
           >
-            <span
-              className={ui.modeTriggerName}
+            <ModeIcon
+              modeId={activeMode.id}
+              className={ui.modeTriggerIcon}
               data-accent={activeMode.accent}
-            >
-              {activeMode.name}
-            </span>
-            <svg
-              className={
-                modeMenuOpen ? ui.modeTriggerChevronOpen : ui.modeTriggerChevron
-              }
-              viewBox="0 0 16 16"
-              fill="none"
-              aria-hidden="true"
-            >
-              <path
-                d="m4.5 6 3.5 3.5L11.5 6"
-                stroke="currentColor"
-                strokeWidth="1.4"
-                strokeLinecap="round"
-                strokeLinejoin="round"
-              />
-            </svg>
+            />
           </button>
           {modeMenuOpen && promptOn && (
             <div className={ui.modeMenu}>
@@ -148,10 +165,10 @@ export function Composer({
                       <span className={ui.modeOptionCopy}>
                         <span className={ui.modeOptionTitleRow}>
                           <span className={ui.modeOptionIdentity}>
-                            <span
-                              className={ui.modeAccentDot}
+                            <ModeIcon
+                              modeId={mode.id}
+                              className={ui.modeOptionIcon}
                               data-accent={mode.accent}
-                              aria-hidden="true"
                             />
                             <span
                               className={ui.modeOptionName}
@@ -223,39 +240,6 @@ export function Composer({
           )}
         </div>
       </form>
-
-      {promptOn && !busy && !error && !draft.trim() && (
-        <div className={ui.exampleFloat}>
-          <div className={ui.examples}>
-            {examples.map((example) => (
-              <button
-                key={example}
-                type="button"
-                className={ui.example}
-                onClick={() => onSubmitExample(example)}
-                title={example}
-              >
-                {truncate(example)}
-              </button>
-            ))}
-          </div>
-          <span className={ui.exampleRegenerateWrap}>
-            <button
-              type="button"
-              className={ui.exampleRegenerate}
-              onClick={onRegenerateExamples}
-              disabled={generatingExamples || !canRegenerateExamples}
-              aria-label="Generate new examples"
-              aria-busy={generatingExamples}
-            >
-              <span aria-hidden="true">+</span>
-            </button>
-            <span role="tooltip" className={ui.exampleRegenerateTooltip}>
-              Generate new examples
-            </span>
-          </span>
-        </div>
-      )}
     </div>
   );
 }

--- a/apps/site/src/features/playground/components/ConversationTrack.tsx
+++ b/apps/site/src/features/playground/components/ConversationTrack.tsx
@@ -40,14 +40,7 @@ export function ConversationTrack({
   const hasLiveTurn =
     Boolean(currentInput) || events.length > 0 || text || busy || stopReason;
   if (turns.length === 0 && !hasLiveTurn) {
-    return (
-      <div className={ui.emptyConversation}>
-        <div className={ui.emptyConversationTitle}>Start a conversation</div>
-        <p className={ui.emptyConversationText}>
-          Messages, tool calls, and answers will appear here.
-        </p>
-      </div>
-    );
+    return null;
   }
 
   const visibleTurns: TranscriptTurn[] = turns.map((turn) => ({

--- a/apps/site/src/features/playground/components/ConversationView.tsx
+++ b/apps/site/src/features/playground/components/ConversationView.tsx
@@ -9,7 +9,6 @@ import type { AgentThread } from "../lib/agentThreads.js";
 import { useStickToBottom } from "../lib/useStickToBottom.js";
 import { Composer, type ComposerProps } from "./Composer.js";
 import { ConversationTrack } from "./ConversationTrack.js";
-import { PanelToggle } from "./PanelToggle.js";
 
 interface Props {
   thread: AgentThread;
@@ -21,9 +20,6 @@ interface Props {
   liveThought: { index: number; text: string } | null;
   stopReason: AgentStopReason | null;
   busy: boolean;
-  conversationsOpen: boolean;
-  runtimeOpen: boolean;
-  onShowRuntime: () => void;
   composer: ComposerProps;
 }
 
@@ -37,9 +33,6 @@ export function ConversationView({
   liveThought,
   stopReason,
   busy,
-  conversationsOpen,
-  runtimeOpen,
-  onShowRuntime,
   composer,
 }: Props) {
   const transcriptRef = useRef<HTMLDivElement>(null);
@@ -54,6 +47,14 @@ export function ConversationView({
     events.length,
     liveThought?.text,
   ]);
+
+  const hasLiveTurn =
+    Boolean(currentInput) ||
+    events.length > 0 ||
+    Boolean(text) ||
+    busy ||
+    Boolean(stopReason);
+  const isEmpty = thread.turns.length === 0 && !hasLiveTurn;
 
   // Persisted local conversations should render at their final scroll
   // position. Streaming updates can then follow without animating through the
@@ -75,31 +76,13 @@ export function ConversationView({
   return (
     <div className={ui.main}>
       <header
-        className={`${ui.mainHeader} ${
-          hasScrolled ? ui.mainHeaderScrolled : ""
-        } ${conversationsOpen ? "" : ui.mainHeaderWithLeftRestore}`}
+        className={`${ui.mainHeader} ${hasScrolled ? ui.mainHeaderScrolled : ""}`}
         data-playground-main-header
-      >
-        <div className={ui.mainHeaderInner}>
-          <h2 className={ui.title}>{thread.name}</h2>
-          {!runtimeOpen && (
-            <span className={ui.panelRestoreRightMobile}>
-              <PanelToggle side="right" open={false} onClick={onShowRuntime} />
-            </span>
-          )}
-        </div>
-      </header>
+      />
 
-      <div className={ui.mainBody}>
-        <section className={ui.transcriptPanel}>
-          <div
-            ref={transcriptRef}
-            className={ui.answer}
-            data-playground-transcript
-            onScroll={(event) =>
-              setHasScrolled(event.currentTarget.scrollTop > 1)
-            }
-          >
+      <div className={isEmpty ? ui.mainBodyCentered : ui.mainBody}>
+        {isEmpty ? (
+          <>
             <ConversationTrack
               turns={thread.turns}
               currentTurnId={currentTurnId}
@@ -112,21 +95,48 @@ export function ConversationView({
               transcriptRendererId={mode.transcriptRendererId}
               toolRendererId={mode.toolRendererId}
             />
-          </div>
-          {!isPinned && (
-            <button
-              type="button"
-              className={ui.jump}
-              onClick={() => scrollToBottom()}
-              aria-label="Scroll to latest"
-              title="Scroll to latest"
-            >
-              <span aria-hidden="true">↓</span>
-            </button>
-          )}
-        </section>
+            <Composer {...composer} />
+          </>
+        ) : (
+          <>
+            <section className={ui.transcriptPanel}>
+              <div
+                ref={transcriptRef}
+                className={ui.answer}
+                data-playground-transcript
+                onScroll={(event) =>
+                  setHasScrolled(event.currentTarget.scrollTop > 1)
+                }
+              >
+                <ConversationTrack
+                  turns={thread.turns}
+                  currentTurnId={currentTurnId}
+                  currentInput={currentInput}
+                  events={events}
+                  text={text}
+                  liveThought={liveThought}
+                  stopReason={stopReason}
+                  busy={busy}
+                  transcriptRendererId={mode.transcriptRendererId}
+                  toolRendererId={mode.toolRendererId}
+                />
+              </div>
+              {!isPinned && (
+                <button
+                  type="button"
+                  className={ui.jump}
+                  onClick={() => scrollToBottom()}
+                  aria-label="Scroll to latest"
+                  title="Scroll to latest"
+                >
+                  <span aria-hidden="true">↓</span>
+                </button>
+              )}
+            </section>
 
-        <Composer {...composer} />
+            <Composer {...composer} />
+          </>
+        )}
       </div>
     </div>
   );

--- a/apps/site/src/features/playground/components/ModeIcon.tsx
+++ b/apps/site/src/features/playground/components/ModeIcon.tsx
@@ -1,0 +1,94 @@
+import type { ReactNode, SVGProps } from "react";
+
+interface Props extends SVGProps<SVGSVGElement> {
+  modeId: string;
+}
+
+/** One glyph per agent mode, used in both the mode trigger and the mode menu. */
+export function ModeIcon({ modeId, ...svgProps }: Props) {
+  const path = ICONS[modeId] ?? ICONS.minimal;
+  return (
+    <svg viewBox="0 0 16 16" fill="none" aria-hidden="true" {...svgProps}>
+      {path}
+    </svg>
+  );
+}
+
+const ICONS: Record<string, ReactNode> = {
+  minimal: (
+    <circle cx="8" cy="8" r="4.5" stroke="currentColor" strokeWidth="1.4" />
+  ),
+  "web-ai-suite": (
+    <>
+      <rect
+        x="2.75"
+        y="2.75"
+        width="7"
+        height="7"
+        rx="1.4"
+        stroke="currentColor"
+        strokeWidth="1.3"
+      />
+      <rect
+        x="6.25"
+        y="6.25"
+        width="7"
+        height="7"
+        rx="1.4"
+        stroke="currentColor"
+        strokeWidth="1.3"
+      />
+    </>
+  ),
+  platform: (
+    <>
+      <circle cx="8" cy="8" r="5.75" stroke="currentColor" strokeWidth="1.2" />
+      <path
+        d="M2.5 8h11M8 2.25c1.7 1.6 2.65 3.6 2.65 5.75S9.7 12.15 8 13.75c-1.7-1.6-2.65-3.6-2.65-5.75S6.3 3.85 8 2.25Z"
+        stroke="currentColor"
+        strokeWidth="1.1"
+        strokeLinejoin="round"
+      />
+    </>
+  ),
+  "kitchen-sink": (
+    <>
+      <rect
+        x="2.25"
+        y="2.25"
+        width="4.75"
+        height="4.75"
+        rx="1.1"
+        stroke="currentColor"
+        strokeWidth="1.3"
+      />
+      <rect
+        x="9"
+        y="2.25"
+        width="4.75"
+        height="4.75"
+        rx="1.1"
+        stroke="currentColor"
+        strokeWidth="1.3"
+      />
+      <rect
+        x="2.25"
+        y="9"
+        width="4.75"
+        height="4.75"
+        rx="1.1"
+        stroke="currentColor"
+        strokeWidth="1.3"
+      />
+      <rect
+        x="9"
+        y="9"
+        width="4.75"
+        height="4.75"
+        rx="1.1"
+        stroke="currentColor"
+        strokeWidth="1.3"
+      />
+    </>
+  ),
+};

--- a/apps/site/src/features/playground/components/PlaygroundLayout.test.tsx
+++ b/apps/site/src/features/playground/components/PlaygroundLayout.test.tsx
@@ -20,6 +20,56 @@ afterEach(() => {
 });
 
 describe("PlaygroundLayout", () => {
+  it("fades transcript content before the scroll boundary", () => {
+    expect(ui.transcriptPanel).toContain(
+      "after:bg-[linear-gradient(to_top,var(--color-bg)_0%,color-mix(in_oklch,var(--color-bg)_82%,transparent)_45%,transparent_100%)]",
+    );
+    expect(ui.answer).toContain("pb-10");
+  });
+
+  it("positions the runtime restore control below the mobile conversation row", () => {
+    const container = document.createElement("div");
+    document.body.append(container);
+    root = createRoot(container);
+    const noop = vi.fn();
+    const layout = {
+      shellRef: createRef<HTMLDivElement>(),
+      shellStyle: {},
+      gridClassName: "",
+      sidebarWidth: 260,
+      conversationsOpen: true,
+      runtimeOpen: false,
+      showConversations: noop,
+      hideConversations: noop,
+      showRuntime: noop,
+      hideRuntime: noop,
+      startSidebarResize: noop,
+      resizeSidebar: noop,
+      finishSidebarResize: noop,
+      handleLostPointerCapture: noop,
+      resizeSidebarFromKeyboard: noop,
+      resetSidebarWidth: noop,
+    } satisfies PlaygroundLayoutController;
+
+    act(() => {
+      root?.render(
+        <PlaygroundLayout
+          layout={layout}
+          conversations={null}
+          conversation={null}
+          runtime={null}
+        />,
+      );
+    });
+
+    const restore = container
+      .querySelector('[aria-label="Show runtime panel"]')
+      ?.closest("span");
+    expect(restore?.className).toContain(
+      "max-[760px]:top-[calc(var(--playground-mobile-sidebar-height)+0.625rem)]",
+    );
+  });
+
   it("reveals a restored conversation at the bottom", () => {
     const boot = document.createElement("div");
     boot.dataset.playgroundBoot = "";

--- a/apps/site/src/features/playground/lib/usePlaygroundLayout.test.tsx
+++ b/apps/site/src/features/playground/lib/usePlaygroundLayout.test.tsx
@@ -1,0 +1,100 @@
+// @vitest-environment happy-dom
+
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { PLAYGROUND_LAYOUT_STORAGE_KEY } from "./playgroundLayoutStorage.js";
+import { usePlaygroundLayout } from "./usePlaygroundLayout.js";
+
+(
+  globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+let root: Root | undefined;
+let container: HTMLDivElement;
+let mobile = false;
+const mobileListeners = new Set<(event: MediaQueryListEvent) => void>();
+const storedValues = new Map<string, string>();
+
+beforeEach(() => {
+  mobile = false;
+  mobileListeners.clear();
+  storedValues.clear();
+  Object.defineProperty(window, "localStorage", {
+    configurable: true,
+    value: {
+      getItem: (key: string) => storedValues.get(key) ?? null,
+      setItem: (key: string, value: string) => storedValues.set(key, value),
+      clear: () => storedValues.clear(),
+    },
+  });
+  container = document.createElement("div");
+  document.body.append(container);
+  root = createRoot(container);
+
+  Object.defineProperty(window, "matchMedia", {
+    configurable: true,
+    value: vi.fn((query: string) => ({
+      matches: query === "(max-width: 760px)" ? mobile : false,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: (
+        type: string,
+        listener: (event: MediaQueryListEvent) => void,
+      ) => {
+        if (query === "(max-width: 760px)" && type === "change") {
+          mobileListeners.add(listener);
+        }
+      },
+      removeEventListener: (
+        type: string,
+        listener: (event: MediaQueryListEvent) => void,
+      ) => {
+        if (query === "(max-width: 760px)" && type === "change") {
+          mobileListeners.delete(listener);
+        }
+      },
+      dispatchEvent: vi.fn(),
+    })),
+  });
+});
+
+afterEach(() => {
+  act(() => root?.unmount());
+  root = undefined;
+  document.body.replaceChildren();
+});
+
+describe("usePlaygroundLayout", () => {
+  function Probe() {
+    const layout = usePlaygroundLayout();
+    return <output>{layout.conversationsOpen ? "open" : "closed"}</output>;
+  }
+
+  function setMobile(matches: boolean) {
+    mobile = matches;
+    const event = {
+      matches,
+      media: "(max-width: 760px)",
+    } as MediaQueryListEvent;
+    for (const listener of mobileListeners) listener(event);
+  }
+
+  it("keeps conversations open on mobile without changing the desktop preference", () => {
+    window.localStorage.setItem(
+      PLAYGROUND_LAYOUT_STORAGE_KEY,
+      JSON.stringify({ conversationsOpen: false }),
+    );
+
+    act(() => root?.render(<Probe />));
+    expect(container.textContent).toBe("closed");
+
+    act(() => setMobile(true));
+    expect(container.textContent).toBe("open");
+
+    act(() => setMobile(false));
+    expect(container.textContent).toBe("closed");
+  });
+});

--- a/apps/site/src/features/playground/lib/usePlaygroundLayout.ts
+++ b/apps/site/src/features/playground/lib/usePlaygroundLayout.ts
@@ -3,6 +3,7 @@ import {
   type KeyboardEvent as ReactKeyboardEvent,
   type PointerEvent as ReactPointerEvent,
   useCallback,
+  useEffect,
   useRef,
   useState,
 } from "react";
@@ -18,14 +19,18 @@ export const MIN_SIDEBAR_WIDTH = 200;
 export const MAX_SIDEBAR_WIDTH = 400;
 const SIDEBAR_RESIZE_STEP = 16;
 const SIDEBAR_WIDTH_STORAGE_KEY = "web-ai-sdk:playground:sidebar-width";
+const MOBILE_LAYOUT_QUERY = "(max-width: 760px)";
 
 export function usePlaygroundLayout() {
   const shellRef = useRef<HTMLDivElement>(null);
   const [initialLayoutState] = useState(loadPlaygroundLayoutState);
   const [sidebarWidth, setSidebarWidth] = useState(loadSidebarWidth);
   const [sidebarResizing, setSidebarResizing] = useState(false);
-  const [conversationsOpen, setConversationsOpen] = useState(
+  const [desktopConversationsOpen, setDesktopConversationsOpen] = useState(
     initialLayoutState.conversationsOpen ?? true,
+  );
+  const [mobileLayout, setMobileLayout] = useState(
+    () => window.matchMedia(MOBILE_LAYOUT_QUERY).matches,
   );
   const [runtimeOpen, setRuntimeOpen] = useState(
     () =>
@@ -38,6 +43,16 @@ export function usePlaygroundLayout() {
     startWidth: number;
   } | null>(null);
   const sidebarWidthRef = useRef(sidebarWidth);
+  const conversationsOpen = mobileLayout || desktopConversationsOpen;
+
+  useEffect(() => {
+    const media = window.matchMedia(MOBILE_LAYOUT_QUERY);
+    const updateMobileLayout = (event: MediaQueryListEvent) => {
+      setMobileLayout(event.matches);
+    };
+    media.addEventListener("change", updateMobileLayout);
+    return () => media.removeEventListener("change", updateMobileLayout);
+  }, []);
 
   const persistSidebarWidth = useCallback((width: number) => {
     try {
@@ -124,7 +139,7 @@ export function usePlaygroundLayout() {
   };
 
   const setConversationsVisibility = useCallback((open: boolean) => {
-    setConversationsOpen(open);
+    setDesktopConversationsOpen(open);
     updatePlaygroundLayoutState({ conversationsOpen: open });
   }, []);
 

--- a/apps/site/src/shared/ui.ts
+++ b/apps/site/src/shared/ui.ts
@@ -619,34 +619,23 @@ export const playground = {
     "inline-flex h-9 w-full cursor-pointer items-center justify-center gap-2 rounded-sm bg-accent px-3 font-mono text-[10px] font-semibold text-brand-dark transition-[background-color,transform] hover:bg-accent-bright active:scale-95 disabled:cursor-not-allowed disabled:opacity-45 motion-reduce:transform-none max-[760px]:size-9 max-[760px]:shrink-0 max-[760px]:rounded-full max-[760px]:p-0",
   wideButtonIcon: "text-sm leading-none",
   wideButtonLabel: "max-[760px]:hidden",
-  main: "flex h-full w-full min-w-0 flex-col overflow-hidden bg-bg max-[760px]:h-auto",
+  main: "relative flex h-full w-full min-w-0 flex-col overflow-hidden bg-bg max-[760px]:h-auto",
   mainHeader:
-    "relative z-20 flex h-12 w-full min-w-0 shrink-0 bg-bg after:pointer-events-none after:absolute after:inset-x-0 after:top-full after:h-9 after:bg-[linear-gradient(to_bottom,var(--color-bg)_0%,color-mix(in_oklch,var(--color-bg)_78%,transparent)_48%,transparent_100%)] after:opacity-0 after:transition-opacity after:duration-200 after:ease-out after:content-[''] max-[640px]:h-11",
-  mainHeaderInner:
-    "mx-auto flex h-full w-full max-w-[960px] min-w-0 items-center gap-2.5 px-3 max-[640px]:max-w-none max-[640px]:px-4",
-  mainHeaderBoot: "after:transition-none",
-  mainHeaderScrolled: "after:opacity-100",
-  mainHeaderWithLeftRestore: "max-[760px]:pl-8",
-  title:
-    "m-0 min-w-0 flex-1 truncate font-display text-base font-medium leading-none tracking-[-0.02em] text-fg",
+    "pointer-events-none absolute inset-x-0 top-0 z-20 h-16 bg-[linear-gradient(to_bottom,var(--color-bg)_0%,color-mix(in_oklch,var(--color-bg)_78%,transparent)_48%,transparent_100%)] opacity-0 transition-opacity duration-200 ease-out",
+  mainHeaderBoot: "transition-none",
+  mainHeaderScrolled: "opacity-100",
   panelRestoreLeft:
     "absolute top-2.5 left-3 z-40 motion-safe:animate-[playground-fade_180ms_ease-out_100ms_both]",
   panelRestoreRight:
-    "absolute top-2.5 right-3 z-40 motion-safe:animate-[playground-fade_180ms_ease-out_100ms_both] max-[760px]:hidden",
-  panelRestoreRightMobile:
-    "hidden shrink-0 motion-safe:animate-[playground-fade_180ms_ease-out_100ms_both] max-[760px]:inline-flex",
+    "absolute top-2.5 right-3 z-40 motion-safe:animate-[playground-fade_180ms_ease-out_100ms_both] max-[760px]:top-[calc(var(--playground-mobile-sidebar-height)+0.625rem)]",
   panelToggle:
     "inline-flex size-7 shrink-0 cursor-pointer items-center justify-center rounded-sm bg-transparent text-fg-4 transition-[color,background-color,transform] hover:bg-surface hover:text-fg-2 active:scale-95 focus-visible:bg-surface focus-visible:text-fg focus-visible:outline focus-visible:outline-1 focus-visible:outline-offset-1 focus-visible:outline-accent motion-reduce:transform-none max-[760px]:size-9",
   panelToggleIcon: "size-4",
   modeSelector: "relative min-w-0 [grid-area:mode]",
   modeTrigger:
-    "inline-flex min-h-9 max-w-52 cursor-pointer items-center gap-2 rounded-pill bg-bg px-3 py-2 text-left transition-colors data-[accent=info]:bg-[color-mix(in_oklch,var(--color-info)_9%,var(--color-bg))] data-[accent=ok]:bg-[color-mix(in_oklch,var(--color-ok)_9%,var(--color-bg))] data-[accent=warn]:bg-[color-mix(in_oklch,var(--color-warn)_9%,var(--color-bg))] data-[accent=violet]:bg-[color-mix(in_oklch,var(--color-info)_5%,color-mix(in_oklch,var(--color-err)_5%,var(--color-bg)))] hover:data-[accent=info]:bg-[color-mix(in_oklch,var(--color-info)_14%,var(--color-bg))] hover:data-[accent=ok]:bg-[color-mix(in_oklch,var(--color-ok)_14%,var(--color-bg))] hover:data-[accent=warn]:bg-[color-mix(in_oklch,var(--color-warn)_14%,var(--color-bg))] hover:data-[accent=violet]:bg-[color-mix(in_oklch,var(--color-info)_8%,color-mix(in_oklch,var(--color-err)_8%,var(--color-bg)))] focus-visible:outline focus-visible:outline-1 focus-visible:outline-offset-1 data-[accent=info]:focus-visible:outline-info data-[accent=ok]:focus-visible:outline-ok data-[accent=warn]:focus-visible:outline-warn data-[accent=violet]:focus-visible:outline-[color-mix(in_oklch,var(--color-info)_45%,var(--color-err))] disabled:cursor-not-allowed disabled:opacity-45 max-[640px]:min-h-8 max-[640px]:max-w-40 max-[640px]:gap-1.5 max-[640px]:px-2.5 max-[640px]:py-1.5",
-  modeTriggerName:
-    "truncate font-mono text-[10px] data-[accent=info]:text-info data-[accent=ok]:text-ok data-[accent=warn]:text-warn data-[accent=violet]:text-[color-mix(in_oklch,var(--color-info)_45%,var(--color-err))]",
-  modeTriggerChevron:
-    "size-3.5 shrink-0 text-fg-4 transition-transform duration-150",
-  modeTriggerChevronOpen:
-    "size-3.5 shrink-0 rotate-180 text-fg-4 transition-transform duration-150",
+    "inline-flex size-9 shrink-0 cursor-pointer items-center justify-center gap-1 rounded-pill bg-bg px-2 py-2 text-left transition-colors data-[accent=info]:bg-[color-mix(in_oklch,var(--color-info)_9%,var(--color-bg))] data-[accent=ok]:bg-[color-mix(in_oklch,var(--color-ok)_9%,var(--color-bg))] data-[accent=warn]:bg-[color-mix(in_oklch,var(--color-warn)_9%,var(--color-bg))] data-[accent=violet]:bg-[color-mix(in_oklch,var(--color-info)_5%,color-mix(in_oklch,var(--color-err)_5%,var(--color-bg)))] hover:data-[accent=info]:bg-[color-mix(in_oklch,var(--color-info)_14%,var(--color-bg))] hover:data-[accent=ok]:bg-[color-mix(in_oklch,var(--color-ok)_14%,var(--color-bg))] hover:data-[accent=warn]:bg-[color-mix(in_oklch,var(--color-warn)_14%,var(--color-bg))] hover:data-[accent=violet]:bg-[color-mix(in_oklch,var(--color-info)_8%,color-mix(in_oklch,var(--color-err)_8%,var(--color-bg)))] focus-visible:outline focus-visible:outline-1 focus-visible:outline-offset-1 data-[accent=info]:focus-visible:outline-info data-[accent=ok]:focus-visible:outline-ok data-[accent=warn]:focus-visible:outline-warn data-[accent=violet]:focus-visible:outline-[color-mix(in_oklch,var(--color-info)_45%,var(--color-err))] disabled:cursor-not-allowed disabled:opacity-45 max-[640px]:size-8",
+  modeTriggerIcon:
+    "size-4 shrink-0 data-[accent=info]:text-info data-[accent=ok]:text-ok data-[accent=warn]:text-warn data-[accent=violet]:text-[color-mix(in_oklch,var(--color-info)_45%,var(--color-err))]",
   modeMenu:
     "absolute bottom-[calc(100%+0.65rem)] left-0 z-50 w-[min(440px,calc(100vw-2rem))] overflow-x-hidden rounded-xl bg-surface-3 p-2 shadow-2xl max-[640px]:fixed max-[640px]:top-auto max-[640px]:right-3 max-[640px]:bottom-3 max-[640px]:left-3 max-[640px]:max-h-[calc(100svh-var(--nav-height)-1.5rem)] max-[640px]:w-auto max-[640px]:overflow-y-auto",
   modeMenuHeader: "grid gap-1 px-3 py-3 max-[640px]:pt-2.5 max-[640px]:pb-2",
@@ -659,9 +648,9 @@ export const playground = {
     "grid w-full cursor-pointer rounded-lg bg-surface-2 px-3 py-3 text-left max-[640px]:py-2.5",
   modeOptionCopy: "grid min-w-0 gap-1",
   modeOptionTitleRow: "flex min-w-0 items-center justify-between gap-3",
-  modeOptionIdentity: "flex min-w-0 items-center gap-2.5",
-  modeAccentDot:
-    "size-2 shrink-0 rounded-full data-[accent=info]:bg-info data-[accent=ok]:bg-ok data-[accent=warn]:bg-warn data-[accent=violet]:bg-[color-mix(in_oklch,var(--color-info)_45%,var(--color-err))]",
+  modeOptionIdentity: "flex min-w-0 items-center gap-1.5",
+  modeOptionIcon:
+    "size-4 shrink-0 data-[accent=info]:text-info data-[accent=ok]:text-ok data-[accent=warn]:text-warn data-[accent=violet]:text-[color-mix(in_oklch,var(--color-info)_45%,var(--color-err))]",
   modeOptionName:
     "truncate font-sans text-[13px] font-medium data-[accent=info]:text-info data-[accent=ok]:text-ok data-[accent=warn]:text-warn data-[accent=violet]:text-[color-mix(in_oklch,var(--color-info)_45%,var(--color-err))]",
   modeOptionToolCount:
@@ -671,14 +660,17 @@ export const playground = {
     "rounded-md bg-bg px-3 py-2.5 font-mono text-[8px] leading-relaxed text-fg-4",
   mainBody:
     "grid min-h-0 w-full max-w-[960px] flex-1 self-center grid-rows-[minmax(0,1fr)_auto] gap-0 px-3 pb-4 max-[640px]:max-w-none max-[640px]:px-3 max-[640px]:pb-2",
-  transcriptPanel: "relative min-h-0 overflow-hidden",
+  mainBodyCentered:
+    "flex min-h-0 w-full max-w-[960px] flex-1 flex-col justify-center gap-6 self-center px-3 pb-4 max-[640px]:max-w-none max-[640px]:px-3 max-[640px]:pb-2",
+  transcriptPanel:
+    "relative min-h-0 overflow-hidden after:pointer-events-none after:absolute after:inset-x-0 after:bottom-0 after:z-10 after:h-10 after:bg-[linear-gradient(to_top,var(--color-bg)_0%,color-mix(in_oklch,var(--color-bg)_82%,transparent)_45%,transparent_100%)] after:content-['']",
   answer:
-    "h-full min-h-0 overflow-y-auto px-6 pt-5 pb-6 [scrollbar-width:thin] max-[640px]:px-4 max-[640px]:pt-4 max-[640px]:pb-5",
+    "h-full min-h-0 overflow-y-auto px-6 pt-5 pb-10 [scrollbar-width:thin] max-[640px]:px-4 max-[640px]:pt-4 max-[640px]:pb-10",
   banner:
     "mb-4 rounded-sm border border-[color-mix(in_oklch,var(--color-warn)_35%,transparent)] bg-[color-mix(in_oklch,var(--color-warn)_10%,var(--color-bg))] px-3.5 py-3 font-mono text-[11px] leading-relaxed text-warn [&_code]:text-fg",
   bannerError:
     "mb-4 rounded-sm border border-[color-mix(in_oklch,var(--color-err)_35%,transparent)] bg-[color-mix(in_oklch,var(--color-err)_10%,var(--color-bg))] px-3.5 py-3 font-mono text-[11px] leading-relaxed text-err",
-  jump: "absolute right-4 bottom-4 inline-flex size-8 cursor-pointer items-center justify-center rounded-full bg-[color-mix(in_oklch,var(--color-surface-3)_92%,transparent)] font-mono text-[13px] text-fg-2 shadow-card backdrop-blur-sm transition-colors hover:text-fg",
+  jump: "absolute right-4 bottom-4 z-20 inline-flex size-8 cursor-pointer items-center justify-center rounded-full bg-[color-mix(in_oklch,var(--color-surface-3)_92%,transparent)] font-mono text-[13px] text-fg-2 shadow-card backdrop-blur-sm transition-colors hover:text-fg",
   composer:
     "relative z-10 grid grid-cols-[auto_minmax(0,1fr)_auto] [grid-template-areas:'mode_input_actions'] items-end gap-x-1.5 rounded-3xl bg-surface p-2 shadow-[0_-14px_30px_-18px_rgba(0,0,0,0.95)] transition-colors focus-within:bg-surface-2 max-[640px]:grid-cols-[minmax(0,1fr)_auto] max-[640px]:[grid-template-areas:'input_input'_'mode_actions'] max-[640px]:gap-y-1.5",
   composerDock: "relative z-20",
@@ -700,7 +692,7 @@ export const playground = {
     "[grid-area:input] max-h-40 w-full resize-none overflow-y-auto border-0 bg-transparent px-1.5 py-2 font-sans text-[14px] leading-[1.55] text-fg outline-none [field-sizing:content] [scrollbar-width:thin] placeholder:text-fg-4 disabled:cursor-not-allowed disabled:opacity-55 max-[640px]:max-h-32",
   fallbackMuted: "text-fg-4",
   exampleFloat:
-    "pointer-events-none absolute bottom-full left-0 flex w-full flex-wrap items-center gap-1 bg-[linear-gradient(to_top,var(--color-bg)_62%,transparent)] px-1 pt-8 pb-2.5 max-[640px]:hidden",
+    "flex w-full flex-wrap items-center gap-1 bg-[linear-gradient(to_top,var(--color-bg)_62%,transparent)] px-1 pb-2.5 max-[640px]:hidden",
   examples: "flex min-w-0 flex-wrap items-center gap-1",
   example:
     "pointer-events-auto max-w-48 cursor-pointer truncate rounded-pill bg-surface-2 px-2 py-1 font-mono text-[8px] text-fg-4 transition-[color,background-color,transform] hover:bg-surface-3 hover:text-fg-2 active:scale-[0.98] motion-reduce:transform-none disabled:cursor-not-allowed disabled:opacity-45",
@@ -761,12 +753,6 @@ export const playground = {
   workspaceAdvice: "font-sans text-[10px] leading-relaxed text-fg-4",
   empty:
     "px-4 py-5 text-center font-mono text-[10px] leading-relaxed text-fg-4",
-  emptyConversation:
-    "grid min-h-full place-content-center gap-2 px-6 py-12 text-center",
-  emptyConversationTitle:
-    "font-display text-xl font-semibold leading-tight tracking-[-0.025em] text-fg",
-  emptyConversationText:
-    "m-0 max-w-md font-sans text-[13px] leading-relaxed text-fg-4",
   activity: "grid list-none divide-y divide-hairline p-0",
   activityItem:
     "grid grid-cols-[minmax(0,1fr)_auto] items-start gap-3 px-3 py-2.5 font-mono text-[8px] leading-relaxed",


### PR DESCRIPTION
## Summary

- Center the empty-state composer and align Playground controls.
- Keep example prompts in normal flow and add a transcript boundary fade.
- Open the conversation list by default on mobile.
- Prevent panel restore controls from overlapping the mobile conversation list.
- Add regression coverage for responsive layout behavior.

## Testing

- 123 Vitest tests passed.
- Astro check passed with zero errors.
- Biome check passed.
