### PR TITLE
fix(webmcp): isolate failed registration cleanup from replacement tools

### DIFF
--- a/.changeset/webmcp-failed-registration-cleanup.md
+++ b/.changeset/webmcp-failed-registration-cleanup.md
@@ -1,0 +1,5 @@
+---
+"@web-ai-sdk/webmcp": patch
+---
+
+Isolate failed-registration cleanup from same-name replacement tools. Browser builds with the pre-WebMCP-PR-#240 ordering attach the signal's unregister algorithm before validating `exposedTo`, so aborting the signal of a rejected registration could unregister a later valid tool with the same name. Cleanup returned by `registerTool()` (and React unmount via `useWebMCP`) no longer aborts once the native registration has rejected; cancelling a pending registration and unregistering a successful one are unchanged, and cleanup stays idempotent.

--- a/packages/webmcp/src/index.test.ts
+++ b/packages/webmcp/src/index.test.ts
@@ -649,6 +649,209 @@ describe("registerTool", () => {
   });
 });
 
+describe("failed-registration cleanup isolation", () => {
+  const INVALID_ORIGIN = "not-a-trustworthy-origin";
+  const securityError = () =>
+    new DOMException(
+      "Failed to execute 'registerTool' on 'ModelContext': exposedTo contains an origin that is not potentially trustworthy.",
+      "SecurityError",
+    );
+
+  /**
+   * Deterministic fake host reproducing the ordering defect documented in
+   * WebMCP PR #240: the signal's unregister algorithm is attached BEFORE
+   * `exposedTo` validation. A rejected registration therefore leaves a stale
+   * abort handler that removes whatever tool currently holds the name — the
+   * exact hazard the SDK cleanup must not trigger. Pass `{ sync: true }` for
+   * the legacy synchronous-throw shape.
+   */
+  const installPreFixOrderingModelContext = ({
+    sync = false,
+  }: {
+    sync?: boolean;
+  } = {}) => {
+    const registered = new Map<string, RegisteredCall>();
+    const registerTool = vi.fn(
+      (def: RegisteredCall, options?: NativeRegisterOptions) => {
+        // Pre-fix ordering: unregister algorithm attached first...
+        options?.signal?.addEventListener("abort", () => {
+          registered.delete(def.name);
+        });
+        // ...then options are validated; rejecting leaves the handler live.
+        const validateAndApply = () => {
+          if (options?.exposedTo?.includes(INVALID_ORIGIN)) {
+            throw securityError();
+          }
+          if (registered.has(def.name)) {
+            throw new Error(
+              "Failed to execute 'registerTool' on 'ModelContext': Duplicate tool name",
+            );
+          }
+          registered.set(def.name, def);
+        };
+        if (sync) {
+          validateAndApply();
+          return undefined;
+        }
+        return new Promise<void>((resolve, reject) => {
+          try {
+            validateAndApply();
+            resolve();
+          } catch (err) {
+            reject(err);
+          }
+        });
+      },
+    );
+    setModelContext("navigator", { registerTool });
+    return { registered, registerTool };
+  };
+
+  const sharedTool = (description: string): Tool => ({
+    name: "shared",
+    description,
+    execute: async () => ({}),
+  });
+
+  it("cleanup from an asynchronously rejected registration does not unregister a later valid same-name tool", async () => {
+    const { registered } = installPreFixOrderingModelContext();
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const cleanupRejected = registerTool(sharedTool("rejected"), {
+      exposedTo: [INVALID_ORIGIN],
+    });
+    await flush();
+    expect(registered.has("shared")).toBe(false);
+    // Native error name/message surface unchanged in the existing log.
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringMatching(/not potentially trustworthy/),
+    );
+
+    const cleanupValid = registerTool(sharedTool("replacement"));
+    await flush();
+    expect(registered.get("shared")?.description).toBe("replacement");
+
+    // The rejected attempt's cleanup must not fire its stale abort handler.
+    cleanupRejected();
+    expect(registered.get("shared")?.description).toBe("replacement");
+
+    // Repeated cleanup of the failed attempt stays a no-op.
+    cleanupRejected();
+    expect(registered.get("shared")?.description).toBe("replacement");
+
+    // The successful registration still unregisters exactly once.
+    cleanupValid();
+    expect(registered.has("shared")).toBe(false);
+    cleanupValid();
+    expect(registered.has("shared")).toBe(false);
+    errorSpy.mockRestore();
+  });
+
+  it("cleanup from a synchronously thrown registration does not unregister a later valid same-name tool", async () => {
+    const { registered } = installPreFixOrderingModelContext({ sync: true });
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const cleanupRejected = registerTool(sharedTool("rejected"), {
+      exposedTo: [INVALID_ORIGIN],
+    });
+    await flush();
+    expect(registered.has("shared")).toBe(false);
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringMatching(/not potentially trustworthy/),
+    );
+
+    const cleanupValid = registerTool(sharedTool("replacement"));
+    await flush();
+    expect(registered.get("shared")?.description).toBe("replacement");
+
+    cleanupRejected();
+    cleanupRejected();
+    expect(registered.get("shared")?.description).toBe("replacement");
+
+    cleanupValid();
+    expect(registered.has("shared")).toBe(false);
+    errorSpy.mockRestore();
+  });
+
+  it("cleanup while registration is pending still cancels it on a pre-fix host", async () => {
+    const registered = new Map<string, RegisteredCall>();
+    let settle: (() => void) | undefined;
+    const nativeRegister = vi.fn(
+      (def: RegisteredCall, options?: NativeRegisterOptions) => {
+        // Pre-fix ordering: handler attached before validation completes.
+        options?.signal?.addEventListener("abort", () => {
+          registered.delete(def.name);
+        });
+        return new Promise<void>((resolve, reject) => {
+          options?.signal?.addEventListener("abort", () => {
+            reject(
+              new DOMException("The user aborted a request.", "AbortError"),
+            );
+          });
+          settle = () => {
+            registered.set(def.name, def);
+            resolve();
+          };
+        });
+      },
+    );
+    setModelContext("navigator", { registerTool: nativeRegister });
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    const cleanup = registerTool(sharedTool("pending"));
+    expect(settle).toBeDefined();
+    cleanup(); // abort before the pending registration settles
+    await flush();
+
+    expect(registered.has("shared")).toBe(false);
+    expect(errorSpy).not.toHaveBeenCalled();
+    expect(warnSpy).not.toHaveBeenCalled();
+    errorSpy.mockRestore();
+    warnSpy.mockRestore();
+  });
+
+  it("preserves last-writer eviction on a pre-fix host", async () => {
+    const { registered } = installPreFixOrderingModelContext();
+
+    const cleanupA = registerTool(sharedTool("first"));
+    await flush();
+    expect(registered.get("shared")?.description).toBe("first");
+
+    const cleanupB = registerTool(sharedTool("second"));
+    await flush();
+    expect(registered.get("shared")?.description).toBe("second");
+
+    cleanupA();
+    expect(registered.get("shared")?.description).toBe("second");
+    cleanupB();
+    expect(registered.has("shared")).toBe(false);
+  });
+
+  it("cleanup after a duplicate-name skip does not tear down the other caller's tool on a pre-fix host", async () => {
+    const { registered } = installPreFixOrderingModelContext();
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    // Pre-occupy the name outside the wrapper; the wrapper cannot evict it.
+    registered.set("shared", {
+      name: "shared",
+      description: "owned by someone else",
+      execute: () => ({}),
+    });
+
+    const cleanup = registerTool(sharedTool("ours"));
+    await flush();
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringMatching(/already registered by another caller/),
+    );
+
+    // Both failed attempts left stale abort handlers; cleanup must not fire
+    // them against the other caller's registration.
+    cleanup();
+    expect(registered.get("shared")?.description).toBe("owned by someone else");
+    warnSpy.mockRestore();
+  });
+});
+
 describe("Standard Schema tool definitions", () => {
   // Tiny Standard-Schema-shaped validator for tests; mirrors what a real
   // Zod/Valibot schema would expose via the `~standard` property. Kept inline

--- a/packages/webmcp/src/index.ts
+++ b/packages/webmcp/src/index.ts
@@ -197,6 +197,21 @@ export const subscribeToToolChanges = (
  */
 const ownedControllers = new Map<string, AbortController>();
 
+/**
+ * Outcome of one async native registration, shared between the registration
+ * pipeline and the synchronous cleanup returned by `registerTool`.
+ *
+ * Affected browser builds attach the signal's unregister algorithm before
+ * validating registration options (see WebMCP PR #240), so a rejected
+ * registration can leave a stale unregister algorithm on our signal. Cleanup
+ * must therefore never abort once the outcome is `"failed"`: nothing of ours
+ * is registered, and the stale algorithm could remove a later valid tool
+ * with the same name.
+ */
+interface RegistrationState {
+  outcome: "pending" | "registered" | "failed";
+}
+
 const isDuplicateNameError = (err: unknown): boolean =>
   /duplicate/i.test((err as Error)?.message ?? "");
 
@@ -258,6 +273,7 @@ const registerOne = async (
   mc: ModelContext,
   registered: NativeToolDefinition,
   controller: AbortController,
+  state: RegistrationState,
   options?: RegisterToolOptions,
 ): Promise<boolean> => {
   // If we still hold a live controller for this name, evict it before the
@@ -277,6 +293,7 @@ const registerOne = async (
 
     if (!isDuplicateNameError(err)) {
       // Unrecoverable first-call failure: log and give up (no throw).
+      state.outcome = "failed";
       if (typeof console !== "undefined") {
         console.error(
           `[@web-ai-sdk/webmcp] tool "${registered.name}" could not be registered: ${(err as Error)?.message ?? String(err)}`,
@@ -295,6 +312,7 @@ const registerOne = async (
       await callRegister(mc, registered, controller, options);
     } catch (retryErr) {
       if (controller.signal.aborted) return false;
+      state.outcome = "failed";
       if (isDuplicateNameError(retryErr)) {
         if (typeof console !== "undefined") {
           console.warn(
@@ -312,6 +330,7 @@ const registerOne = async (
     }
   }
 
+  state.outcome = "registered";
   trackOwnership(controller, registered.name);
   return true;
 };
@@ -357,16 +376,22 @@ export function registerTool(
 
   const registered = toRegistered(normalizeToolDefinition(tool));
   const controller = new AbortController();
+  const state: RegistrationState = { outcome: "pending" };
   // Fire-and-forget: registerOne is total (never rejects — see its contract),
   // so there is no unhandled-rejection risk. The sync cleanup below aborts the
   // controller; if registration is still pending, the abort propagates to the
   // host and registerOne treats it as a clean cancellation.
-  void registerOne(mc, registered, controller, options);
+  void registerOne(mc, registered, controller, state, options);
 
   let disposed = false;
   return () => {
     if (disposed) return;
     disposed = true;
+    // Once the native registration has rejected there is nothing of ours to
+    // unregister, and aborting would fire any stale unregister algorithm the
+    // failed attempt left on our signal (see RegistrationState) — which could
+    // remove a later valid tool registered under the same name.
+    if (state.outcome === "failed") return;
     controller.abort();
   };
 }

--- a/packages/webmcp/src/react/index.test.tsx
+++ b/packages/webmcp/src/react/index.test.tsx
@@ -694,3 +694,122 @@ describe("useWebMCP discovery", () => {
     expect(result.current.tools).toEqual([]);
   });
 });
+
+describe("useWebMCP cleanup isolation after failed registration", () => {
+  const INVALID_ORIGIN = "not-a-trustworthy-origin";
+
+  /** Flush the async native register pipeline (chains several microtasks). */
+  const flush = () => new Promise<void>((resolve) => setTimeout(resolve, 0));
+
+  /**
+   * Fake host reproducing the pre-WebMCP-PR-#240 ordering: the signal's
+   * unregister algorithm is attached BEFORE `exposedTo` validation, so a
+   * rejected registration leaves a stale abort handler able to remove a
+   * later valid tool with the same name.
+   */
+  const installPreFixOrderingModelContext = () => {
+    const registered = new Map<string, RegisteredCall>();
+    const registerTool = vi.fn(
+      (
+        def: RegisteredCall,
+        options?: { signal?: AbortSignal; exposedTo?: readonly string[] },
+      ) => {
+        options?.signal?.addEventListener("abort", () => {
+          registered.delete(def.name);
+        });
+        return new Promise<void>((resolve, reject) => {
+          if (options?.exposedTo?.includes(INVALID_ORIGIN)) {
+            reject(
+              new DOMException(
+                "Failed to execute 'registerTool' on 'ModelContext': exposedTo contains an origin that is not potentially trustworthy.",
+                "SecurityError",
+              ),
+            );
+            return;
+          }
+          if (registered.has(def.name)) {
+            reject(
+              new Error(
+                "Failed to execute 'registerTool' on 'ModelContext': Duplicate tool name",
+              ),
+            );
+            return;
+          }
+          registered.set(def.name, def);
+          resolve();
+        });
+      },
+    );
+    setModelContext("navigator", { registerTool });
+    return { registered, registerTool };
+  };
+
+  const sharedTool = (description: string): Tool => ({
+    name: "shared",
+    description,
+    execute: async () => ({}),
+  });
+
+  it("unmount after a rejected registration does not unregister a later valid same-name tool", async () => {
+    const { registered } = installPreFixOrderingModelContext();
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const failed = renderHook(() =>
+      useWebMCP(sharedTool("rejected"), { exposedTo: [INVALID_ORIGIN] }),
+    );
+    await act(flush);
+    expect(registered.has("shared")).toBe(false);
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringMatching(/not potentially trustworthy/),
+    );
+
+    const replacement = renderHook(() => useWebMCP(sharedTool("replacement")));
+    await act(flush);
+    expect(registered.get("shared")?.description).toBe("replacement");
+
+    failed.unmount();
+    expect(registered.get("shared")?.description).toBe("replacement");
+
+    // Unmount after successful registration still unregisters exactly once.
+    replacement.unmount();
+    expect(registered.has("shared")).toBe(false);
+    errorSpy.mockRestore();
+  });
+
+  it("unmount while registration is pending still cancels it", async () => {
+    const registered = new Map<string, RegisteredCall>();
+    let settle: (() => void) | undefined;
+    const nativeRegister = vi.fn(
+      (def: RegisteredCall, options?: { signal?: AbortSignal }) => {
+        options?.signal?.addEventListener("abort", () => {
+          registered.delete(def.name);
+        });
+        return new Promise<void>((resolve, reject) => {
+          options?.signal?.addEventListener("abort", () => {
+            reject(
+              new DOMException("The user aborted a request.", "AbortError"),
+            );
+          });
+          settle = () => {
+            registered.set(def.name, def);
+            resolve();
+          };
+        });
+      },
+    );
+    setModelContext("navigator", { registerTool: nativeRegister });
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    const { unmount } = renderHook(() => useWebMCP(sharedTool("pending")));
+    expect(settle).toBeDefined();
+    unmount(); // abort before the pending registration settles
+    await act(flush);
+
+    expect(registered.has("shared")).toBe(false);
+    expect(errorSpy).not.toHaveBeenCalled();
+    expect(warnSpy).not.toHaveBeenCalled();
+    errorSpy.mockRestore();
+    warnSpy.mockRestore();
+  });
+});


### PR DESCRIPTION
Closes #206

## Problem

`registerTool()` returns its cleanup synchronously and aborts the owned `AbortSignal` unconditionally. On browser builds with the ordering defect documented in [WebMCP PR #240](https://github.com/webmachinelearning/webmcp/pull/240), the signal's unregister algorithm is attached **before** `exposedTo` validation, so a rejected registration leaves a stale unregister algorithm on our signal. Calling cleanup from that rejected attempt after a later valid tool registered under the same name would remove the valid replacement.

## Fix

- Track each registration's outcome (`pending` / `registered` / `failed`) in a state record shared between the async `registerOne` pipeline and the synchronous cleanup.
- Cleanup becomes a no-op once the native registration has rejected (including the duplicate-name warn-and-skip path, which previously could tear down another caller's tool on affected builds).
- Unchanged: cancelling a still-pending registration, unregistering a successful one exactly once, cleanup idempotency, last-writer eviction, native error names, and existing logging. The React adapter inherits the corrected lifecycle with no changes.

## Tests

New deterministic fake hosts reproduce the pre-#240 ordering (unregister handler attached before validation), covering async rejection, synchronous throw, pending cancellation, duplicate-name skip, last-writer eviction, and React unmount after failed/pending/successful registration. All 6 new regression tests fail without the one-line cleanup gate and pass with it.

- `pnpm gate` passes (lint, docs:check, build, typecheck, all tests).
- Patch changeset for `@web-ai-sdk/webmcp` included.