### PR TITLE
fix(deps): update nanoid to 3.3.18

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,7 +7,7 @@ settings:
 overrides:
   yaml@<2.8.3: '>=2.8.3 <3.0.0'
   postcss@^8.0.0: 8.5.23
-  nanoid@^3.0.0: 3.3.17
+  nanoid@^3.0.0: 3.3.18
   js-yaml@^4.0.0: 4.3.1
   read-yaml-file>js-yaml: 3.15.1
   fast-uri@^3.0.0: 3.1.5
@@ -3303,8 +3303,8 @@ packages:
   mz@2.7.0:
     resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
 
-  nanoid@3.3.17:
-    resolution: {integrity: sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==}
+  nanoid@3.3.18:
+    resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -7405,7 +7405,7 @@ snapshots:
       object-assign: 4.1.1
       thenify-all: 1.6.0
 
-  nanoid@3.3.17: {}
+  nanoid@3.3.18: {}
 
   neotraverse@1.0.1: {}
 
@@ -7539,7 +7539,7 @@ snapshots:
 
   postcss@8.5.23:
     dependencies:
-      nanoid: 3.3.17
+      nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -5,7 +5,7 @@ packages:
 overrides:
   yaml@<2.8.3: ">=2.8.3 <3.0.0"
   postcss@^8.0.0: "8.5.23"
-  nanoid@^3.0.0: "3.3.17"
+  nanoid@^3.0.0: "3.3.18"
   js-yaml@^4.0.0: "4.3.1"
   read-yaml-file>js-yaml: 3.15.1
   fast-uri@^3.0.0: "3.1.5"


### PR DESCRIPTION
Updates the pnpm override for `nanoid` from 3.3.17 to 3.3.18.

This resolves Dependabot alert #72 for CVE-2026-67213.

Validation:
- `pnpm install --frozen-lockfile`
- `pnpm audit --prod` reports zero vulnerabilities