### PR TITLE
fix(mcp): run deploy package script

### DIFF
--- a/.github/workflows/mcp.yml
+++ b/.github/workflows/mcp.yml
@@ -47,7 +47,7 @@ jobs:
           pnpm --filter @web-ai-sdk-apps/mcp test
 
       - name: Deploy documentation MCP Worker
-        run: pnpm --filter @web-ai-sdk-apps/mcp deploy
+        run: pnpm --filter @web-ai-sdk-apps/mcp run deploy
         env:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}


### PR DESCRIPTION
## Summary

- run the MCP deployment through pnpm's package-script runner
- prevent pnpm from treating `deploy` as its built-in command

## Root cause

The workflow omitted `run`, so pnpm returned `ERR_PNPM_INVALID_DEPLOY_TARGET` before Wrangler started.

## Verification

- `pnpm --filter @web-ai-sdk-apps/mcp run deploy --help`
- `pnpm gate`