### PR TITLE
chore(site): remove DataFast analytics tracker

### DIFF
--- a/apps/site/astro.config.mjs
+++ b/apps/site/astro.config.mjs
@@ -82,15 +82,6 @@ export default defineConfig({
             "data-website-id": "9e24f5c3-6b64-48fc-8679-610907092f1c",
           },
         },
-        {
-          tag: "script",
-          attrs: {
-            defer: true,
-            src: "https://datafa.st/js/script.js",
-            "data-website-id": "dfid_mEnHw3sriSnXWCpCQsoM6",
-            "data-domain": "web-ai-sdk.dev",
-          },
-        },
         ...preloadedFonts.map((file) => ({
           tag: "link",
           attrs: {

--- a/apps/site/src/pages/index.astro
+++ b/apps/site/src/pages/index.astro
@@ -381,13 +381,6 @@ const browserColumns = [
     <link rel="alternate" type="text/plain" title="LLM-friendly docs (llms.txt)" href={pathFromBase("llms.txt")} />
     <link rel="alternate" type="text/plain" title="LLM-friendly docs (full text)" href={pathFromBase("llms-full.txt")} />
     <script is:inline defer src="https://cloud.umami.is/script.js" data-website-id="9e24f5c3-6b64-48fc-8679-610907092f1c"></script>
-    <script
-      is:inline
-      defer
-      src="https://datafa.st/js/script.js"
-      data-website-id="dfid_mEnHw3sriSnXWCpCQsoM6"
-      data-domain="web-ai-sdk.dev"
-    ></script>
     <script is:inline type="application/ld+json" set:html={JSON.stringify(structuredData)} />
     <script>
       import { registerTool } from "@web-ai-sdk/webmcp";

--- a/apps/site/src/pages/playground/index.astro
+++ b/apps/site/src/pages/playground/index.astro
@@ -51,13 +51,6 @@ const ogImageUrl = new URL(pathFromBase("og/playground.png"), SITE_ORIGIN).toStr
       src="https://cloud.umami.is/script.js"
       data-website-id="9e24f5c3-6b64-48fc-8679-610907092f1c"
     ></script>
-    <script
-      is:inline
-      defer
-      src="https://datafa.st/js/script.js"
-      data-website-id="dfid_mEnHw3sriSnXWCpCQsoM6"
-      data-domain="web-ai-sdk.dev"
-    ></script>
   </head>
   <body class="min-h-screen bg-bg">
     <SiteNav


### PR DESCRIPTION
## Summary

- Remove DataFast analytics from the home page, Playground, and documentation.
- Keep Umami as the site's only analytics tracker.

## Reason

Umami meets the site's current analytics needs. DataFast bot tracking would require server-side infrastructure that the current GitHub Pages deployment does not provide.

## Validation

- `pnpm build:site`
- `pnpm --filter @web-ai-sdk-apps/site run typecheck`
