### PR TITLE
chore(dev): support isolated worktree environments

### DIFF
--- a/.agents/agents.md
+++ b/.agents/agents.md
@@ -128,8 +128,14 @@ consumes package output. Run `pnpm gate` before any commit.
 
 ## Git and workspace safety
 
-- Work only in the session's current working tree. Never create a worktree,
-  including through a skill, subagent, temporary directory, or `.worktrees/`.
+- Work only in the session's current workspace. Never edit another worktree
+  from the current session.
+- Create a worktree only after the user explicitly approves parallel work.
+- Keep every worktree outside the repository. Never create temporary or in-tree
+  worktrees, including under `.worktrees/`.
+- Give each parallel editor a separate workspace. Confirm its root and branch
+  with `git rev-parse --show-toplevel` and `git status --short --branch`.
+- Run `pnpm dev:setup` in a new worktree before development starts.
 - Do not overwrite or hide existing changes. If unexpected changes exist before
   work starts, stop and ask the user to commit or stash them.
 - Use a dedicated branch. Never commit, merge, or push directly to `main`.
@@ -142,5 +148,5 @@ consumes package output. Run `pnpm gate` before any commit.
 - Never rebase, delete branches, or amend commits without explicit approval.
 - Force-push only with explicit approval to update an existing PR.
 - Do not add agent attribution or `Co-authored-by:` trailers.
-- If parallel work needs another branch, stop and ask the user to create the
-  workspace through their tool.
+- If the current tool cannot provide an isolated workspace, stop and ask the
+  user to create one through their workspace manager.

--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,7 @@ coverage/
 storybook-static/
 _site/
 .astro/
-# In-tree git worktrees for parallel branch work (see .agents/agents.md §11).
+# Keep linked worktrees outside the repository.
 .worktrees/
 
 *.log

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,6 +20,62 @@ Published packages live in `packages/`. The Astro site and Starlight docs live
 in `apps/site/`. The read-only web-ai-sdk MCP Worker lives in `apps/mcp/`.
 Run `pnpm run` to list all workflows.
 
+## Parallel worktrees
+
+Use a separate linked worktree when issues need concurrent editors. Create each
+worktree from the approved base branch or PR.
+
+Run the same setup in every checkout:
+
+```sh
+pnpm dev:setup
+pnpm dev:info
+```
+
+The first command installs locked dependencies and builds publishable packages.
+The second command prints the development identity and service URLs.
+
+The primary checkout preserves the standard service ports. Each linked
+worktree derives stable ports and `*.localhost` names from its canonical path.
+
+Start services normally from any worktree:
+
+```sh
+pnpm dev:packages
+pnpm dev
+pnpm mcp
+```
+
+Do not copy `.env` files or secrets into a worktree. Add required local values
+through that worktree's environment instead.
+
+Set `WEB_AI_SDK_DEV_INSTANCE` to override the derived identity. Set a
+service-specific port variable if a generated port conflicts with another
+process. See the [root README](./README.md#parallel-development-worktrees) for
+the complete variable list.
+
+### Optional Paseo workflow
+
+The checked-in [`paseo.json`](./paseo.json) automates `pnpm dev:setup`. It also
+provides supervised service commands:
+
+Start a managed service from the worktree directory:
+
+```sh
+paseo script ls
+paseo script start packages
+paseo script start site
+paseo script start mcp
+```
+
+Paseo prints a distinct proxy URL for each branch and service. Its adapter maps
+the allocated port to the project's generic environment variables.
+
+Start `packages` with `site` when package source changes must reach a demo.
+
+Keep one editor in each worktree. Confirm the workspace path before editing,
+and archive the workspace only after preserving every required change.
+
 ## Change workflow
 
 1. Change one package or app at a time when possible.

--- a/README.md
+++ b/README.md
@@ -107,6 +107,77 @@ pnpm dev             # site at http://localhost:5173/, docs at /docs/
 
 The demos require a browser that supports the selected API. See [Browser support](./apps/site/src/content/docs/browser-support.mdx) for versions, flags, trials, and hardware requirements.
 
+### Parallel development worktrees
+
+Each linked worktree gets a stable development instance. The instance identity
+uses the worktree directory name and a hash of its canonical path.
+
+Set up any checkout or worktree with the same command:
+
+```sh
+pnpm dev:setup
+pnpm dev:info
+```
+
+`pnpm dev:setup` installs locked dependencies and builds the packages.
+`pnpm dev:info` prints the instance identity and local service URLs.
+
+The primary checkout keeps the standard ports. Linked worktrees receive stable
+ports and distinct `*.localhost` names:
+
+| Service | Primary checkout | Linked worktree port range |
+| --- | --- | --- |
+| Site | `http://localhost:5173/` | `20000-24999` |
+| Preview | `http://localhost:4173/` | `30000-34999` |
+| MCP | `http://localhost:8787/` | `40000-44999` |
+| MCP inspector | Wrangler default | `50000-54999` |
+
+A linked site URL uses this form:
+
+```text
+http://site--<instance>.web-ai-sdk.localhost:<port>/
+```
+
+Use these environment variables when you need explicit values:
+
+| Variable | Behavior |
+| --- | --- |
+| `WEB_AI_SDK_DEV_INSTANCE` | Overrides the derived development identity. |
+| `WEB_AI_SDK_HOST` | Overrides the local bind address. |
+| `WEB_AI_SDK_SITE_PORT` | Overrides the site port. |
+| `WEB_AI_SDK_PREVIEW_PORT` | Overrides the preview port. |
+| `WEB_AI_SDK_MCP_PORT` | Overrides the MCP server port. |
+| `WEB_AI_SDK_MCP_INSPECTOR_PORT` | Overrides the MCP inspector port. |
+
+The generated port can rarely conflict with another local process. Set the
+matching port variable when that happens.
+
+#### Optional Paseo integration
+
+The checked-in [`paseo.json`](./paseo.json) automates setup and process
+supervision. The project does not require Paseo for development isolation.
+
+Paseo provides these workspace scripts:
+
+| Script | Behavior |
+| --- | --- |
+| `site` | Runs the Astro site through a stable `*.localhost` proxy URL. |
+| `mcp` | Runs the local MCP Worker through a separate proxy URL. |
+| `packages` | Watches wrapper package builds during SDK changes. |
+| `preview` | Builds and previews the complete Pages artifact. |
+| `gate` | Runs the full quality gate without starting a service. |
+
+List the URLs and service state from a workspace:
+
+```sh
+paseo script ls
+paseo script start packages
+paseo script start site
+```
+
+Paseo allocates backend ports and exposes each service through a proxy URL. A
+small adapter passes each backend port through a generic variable listed above.
+
 ## Repo layout
 
 ```
@@ -124,6 +195,8 @@ The demos require a browser that supports the selected API. See [Browser support
 ├── apps/
 │   ├── site/           # @web-ai-sdk-apps/site (private; Astro site + Starlight docs)
 │   └── mcp/            # @web-ai-sdk-apps/mcp (private; web-ai-sdk MCP Worker)
+├── scripts/            # development instance and optional tool adapters
+├── paseo.json          # optional worktree setup and managed local services
 ├── .agents/agents.md           # agent instructions (AGENTS.md symlink kept at root)
 ├── README.md           # ← you are here
 └── …

--- a/apps/mcp/package.json
+++ b/apps/mcp/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "build": "pnpm docs:build && wrangler deploy --dry-run --outdir dist",
     "deploy": "pnpm docs:build && wrangler deploy",
-    "dev": "pnpm docs:build && wrangler dev",
+    "dev": "pnpm docs:build && node scripts/run-dev.mjs",
     "docs:build": "node scripts/build-docs.mjs",
     "test": "pnpm docs:build && vitest run",
     "test:watch": "pnpm docs:build && vitest",

--- a/apps/mcp/scripts/local-server.mjs
+++ b/apps/mcp/scripts/local-server.mjs
@@ -1,0 +1,32 @@
+import { fileURLToPath } from "node:url";
+import { resolveDevelopmentService } from "../../../scripts/development-instance.mjs";
+
+const repositoryRoot = fileURLToPath(new URL("../../../", import.meta.url));
+
+export function buildWranglerDevArgs(
+  env = process.env,
+  root = repositoryRoot,
+) {
+  const server = resolveDevelopmentService("mcp", root, env);
+  const inspector = resolveDevelopmentService("mcpInspector", root, env);
+
+  if (
+    server.instance.primary &&
+    !server.configured &&
+    !inspector.configured
+  ) {
+    return ["exec", "wrangler", "dev"];
+  }
+
+  return [
+    "exec",
+    "wrangler",
+    "dev",
+    "--ip",
+    server.bindHost ?? "127.0.0.1",
+    "--port",
+    String(server.port),
+    "--inspector-port",
+    String(inspector.port),
+  ];
+}

--- a/apps/mcp/scripts/local-server.test.mjs
+++ b/apps/mcp/scripts/local-server.test.mjs
@@ -1,0 +1,93 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { buildWranglerDevArgs } from "./local-server.mjs";
+
+const temporaryRoots = [];
+
+function createCheckout(primary) {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "web-ai-sdk-mcp-"));
+  temporaryRoots.push(root);
+
+  if (primary) {
+    fs.mkdirSync(path.join(root, ".git"));
+  } else {
+    fs.writeFileSync(path.join(root, ".git"), "gitdir: elsewhere");
+  }
+
+  return root;
+}
+
+afterEach(() => {
+  for (const root of temporaryRoots.splice(0)) {
+    fs.rmSync(root, { force: true, recursive: true });
+  }
+});
+
+describe("buildWranglerDevArgs", () => {
+  it("keeps Wrangler defaults in the primary checkout", () => {
+    expect(buildWranglerDevArgs({}, createCheckout(true))).toEqual([
+      "exec",
+      "wrangler",
+      "dev",
+    ]);
+  });
+
+  it("uses stable MCP and inspector ports in a linked worktree", () => {
+    const args = buildWranglerDevArgs({}, createCheckout(false));
+    const port = Number(args[args.indexOf("--port") + 1]);
+    const inspectorPort = Number(args[args.indexOf("--inspector-port") + 1]);
+
+    expect(args.slice(0, 5)).toEqual([
+      "exec",
+      "wrangler",
+      "dev",
+      "--ip",
+      "127.0.0.1",
+    ]);
+    expect(port).toBeGreaterThanOrEqual(40_000);
+    expect(port).toBeLessThan(45_000);
+    expect(inspectorPort).toBeGreaterThanOrEqual(50_000);
+    expect(inspectorPort).toBeLessThan(55_000);
+  });
+
+  it("accepts generic host, server, and inspector overrides", () => {
+    expect(
+      buildWranglerDevArgs(
+        {
+          WEB_AI_SDK_HOST: "127.0.0.1",
+          WEB_AI_SDK_MCP_INSPECTOR_PORT: "0",
+          WEB_AI_SDK_MCP_PORT: "24567",
+        },
+        createCheckout(true),
+      ),
+    ).toEqual([
+      "exec",
+      "wrangler",
+      "dev",
+      "--ip",
+      "127.0.0.1",
+      "--port",
+      "24567",
+      "--inspector-port",
+      "0",
+    ]);
+  });
+
+  it("rejects invalid generic ports", () => {
+    const root = createCheckout(true);
+
+    expect(() =>
+      buildWranglerDevArgs({ WEB_AI_SDK_MCP_PORT: "0" }, root),
+    ).toThrow("WEB_AI_SDK_MCP_PORT must be an integer from 1 through 65535.");
+    expect(() =>
+      buildWranglerDevArgs(
+        { WEB_AI_SDK_MCP_INSPECTOR_PORT: "12.5" },
+        root,
+      ),
+    ).toThrow(
+      "WEB_AI_SDK_MCP_INSPECTOR_PORT must be an integer from 0 through 65535.",
+    );
+  });
+});

--- a/apps/mcp/scripts/process-tree.test.mjs
+++ b/apps/mcp/scripts/process-tree.test.mjs
@@ -1,0 +1,60 @@
+import { once } from "node:events";
+import { setTimeout as delay } from "node:timers/promises";
+import { describe, expect, it } from "vitest";
+import {
+  spawnManagedProcess,
+  terminateProcessTree,
+} from "../../../scripts/process-tree.mjs";
+
+function isRunning(pid) {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function waitUntilStopped(pid) {
+  for (let attempt = 0; attempt < 50; attempt += 1) {
+    if (!isRunning(pid)) {
+      return true;
+    }
+
+    await delay(20);
+  }
+
+  return false;
+}
+
+describe("managed process trees", () => {
+  it.skipIf(process.platform === "win32")(
+    "terminates a spawned process and its descendants",
+    async () => {
+      const childSource = `
+        const { spawn } = require("node:child_process");
+        const grandchild = spawn(
+          process.execPath,
+          ["-e", "setInterval(() => {}, 1000)"],
+          { stdio: "ignore" },
+        );
+        process.stdout.write(String(grandchild.pid));
+        setInterval(() => {}, 1000);
+      `;
+      const child = spawnManagedProcess(
+        process.execPath,
+        ["-e", childSource],
+        { stdio: ["ignore", "pipe", "ignore"] },
+      );
+      const [output] = await once(child.stdout, "data");
+      const grandchildPid = Number(String(output));
+      const childExit = once(child, "exit");
+
+      expect(grandchildPid).toBeGreaterThan(0);
+      terminateProcessTree(child, "SIGTERM");
+      await childExit;
+
+      expect(await waitUntilStopped(grandchildPid)).toBe(true);
+    },
+  );
+});

--- a/apps/mcp/scripts/run-dev.mjs
+++ b/apps/mcp/scripts/run-dev.mjs
@@ -1,0 +1,19 @@
+import {
+  childProcessExitCode,
+  spawnManagedProcess,
+} from "../../../scripts/process-tree.mjs";
+import { buildWranglerDevArgs } from "./local-server.mjs";
+
+const pnpmCommand = process.platform === "win32" ? "pnpm.cmd" : "pnpm";
+const child = spawnManagedProcess(pnpmCommand, buildWranglerDevArgs(), {
+  stdio: "inherit",
+});
+
+child.once("error", (error) => {
+  console.error(error.message);
+  process.exitCode = 1;
+});
+
+child.once("exit", (code, signal) => {
+  process.exitCode = childProcessExitCode(code, signal);
+});

--- a/apps/mcp/vitest.config.ts
+++ b/apps/mcp/vitest.config.ts
@@ -3,6 +3,6 @@ import { defineConfig } from "vitest/config";
 export default defineConfig({
   test: {
     environment: "node",
-    include: ["src/**/*.test.ts"],
+    include: ["src/**/*.test.ts", "scripts/**/*.test.mjs"],
   },
 });

--- a/apps/site/astro.config.mjs
+++ b/apps/site/astro.config.mjs
@@ -3,6 +3,7 @@ import react from "@astrojs/react";
 import starlight from "@astrojs/starlight";
 import tailwindcss from "@tailwindcss/vite";
 import { defineConfig } from "astro/config";
+import { resolveLocalServer } from "./scripts/local-server.mjs";
 
 // Defaults to the custom-domain root. GitHub Pages builds override this with
 // SITE_BASE for project Pages or any other host prefix.
@@ -19,6 +20,7 @@ const preloadedFonts = [
 export default defineConfig({
   base,
   site: "https://web-ai-sdk.dev",
+  server: ({ command }) => resolveLocalServer(command),
   // Static meta-refresh stub so links to the pre-rename hook URL keep working.
   redirects: {
     "/docs/react/use-web-mcp/": "/docs/react/use-webmcp/",

--- a/apps/site/package.json
+++ b/apps/site/package.json
@@ -5,9 +5,9 @@
   "description": "Unified site for web-ai-sdk (Astro + Starlight docs + React islands)",
   "type": "module",
   "scripts": {
-    "dev": "astro dev --port 5173 --strictPort",
+    "dev": "astro dev --strictPort",
     "build": "astro build && node scripts/build-llms.mjs",
-    "preview": "astro preview --port 4173",
+    "preview": "astro preview",
     "test": "vitest run",
     "typecheck": "astro check",
     "og:build": "node scripts/build-og-image.mjs",

--- a/apps/site/scripts/development-instance.test.mjs
+++ b/apps/site/scripts/development-instance.test.mjs
@@ -1,0 +1,104 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  normalizeDevelopmentInstanceId,
+  resolveDevelopmentInstance,
+  resolveDevelopmentService,
+} from "../../../scripts/development-instance.mjs";
+
+const temporaryRoots = [];
+
+function createCheckout(name, primary) {
+  const parent = fs.mkdtempSync(
+    path.join(os.tmpdir(), "web-ai-sdk-instance-"),
+  );
+  const root = path.join(parent, name);
+  temporaryRoots.push(parent);
+  fs.mkdirSync(root);
+
+  if (primary) {
+    fs.mkdirSync(path.join(root, ".git"));
+  } else {
+    fs.writeFileSync(path.join(root, ".git"), "gitdir: elsewhere");
+  }
+
+  return root;
+}
+
+afterEach(() => {
+  for (const root of temporaryRoots.splice(0)) {
+    fs.rmSync(root, { force: true, recursive: true });
+  }
+});
+
+describe("development instances", () => {
+  it("uses the reserved default identity for the primary checkout", () => {
+    expect(
+      resolveDevelopmentInstance(createCheckout("sdk", true), {}),
+    ).toMatchObject({
+      id: "default",
+      portSlot: 0,
+      primary: true,
+      source: "primary-checkout",
+    });
+  });
+
+  it("derives a stable path-safe identity for a linked worktree", () => {
+    const root = createCheckout("Issue 224 ç", false);
+    const first = resolveDevelopmentInstance(root, {});
+    const second = resolveDevelopmentInstance(root, {});
+
+    expect(first).toEqual(second);
+    expect(first.id).toMatch(/^issue-224-c-[a-f0-9]{8}$/);
+    expect(first.primary).toBe(false);
+    expect(first.source).toBe("linked-worktree");
+    expect(first.portSlot).toBeGreaterThanOrEqual(0);
+    expect(first.portSlot).toBeLessThan(5_000);
+  });
+
+  it("supports an explicit tool-neutral instance override", () => {
+    const root = createCheckout("sdk", true);
+    const instance = resolveDevelopmentInstance(root, {
+      WEB_AI_SDK_DEV_INSTANCE: "Issue 227 / Review",
+    });
+
+    expect(instance).toMatchObject({
+      id: "issue-227-review",
+      primary: false,
+      source: "override",
+    });
+    expect(
+      resolveDevelopmentService("site", root, {
+        WEB_AI_SDK_DEV_INSTANCE: "Issue 227 / Review",
+      }).hostname,
+    ).toBe("site--issue-227-review.web-ai-sdk.localhost");
+  });
+
+  it("rejects empty and reserved normalized overrides", () => {
+    const root = createCheckout("sdk", true);
+
+    expect(() =>
+      resolveDevelopmentInstance(root, {
+        WEB_AI_SDK_DEV_INSTANCE: "!!!",
+      }),
+    ).toThrow(
+      "WEB_AI_SDK_DEV_INSTANCE must normalize to a non-reserved identifier.",
+    );
+    expect(() =>
+      resolveDevelopmentInstance(root, {
+        WEB_AI_SDK_DEV_INSTANCE: "default",
+      }),
+    ).toThrow(
+      "WEB_AI_SDK_DEV_INSTANCE must normalize to a non-reserved identifier.",
+    );
+  });
+
+  it("normalizes accents, separators, and length", () => {
+    expect(normalizeDevelopmentInstanceId("  Revisão / Issue 224  ")).toBe(
+      "revisao-issue-224",
+    );
+    expect(normalizeDevelopmentInstanceId("abcdefghij", 5)).toBe("abcde");
+  });
+});

--- a/apps/site/scripts/local-server.mjs
+++ b/apps/site/scripts/local-server.mjs
@@ -1,0 +1,21 @@
+import { fileURLToPath } from "node:url";
+import { resolveDevelopmentService } from "../../../scripts/development-instance.mjs";
+
+const repositoryRoot = fileURLToPath(new URL("../../../", import.meta.url));
+
+export function resolveLocalServer(
+  command,
+  env = process.env,
+  root = repositoryRoot,
+) {
+  const service = resolveDevelopmentService(
+    command === "dev" ? "site" : "preview",
+    root,
+    env,
+  );
+
+  return {
+    host: service.bindHost ?? false,
+    port: service.port,
+  };
+}

--- a/apps/site/scripts/local-server.test.mjs
+++ b/apps/site/scripts/local-server.test.mjs
@@ -1,0 +1,91 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { resolveLocalServer } from "./local-server.mjs";
+
+const temporaryRoots = [];
+
+function createCheckout(primary) {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "web-ai-sdk-site-"));
+  temporaryRoots.push(root);
+
+  if (primary) {
+    fs.mkdirSync(path.join(root, ".git"));
+  } else {
+    fs.writeFileSync(path.join(root, ".git"), "gitdir: elsewhere");
+  }
+
+  return root;
+}
+
+afterEach(() => {
+  for (const root of temporaryRoots.splice(0)) {
+    fs.rmSync(root, { force: true, recursive: true });
+  }
+});
+
+describe("resolveLocalServer", () => {
+  it("keeps the existing site defaults in the primary checkout", () => {
+    const root = createCheckout(true);
+
+    expect(resolveLocalServer("dev", {}, root)).toEqual({
+      host: false,
+      port: 5173,
+    });
+    expect(resolveLocalServer("preview", {}, root)).toEqual({
+      host: false,
+      port: 4173,
+    });
+  });
+
+  it("uses stable isolated addresses in a linked worktree", () => {
+    const root = createCheckout(false);
+    const first = resolveLocalServer("dev", {}, root);
+    const second = resolveLocalServer("dev", {}, root);
+
+    expect(first).toEqual(second);
+    expect(first.host).toBe("127.0.0.1");
+    expect(first.port).toBeGreaterThanOrEqual(20_000);
+    expect(first.port).toBeLessThan(25_000);
+  });
+
+  it("accepts generic host and port overrides", () => {
+    expect(
+      resolveLocalServer(
+        "dev",
+        {
+          WEB_AI_SDK_HOST: "0.0.0.0",
+          WEB_AI_SDK_SITE_PORT: "23456",
+        },
+        createCheckout(true),
+      ),
+    ).toEqual({
+      host: "0.0.0.0",
+      port: 23456,
+    });
+  });
+
+  it("rejects invalid generic ports", () => {
+    const root = createCheckout(true);
+
+    expect(() =>
+      resolveLocalServer(
+        "dev",
+        { WEB_AI_SDK_SITE_PORT: "not-a-port" },
+        root,
+      ),
+    ).toThrow(
+      "WEB_AI_SDK_SITE_PORT must be an integer from 1 through 65535.",
+    );
+    expect(() =>
+      resolveLocalServer(
+        "dev",
+        { WEB_AI_SDK_SITE_PORT: "65536" },
+        root,
+      ),
+    ).toThrow(
+      "WEB_AI_SDK_SITE_PORT must be an integer from 1 through 65535.",
+    );
+  });
+});

--- a/biome.json
+++ b/biome.json
@@ -12,6 +12,8 @@
       "!**/storybook-static",
       "!**/.astro",
       "!**/_site",
+      "!**/.claude/worktrees",
+      "!**/.codex/worktrees",
       "!**/.worktrees"
     ]
   },

--- a/package.json
+++ b/package.json
@@ -20,6 +20,8 @@
   },
   "scripts": {
     "dev": "pnpm --filter @web-ai-sdk-apps/site run dev",
+    "dev:info": "node scripts/development-info.mjs",
+    "dev:setup": "pnpm install --frozen-lockfile && pnpm build:packages",
     "dev:packages": "pnpm --filter \"./packages/**\" --filter \"!@web-ai-sdk/all\" -r --parallel run dev",
     "dev:sdk": "pnpm build:packages && pnpm --filter @web-ai-sdk/all run dev",
     "dev:apps": "pnpm dev",

--- a/paseo.json
+++ b/paseo.json
@@ -1,0 +1,30 @@
+{
+  "worktree": {
+    "setup": [
+      "pnpm dev:setup"
+    ],
+    "servicePorts": {
+      "range": "20000-29999"
+    }
+  },
+  "scripts": {
+    "site": {
+      "type": "service",
+      "command": "node scripts/paseo-service.mjs site"
+    },
+    "mcp": {
+      "type": "service",
+      "command": "node scripts/paseo-service.mjs mcp"
+    },
+    "packages": {
+      "command": "pnpm dev:packages"
+    },
+    "preview": {
+      "type": "service",
+      "command": "node scripts/paseo-service.mjs preview"
+    },
+    "gate": {
+      "command": "pnpm gate"
+    }
+  }
+}

--- a/scripts/development-info.mjs
+++ b/scripts/development-info.mjs
@@ -1,0 +1,19 @@
+import { fileURLToPath } from "node:url";
+import {
+  resolveDevelopmentInstance,
+  resolveDevelopmentService,
+} from "./development-instance.mjs";
+
+const root = fileURLToPath(new URL("../", import.meta.url));
+const instance = resolveDevelopmentInstance(root);
+
+console.log(`Development instance: ${instance.id}`);
+console.log(`Source: ${instance.source}`);
+
+for (const [label, service] of [
+  ["Site", "site"],
+  ["Preview", "preview"],
+  ["MCP", "mcp"],
+]) {
+  console.log(`${label}: ${resolveDevelopmentService(service, root).url}`);
+}

--- a/scripts/development-instance.mjs
+++ b/scripts/development-instance.mjs
@@ -1,0 +1,188 @@
+import crypto from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+
+const DEFAULT_INSTANCE_ID = "default";
+const INSTANCE_OVERRIDE_VARIABLE = "WEB_AI_SDK_DEV_INSTANCE";
+const HOST_OVERRIDE_VARIABLE = "WEB_AI_SDK_HOST";
+const MAX_OVERRIDE_LENGTH = 32;
+const MAX_SLUG_LENGTH = 18;
+const PORT_SLOT_COUNT = 5_000;
+
+const SERVICE_DEFINITIONS = Object.freeze({
+  site: Object.freeze({
+    defaultPort: 5_173,
+    isolatedPortBase: 20_000,
+    portVariable: "WEB_AI_SDK_SITE_PORT",
+  }),
+  preview: Object.freeze({
+    defaultPort: 4_173,
+    isolatedPortBase: 30_000,
+    portVariable: "WEB_AI_SDK_PREVIEW_PORT",
+  }),
+  mcp: Object.freeze({
+    defaultPort: 8_787,
+    isolatedPortBase: 40_000,
+    portVariable: "WEB_AI_SDK_MCP_PORT",
+  }),
+  mcpInspector: Object.freeze({
+    allowZero: true,
+    defaultPort: 9_229,
+    isolatedPortBase: 50_000,
+    portVariable: "WEB_AI_SDK_MCP_INSPECTOR_PORT",
+  }),
+});
+
+export function normalizeDevelopmentInstanceId(
+  value,
+  maximumLength = MAX_OVERRIDE_LENGTH,
+) {
+  return String(value ?? "")
+    .normalize("NFKD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, maximumLength)
+    .replace(/-+$/g, "");
+}
+
+function canonicalCheckoutRoot(root) {
+  const resolved = fs.realpathSync.native(path.resolve(root));
+  return process.platform === "win32" ? resolved.toLowerCase() : resolved;
+}
+
+function isPrimaryCheckout(root) {
+  try {
+    return fs.statSync(path.join(root, ".git")).isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+function hash(value) {
+  return crypto.createHash("sha256").update(value).digest("hex");
+}
+
+function derivedWorktreeIdentity(canonicalRoot) {
+  const slug =
+    normalizeDevelopmentInstanceId(
+      path.basename(canonicalRoot),
+      MAX_SLUG_LENGTH,
+    ) || "worktree";
+  const pathHash = hash(canonicalRoot);
+
+  return {
+    id: `${slug}-${pathHash.slice(0, 8)}`,
+    portSlot: Number.parseInt(pathHash.slice(0, 8), 16) % PORT_SLOT_COUNT,
+  };
+}
+
+function overrideIdentity(override) {
+  const id = normalizeDevelopmentInstanceId(override);
+
+  if (!id || id === DEFAULT_INSTANCE_ID) {
+    throw new Error(
+      `${INSTANCE_OVERRIDE_VARIABLE} must normalize to a non-reserved identifier.`,
+    );
+  }
+
+  return {
+    id,
+    portSlot: Number.parseInt(hash(id).slice(0, 8), 16) % PORT_SLOT_COUNT,
+  };
+}
+
+export function resolveDevelopmentInstance(root, environment = process.env) {
+  const canonicalRoot = canonicalCheckoutRoot(root);
+  const override = environment[INSTANCE_OVERRIDE_VARIABLE];
+  let identity;
+  let source;
+
+  if (override !== undefined && String(override).trim() !== "") {
+    identity = overrideIdentity(override);
+    source = "override";
+  } else if (isPrimaryCheckout(canonicalRoot)) {
+    identity = { id: DEFAULT_INSTANCE_ID, portSlot: 0 };
+    source = "primary-checkout";
+  } else {
+    identity = derivedWorktreeIdentity(canonicalRoot);
+    source = "linked-worktree";
+  }
+
+  return Object.freeze({
+    id: identity.id,
+    portSlot: identity.portSlot,
+    primary: identity.id === DEFAULT_INSTANCE_ID,
+    root: canonicalRoot,
+    source,
+  });
+}
+
+function parsePort(value, variable, allowZero = false) {
+  const normalized = value?.trim();
+
+  if (!normalized) {
+    return null;
+  }
+
+  const minimum = allowZero ? 0 : 1;
+  const message = `${variable} must be an integer from ${minimum} through 65535.`;
+
+  if (!/^\d+$/.test(normalized)) {
+    throw new Error(message);
+  }
+
+  const port = Number(normalized);
+
+  if (port < minimum || port > 65_535) {
+    throw new Error(message);
+  }
+
+  return port;
+}
+
+export function resolveDevelopmentService(
+  service,
+  root,
+  environment = process.env,
+) {
+  const definition = SERVICE_DEFINITIONS[service];
+
+  if (!definition) {
+    throw new Error(`Unknown development service: ${service}`);
+  }
+
+  const instance = resolveDevelopmentInstance(root, environment);
+  const configuredPort = parsePort(
+    environment[definition.portVariable],
+    definition.portVariable,
+    definition.allowZero,
+  );
+  const configuredHost = environment[HOST_OVERRIDE_VARIABLE]?.trim() || null;
+  const port =
+    configuredPort ??
+    (instance.primary
+      ? definition.defaultPort
+      : definition.isolatedPortBase + instance.portSlot);
+  const hostname = instance.primary
+    ? "localhost"
+    : `${service}--${instance.id}.web-ai-sdk.localhost`;
+
+  return Object.freeze({
+    bindHost: configuredHost ?? (instance.primary ? null : "127.0.0.1"),
+    configured: configuredPort !== null || configuredHost !== null,
+    hostname,
+    instance,
+    port,
+    portVariable: definition.portVariable,
+    url: `http://${hostname}:${port}/`,
+  });
+}
+
+export const developmentInstanceConstants = Object.freeze({
+  defaultInstanceId: DEFAULT_INSTANCE_ID,
+  hostOverrideVariable: HOST_OVERRIDE_VARIABLE,
+  instanceOverrideVariable: INSTANCE_OVERRIDE_VARIABLE,
+  portSlotCount: PORT_SLOT_COUNT,
+});

--- a/scripts/paseo-service.mjs
+++ b/scripts/paseo-service.mjs
@@ -1,0 +1,62 @@
+import {
+  childProcessExitCode,
+  spawnManagedProcess,
+} from "./process-tree.mjs";
+
+const SERVICES = Object.freeze({
+  site: Object.freeze({
+    args: ["dev"],
+    portVariable: "WEB_AI_SDK_SITE_PORT",
+  }),
+  preview: Object.freeze({
+    args: ["pages:preview"],
+    portVariable: "WEB_AI_SDK_PREVIEW_PORT",
+  }),
+  mcp: Object.freeze({
+    args: ["mcp"],
+    portVariable: "WEB_AI_SDK_MCP_PORT",
+  }),
+});
+
+const serviceName = process.argv[2];
+const service = SERVICES[serviceName];
+
+if (!service) {
+  console.error(`Unknown Paseo service: ${serviceName ?? "<missing>"}`);
+  process.exit(1);
+}
+
+const paseoPort = process.env.PASEO_PORT?.trim();
+
+if (!paseoPort) {
+  console.error("PASEO_PORT is required for a Paseo service.");
+  process.exit(1);
+}
+
+const pnpmCommand = process.platform === "win32" ? "pnpm.cmd" : "pnpm";
+const environment = {
+  ...process.env,
+  [service.portVariable]: paseoPort,
+  WEB_AI_SDK_HOST:
+    process.env.WEB_AI_SDK_HOST?.trim() ||
+    process.env.HOST?.trim() ||
+    "127.0.0.1",
+};
+
+if (serviceName === "mcp") {
+  environment.WEB_AI_SDK_MCP_INSPECTOR_PORT = "0";
+}
+
+const child = spawnManagedProcess(pnpmCommand, service.args, {
+  env: environment,
+  stdio: "inherit",
+});
+
+child.once("error", (error) => {
+  console.error(error.message);
+  process.exitCode = 1;
+});
+
+child.once("exit", (code, signal) => {
+  process.exitCode = childProcessExitCode(code, signal);
+});

--- a/scripts/process-tree.mjs
+++ b/scripts/process-tree.mjs
@@ -1,0 +1,64 @@
+import { spawn } from "node:child_process";
+
+const SIGNAL_EXIT_CODES = Object.freeze({
+  SIGHUP: 129,
+  SIGINT: 130,
+  SIGTERM: 143,
+});
+const TERMINATION_SIGNALS =
+  process.platform === "win32"
+    ? Object.freeze(["SIGINT", "SIGTERM"])
+    : Object.freeze(["SIGHUP", "SIGINT", "SIGTERM"]);
+
+export function terminateProcessTree(child, signal = "SIGTERM") {
+  if (!child.pid || child.exitCode !== null || child.signalCode !== null) {
+    return;
+  }
+
+  if (process.platform === "win32") {
+    const taskkill = spawn(
+      "taskkill",
+      ["/pid", String(child.pid), "/t", "/f"],
+      {
+        stdio: "ignore",
+        windowsHide: true,
+      },
+    );
+    taskkill.once("error", () => child.kill());
+    return;
+  }
+
+  try {
+    process.kill(-child.pid, signal);
+  } catch (error) {
+    if (error?.code !== "ESRCH") {
+      child.kill(signal);
+    }
+  }
+}
+
+export function spawnManagedProcess(command, args, options = {}) {
+  const child = spawn(command, args, {
+    ...options,
+    detached: process.platform !== "win32",
+  });
+  const signalHandlers = new Map();
+
+  for (const signal of TERMINATION_SIGNALS) {
+    const handler = () => terminateProcessTree(child, signal);
+    signalHandlers.set(signal, handler);
+    process.once(signal, handler);
+  }
+
+  child.once("close", () => {
+    for (const [signal, handler] of signalHandlers) {
+      process.removeListener(signal, handler);
+    }
+  });
+
+  return child;
+}
+
+export function childProcessExitCode(code, signal) {
+  return code ?? SIGNAL_EXIT_CODES[signal] ?? 1;
+}


### PR DESCRIPTION
## Summary

- derive stable development instances for linked worktrees
- isolate site, preview, MCP, and inspector addresses
- add generic environment overrides and setup commands
- keep Paseo as an optional process supervisor
- document the parallel worktree workflow

## Validation

- `pnpm gate`
- direct site and MCP custom hostnames returned HTTP 200
- Paseo site and MCP proxy URLs returned HTTP 200
- verified that stopped services leave no listening processes