### PR TITLE
fix(ci): migrate Changesets action v2 inputs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,7 +43,7 @@ jobs:
       # pointing at this repo + workflow filename (release.yml).
       # The `id-token: write` permission above lets the npm CLI mint
       # a short-lived registry token from the GitHub OIDC token.
-      - uses: changesets/action@v1.9.0
+      - uses: changesets/action@v2.1.0
         with:
           publish: pnpm release
           version: pnpm version-packages

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,10 +45,10 @@ jobs:
       # a short-lived registry token from the GitHub OIDC token.
       - uses: changesets/action@v2.1.0
         with:
-          publish: pnpm release
-          version: pnpm version-packages
-          commit: "chore: version packages"
-          title: "chore: version packages"
+          publish-script: pnpm release
+          version-script: pnpm version-packages
+          commit-message: "chore: version packages"
+          pr-title: "chore: version packages"
           # A PAT (not the default GITHUB_TOKEN) so the opened "Version
           # Packages" PR triggers the CI workflow. GitHub intentionally
           # suppresses workflow runs for events created by GITHUB_TOKEN.


### PR DESCRIPTION
Updates `changesets/action` to v2.1.0 and migrates the release workflow to its renamed inputs:

- `publish` → `publish-script`
- `version` → `version-script`
- `commit` → `commit-message`
- `title` → `pr-title`

This preserves the existing versioning and publishing commands after the action upgrade.

Closes #219