### PR TITLE
feat(mcp): rank partial matches in docs search

### DIFF
--- a/apps/mcp/src/catalog.test.ts
+++ b/apps/mcp/src/catalog.test.ts
@@ -36,6 +36,24 @@ describe("documentation catalog", () => {
     expect(searchDocumentation("definitely-not-in-these-docs")).toEqual([]);
   });
 
+  it("ranks partial matches for long natural-language queries", () => {
+    const results = searchDocumentation(
+      "WebMCP how to use @web-ai-sdk/webmcp browser support registration tools declarative imperative",
+    );
+
+    expect(results.length).toBeGreaterThan(0);
+    expect(results.map((result) => result.id)).toContain("guides/webmcp");
+  });
+
+  it("returns nothing when most query tokens are absent", () => {
+    expect(
+      searchDocumentation("quantum blockchain kubernetes terraform webmcp"),
+    ).toEqual([]);
+    expect(searchDocumentation("definitely-not-in-these-docs webmcp")).toEqual(
+      [],
+    );
+  });
+
   it("keeps excerpt offsets aligned after Unicode normalization", () => {
     const document = readDocumentation("packages/webmcp");
     const result = searchDocumentation("heterogeneous", 5).find(

--- a/apps/mcp/src/catalog.ts
+++ b/apps/mcp/src/catalog.ts
@@ -68,28 +68,33 @@ const scoreDocument = (
   document: DocumentationRecord,
   normalizedQuery: string,
   tokens: readonly string[],
-): number => {
+): { score: number; matchedTokens: string[] } => {
   const title = normalize(document.title);
   const description = normalize(document.description);
   const identity = normalize(`${document.id} ${document.uri}`);
   const body = normalize(document.body);
   const combined = `${title} ${description} ${identity} ${body}`;
 
-  if (!tokens.every((token) => combined.includes(token))) return 0;
+  const matchedTokens = tokens.filter((token) => combined.includes(token));
+  // A strict majority of tokens must match so long natural-language queries
+  // can rank by partial coverage while unrelated queries still return nothing.
+  if (matchedTokens.length * 2 <= tokens.length) {
+    return { score: 0, matchedTokens };
+  }
 
-  let score = 1;
+  let score = (matchedTokens.length / tokens.length) * 40;
   if (title === normalizedQuery) score += 120;
   else if (title.includes(normalizedQuery)) score += 60;
   if (identity.includes(normalizedQuery)) score += 45;
   if (description.includes(normalizedQuery)) score += 30;
 
-  for (const token of tokens) {
+  for (const token of matchedTokens) {
     if (title.includes(token)) score += 24;
     if (identity.includes(token)) score += 18;
     if (description.includes(token)) score += 12;
     score += countMatches(body, token) * 2;
   }
-  return score;
+  return { score, matchedTokens };
 };
 
 const excerptFrom = (
@@ -126,7 +131,7 @@ export const searchDocumentation = (
   return documents
     .map((document) => ({
       document,
-      score: scoreDocument(document, normalizedQuery, tokens),
+      ...scoreDocument(document, normalizedQuery, tokens),
     }))
     .filter((candidate) => candidate.score > 0)
     .sort(
@@ -135,14 +140,14 @@ export const searchDocumentation = (
         left.document.title.localeCompare(right.document.title),
     )
     .slice(0, limit)
-    .map(({ document }) => ({
+    .map(({ document, matchedTokens }) => ({
       id: document.id,
       uri: document.uri,
       url: document.url,
       title: document.title,
       description: document.description,
       kind: document.kind,
-      excerpt: excerptFrom(document, tokens),
+      excerpt: excerptFrom(document, matchedTokens),
     }));
 };
 


### PR DESCRIPTION
Closes #214

## What

`search_docs` previously zeroed out any document missing even one query token, so long natural-language queries like the observed one returned nothing:

> WebMCP how to use @web-ai-sdk/webmcp browser support registration tools declarative imperative

`scoreDocument()` now ranks by partial token coverage:

- A **strict majority** of query tokens must match a document; below that the score stays 0, so unrelated queries (and the existing `definitely-not-in-these-docs` case) still return no results.
- Matching documents get a coverage-proportional base score, so higher token coverage ranks higher.
- The exact-title / identifier / description phrase bonuses are unchanged and remain the largest contributions, so exact matches keep top priority.
- Excerpts are built from the tokens that actually contributed to the match.

## Verification

- The observed query now returns `guides/webmcp` at #3 of 5 (behind `react/use-webmcp` and `packages/webmcp`, whose titles contain query tokens).
- Regression tests added for the observed query and for strict no-match behavior (`quantum blockchain kubernetes terraform webmcp`, `definitely-not-in-these-docs webmcp`).
- Live-tested against `wrangler dev` over MCP JSON-RPC: observed query returns the WebMCP docs, unrelated query returns "No matching web-ai-sdk documentation was found."
- Full `pnpm gate` passes (lint, docs:check, build, typecheck, all tests).

Search stays local and deterministic; no tool names or response schemas changed.