### PR TITLE
fix(site): refine playground loading and mobile actions

### DIFF
--- a/apps/site/src/features/playground/Playground.tsx
+++ b/apps/site/src/features/playground/Playground.tsx
@@ -177,10 +177,12 @@ export function Playground() {
           promptOn={promptOn}
           status={status}
           stopReason={stopReason}
+          runtimeOpen={layout.runtimeOpen}
           onCreate={() => createThread()}
           onSelect={selectThread}
           onClose={closeThread}
           onHide={layout.hideConversations}
+          onShowRuntime={layout.showRuntime}
         />
       }
       conversation={

--- a/apps/site/src/features/playground/PlaygroundFallback.astro
+++ b/apps/site/src/features/playground/PlaygroundFallback.astro
@@ -39,6 +39,7 @@ const truncateExample = (value: string, limit = 60) =>
   data-markdown-inline-code-class={ui.markdownInlineCode}
   data-boot-message-class={ui.bootMessage}
   data-main-header-scrolled-class={ui.mainHeaderScrolled}
+  data-main-body-class={ui.mainBody}
   data-layout-mobile-with-sidebar-class={ui.shellMobileWithSidebar}
   data-layout-mobile-without-sidebar-class={ui.shellMobileWithoutSidebar}
   data-panel-slot-open-class={ui.panelSlotOpen}
@@ -89,7 +90,10 @@ const truncateExample = (value: string, limit = 60) =>
           </span>
         </header>
         <div class={ui.sidebarBody}>
-          <section class={ui.sidebarSection}>
+          <section
+            class={ui.sidebarSection}
+            data-playground-conversation-rail
+          >
             <span class={ui.wideButton}>
               <span class={ui.wideButtonIcon}>+</span>
               <span class={ui.wideButtonLabel}>New conversation</span>
@@ -105,6 +109,33 @@ const truncateExample = (value: string, limit = 60) =>
               </div>
             </div>
           </section>
+          <span
+            class={ui.sidebarMobileActions}
+            data-playground-mobile-runtime-action
+            hidden
+          >
+            <span class={ui.panelToggle}>
+              <svg
+                class={ui.panelToggleIcon}
+                viewBox="0 0 18 18"
+                fill="none"
+                aria-hidden="true"
+              >
+                <rect
+                  x="2.25"
+                  y="2.75"
+                  width="13.5"
+                  height="12.5"
+                  rx="2.25"
+                  stroke="currentColor"
+                  stroke-width="1.25"></rect>
+                <path
+                  d="M11.5 3.25v11.5"
+                  stroke="currentColor"
+                  stroke-width="1.25"></path>
+              </svg>
+            </span>
+          </span>
         </div>
       </aside>
     </div>
@@ -163,7 +194,14 @@ const truncateExample = (value: string, limit = 60) =>
         data-playground-main-header
       />
 
-      <div class={ui.mainBodyCentered}>
+      <div class={ui.mainBodyCentered} data-playground-main-body>
+        <section
+          class={ui.transcriptPanel}
+          data-playground-transcript-panel
+          hidden
+        >
+          <div class={ui.answer} data-playground-transcript></div>
+        </section>
         <div class={ui.composerDock}>
           <div class={ui.exampleFloat}>
             <div class={ui.examples} data-playground-examples>
@@ -698,6 +736,12 @@ const truncateExample = (value: string, limit = 60) =>
             "[data-playground-right-restore]",
           );
           if (rightRestore instanceof HTMLElement) rightRestore.hidden = false;
+          const mobileRuntimeAction = fallback.querySelector(
+            "[data-playground-mobile-runtime-action]",
+          );
+          if (mobileRuntimeAction instanceof HTMLElement) {
+            mobileRuntimeAction.hidden = false;
+          }
         }
 
         const raw = localStorage.getItem(fallback.dataset.storageKey ?? "");
@@ -947,6 +991,18 @@ const truncateExample = (value: string, limit = 60) =>
 
         if (transcriptThread.childElementCount > 0) {
           transcript.replaceChildren(transcriptThread);
+          const mainBody = fallback.querySelector(
+            "[data-playground-main-body]",
+          );
+          const transcriptPanel = fallback.querySelector(
+            "[data-playground-transcript-panel]",
+          );
+          if (mainBody instanceof HTMLElement) {
+            mainBody.className = fallback.dataset.mainBodyClass ?? "";
+          }
+          if (transcriptPanel instanceof HTMLElement) {
+            transcriptPanel.hidden = false;
+          }
           restoredTranscript = transcript;
         }
       } catch {

--- a/apps/site/src/features/playground/components/ConversationsPanel.test.tsx
+++ b/apps/site/src/features/playground/components/ConversationsPanel.test.tsx
@@ -1,0 +1,75 @@
+// @vitest-environment happy-dom
+
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { playground as ui } from "../../../shared/ui.js";
+import type { AgentThread } from "../lib/agentThreads.js";
+import { ConversationsPanel } from "./ConversationsPanel.js";
+
+(
+  globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+let root: Root | undefined;
+
+afterEach(() => {
+  act(() => root?.unmount());
+  root = undefined;
+  document.body.replaceChildren();
+});
+
+describe("ConversationsPanel", () => {
+  it("places the mobile runtime action in the conversation rail", () => {
+    const container = document.createElement("div");
+    document.body.append(container);
+    root = createRoot(container);
+    const noop = vi.fn();
+    const thread: AgentThread = {
+      id: "thread-1",
+      name: "Persisted conversation",
+      modeId: "platform",
+      turns: [],
+      createdAt: 1,
+      updatedAt: 1,
+    };
+
+    act(() => {
+      root?.render(
+        <ConversationsPanel
+          open
+          threads={[thread]}
+          activeId={thread.id}
+          busy={false}
+          promptOn
+          status="idle"
+          stopReason={null}
+          runtimeOpen={false}
+          onCreate={noop}
+          onSelect={noop}
+          onClose={noop}
+          onHide={noop}
+          onShowRuntime={noop}
+        />,
+      );
+    });
+
+    const action = container.querySelector(
+      "[data-playground-mobile-runtime-action]",
+    );
+    const row = action?.parentElement;
+    const rail = row?.querySelector("[data-playground-conversation-rail]");
+
+    expect(action).not.toBeNull();
+    expect(action?.className).toContain("max-[760px]:flex");
+    expect(action?.previousElementSibling).toBe(rail);
+    expect(ui.sidebarBody).toContain(
+      "max-[760px]:grid-cols-[minmax(0,1fr)_auto]",
+    );
+    expect(ui.sidebarSection).toContain("max-[760px]:overflow-x-auto");
+    expect(rail?.querySelector("[data-thread-id]")).not.toBeNull();
+    expect(
+      action?.querySelector('[aria-label="Show runtime panel"]'),
+    ).not.toBeNull();
+  });
+});

--- a/apps/site/src/features/playground/components/ConversationsPanel.tsx
+++ b/apps/site/src/features/playground/components/ConversationsPanel.tsx
@@ -12,10 +12,12 @@ interface Props {
   promptOn: boolean;
   status: string;
   stopReason: AgentStopReason | null;
+  runtimeOpen: boolean;
   onCreate: () => void;
   onSelect: (id: string) => void;
   onClose: (id: string) => void;
   onHide: () => void;
+  onShowRuntime: () => void;
 }
 
 export function ConversationsPanel({
@@ -26,10 +28,12 @@ export function ConversationsPanel({
   promptOn,
   status,
   stopReason,
+  runtimeOpen,
   onCreate,
   onSelect,
   onClose,
   onHide,
+  onShowRuntime,
 }: Props) {
   const activeStatus = conversationStatus(promptOn, status, stopReason);
   return (
@@ -48,7 +52,10 @@ export function ConversationsPanel({
           <PanelToggle side="left" open onClick={onHide} />
         </header>
         <div className={ui.sidebarBody}>
-          <section className={ui.sidebarSection}>
+          <section
+            className={ui.sidebarSection}
+            data-playground-conversation-rail
+          >
             <button
               type="button"
               className={ui.wideButton}
@@ -121,6 +128,14 @@ export function ConversationsPanel({
               })}
             </div>
           </section>
+          {!runtimeOpen && (
+            <div
+              className={ui.sidebarMobileActions}
+              data-playground-mobile-runtime-action
+            >
+              <PanelToggle side="right" open={false} onClick={onShowRuntime} />
+            </div>
+          )}
         </div>
       </aside>
     </div>

--- a/apps/site/src/features/playground/components/PlaygroundLayout.test.tsx
+++ b/apps/site/src/features/playground/components/PlaygroundLayout.test.tsx
@@ -20,6 +20,10 @@ afterEach(() => {
 });
 
 describe("PlaygroundLayout", () => {
+  it("keeps the empty-state composer at the bottom on mobile", () => {
+    expect(ui.mainBodyCentered).toContain("max-[760px]:justify-end");
+  });
+
   it("fades transcript content before the scroll boundary", () => {
     expect(ui.transcriptPanel).toContain(
       "after:bg-[linear-gradient(to_top,var(--color-bg)_0%,color-mix(in_oklch,var(--color-bg)_82%,transparent)_45%,transparent_100%)]",
@@ -27,7 +31,7 @@ describe("PlaygroundLayout", () => {
     expect(ui.answer).toContain("pb-10");
   });
 
-  it("positions the runtime restore control below the mobile conversation row", () => {
+  it("keeps the runtime restore control on the desktop layout rail", () => {
     const container = document.createElement("div");
     document.body.append(container);
     root = createRoot(container);
@@ -65,9 +69,7 @@ describe("PlaygroundLayout", () => {
     const restore = container
       .querySelector('[aria-label="Show runtime panel"]')
       ?.closest("span");
-    expect(restore?.className).toContain(
-      "max-[760px]:top-[calc(var(--playground-mobile-sidebar-height)+0.625rem)]",
-    );
+    expect(restore?.className).toContain("max-[760px]:hidden");
   });
 
   it("reveals a restored conversation at the bottom", () => {

--- a/apps/site/src/shared/ui.ts
+++ b/apps/site/src/shared/ui.ts
@@ -593,9 +593,11 @@ export const playground = {
   sidebarResizeHandle:
     "absolute top-0 left-[var(--playground-sidebar-width)] z-30 m-0 h-full w-3 -translate-x-1/2 cursor-col-resize touch-none border-0 bg-transparent p-0 outline-none before:pointer-events-none before:absolute before:top-1/2 before:left-1/2 before:h-10 before:w-0.5 before:-translate-x-1/2 before:-translate-y-1/2 before:rounded-full before:bg-transparent before:transition-[height,background-color] before:content-[''] hover:before:h-14 hover:before:bg-fg-4 focus-visible:before:h-14 focus-visible:before:bg-accent active:before:h-16 active:before:bg-accent max-[760px]:hidden",
   sidebarBody:
-    "grid min-h-0 flex-1 content-start gap-7 overflow-y-auto px-3 py-4 [scrollbar-width:thin] max-[760px]:block max-[760px]:h-[var(--playground-mobile-sidebar-height)] max-[760px]:flex-none max-[760px]:overflow-x-auto max-[760px]:overflow-y-hidden max-[760px]:py-2.5",
+    "grid min-h-0 flex-1 content-start gap-7 overflow-y-auto px-3 py-4 [scrollbar-width:thin] max-[760px]:h-[var(--playground-mobile-sidebar-height)] max-[760px]:flex-none max-[760px]:grid-cols-[minmax(0,1fr)_auto] max-[760px]:items-center max-[760px]:gap-1 max-[760px]:overflow-hidden max-[760px]:py-2.5",
   sidebarSection:
-    "grid min-w-0 content-start gap-2 max-[760px]:flex max-[760px]:w-max max-[760px]:items-center",
+    "grid min-w-0 content-start gap-2 max-[760px]:flex max-[760px]:h-full max-[760px]:items-center max-[760px]:overflow-x-auto max-[760px]:overflow-y-hidden",
+  sidebarMobileActions:
+    "hidden shrink-0 items-center gap-0.5 max-[760px]:flex max-[760px]:self-center max-[760px]:bg-surface max-[760px]:pl-1",
   sectionTitle:
     "m-0 font-mono text-[10px] font-normal uppercase tracking-[0.14em] text-fg-4 max-[760px]:hidden",
   presets: "grid gap-1 max-[760px]:flex max-[760px]:flex-nowrap",
@@ -627,9 +629,9 @@ export const playground = {
   panelRestoreLeft:
     "absolute top-2.5 left-3 z-40 motion-safe:animate-[playground-fade_180ms_ease-out_100ms_both]",
   panelRestoreRight:
-    "absolute top-2.5 right-3 z-40 motion-safe:animate-[playground-fade_180ms_ease-out_100ms_both] max-[760px]:top-[calc(var(--playground-mobile-sidebar-height)+0.625rem)]",
+    "absolute top-2.5 right-3 z-40 motion-safe:animate-[playground-fade_180ms_ease-out_100ms_both] max-[760px]:hidden",
   panelToggle:
-    "inline-flex size-7 shrink-0 cursor-pointer items-center justify-center rounded-sm bg-transparent text-fg-4 transition-[color,background-color,transform] hover:bg-surface hover:text-fg-2 active:scale-95 focus-visible:bg-surface focus-visible:text-fg focus-visible:outline focus-visible:outline-1 focus-visible:outline-offset-1 focus-visible:outline-accent motion-reduce:transform-none max-[760px]:size-9",
+    "inline-flex size-7 shrink-0 cursor-pointer items-center justify-center rounded-sm bg-transparent text-fg-4 transition-[color,background-color,transform] hover:bg-surface-3 hover:text-fg-2 active:scale-95 focus-visible:bg-surface-3 focus-visible:text-fg focus-visible:outline focus-visible:outline-1 focus-visible:outline-offset-1 focus-visible:outline-accent motion-reduce:transform-none max-[760px]:size-9",
   panelToggleIcon: "size-4",
   modeSelector: "relative min-w-0 [grid-area:mode]",
   modeTrigger:
@@ -661,7 +663,7 @@ export const playground = {
   mainBody:
     "grid min-h-0 w-full max-w-[960px] flex-1 self-center grid-rows-[minmax(0,1fr)_auto] gap-0 px-3 pb-4 max-[640px]:max-w-none max-[640px]:px-3 max-[640px]:pb-2",
   mainBodyCentered:
-    "flex min-h-0 w-full max-w-[960px] flex-1 flex-col justify-center gap-6 self-center px-3 pb-4 max-[640px]:max-w-none max-[640px]:px-3 max-[640px]:pb-2",
+    "flex min-h-0 w-full max-w-[960px] flex-1 flex-col justify-center gap-6 self-center px-3 pb-4 max-[760px]:justify-end max-[640px]:max-w-none max-[640px]:px-3 max-[640px]:pb-2",
   transcriptPanel:
     "relative min-h-0 overflow-hidden after:pointer-events-none after:absolute after:inset-x-0 after:bottom-0 after:z-10 after:h-10 after:bg-[linear-gradient(to_top,var(--color-bg)_0%,color-mix(in_oklch,var(--color-bg)_82%,transparent)_45%,transparent_100%)] after:content-['']",
   answer:


### PR DESCRIPTION
## Summary

- Restore persisted transcripts before React hydration.
- Prevent the centered composer from flashing during conversation loading.
- Keep mobile conversation actions on one row without content overlap.
- Bottom-align new-conversation prompts on mobile.
- Refine the runtime toggle hover treatment.
- Add regression coverage for the responsive layouts.

## Validation

- Site build passed.
- All 124 site tests passed.
- Focused layout tests passed.
- Biome and diff checks passed.
- Verified the production preview at mobile and desktop widths.
