### PR TITLE
feat(webmcp): expose execution AbortSignal to tool callbacks

### DIFF
--- a/.agents/agents.md
+++ b/.agents/agents.md
@@ -128,8 +128,14 @@ consumes package output. Run `pnpm gate` before any commit.
 
 ## Git and workspace safety
 
-- Work only in the session's current working tree. Never create a worktree,
-  including through a skill, subagent, temporary directory, or `.worktrees/`.
+- Work only in the session's current workspace. Never edit another worktree
+  from the current session.
+- Create a worktree only after the user explicitly approves parallel work.
+- Keep every worktree outside the repository. Never create temporary or in-tree
+  worktrees, including under `.worktrees/`.
+- Give each parallel editor a separate workspace. Confirm its root and branch
+  with `git rev-parse --show-toplevel` and `git status --short --branch`.
+- Run `pnpm dev:setup` in a new worktree before development starts.
 - Do not overwrite or hide existing changes. If unexpected changes exist before
   work starts, stop and ask the user to commit or stash them.
 - Use a dedicated branch. Never commit, merge, or push directly to `main`.
@@ -142,5 +148,5 @@ consumes package output. Run `pnpm gate` before any commit.
 - Never rebase, delete branches, or amend commits without explicit approval.
 - Force-push only with explicit approval to update an existing PR.
 - Do not add agent attribution or `Co-authored-by:` trailers.
-- If parallel work needs another branch, stop and ask the user to create the
-  workspace through their tool.
+- If the current tool cannot provide an isolated workspace, stop and ask the
+  user to create one through their workspace manager.

--- a/.changeset/bumpy-rats-spend.md
+++ b/.changeset/bumpy-rats-spend.md
@@ -1,0 +1,6 @@
+---
+"@web-ai-sdk/webmcp": minor
+---
+
+Expose native WebMCP execution abort signals to registered tool callbacks.
+  

--- a/.changeset/bumpy-rats-spend.md
+++ b/.changeset/bumpy-rats-spend.md
@@ -3,4 +3,3 @@
 ---
 
 Expose native WebMCP execution abort signals to registered tool callbacks.
-  

--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,7 @@ coverage/
 storybook-static/
 _site/
 .astro/
-# In-tree git worktrees for parallel branch work (see .agents/agents.md §11).
+# Keep linked worktrees outside the repository.
 .worktrees/
 
 *.log

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,6 +20,62 @@ Published packages live in `packages/`. The Astro site and Starlight docs live
 in `apps/site/`. The read-only web-ai-sdk MCP Worker lives in `apps/mcp/`.
 Run `pnpm run` to list all workflows.
 
+## Parallel worktrees
+
+Use a separate linked worktree when issues need concurrent editors. Create each
+worktree from the approved base branch or PR.
+
+Run the same setup in every checkout:
+
+```sh
+pnpm dev:setup
+pnpm dev:info
+```
+
+The first command installs locked dependencies and builds publishable packages.
+The second command prints the development identity and service URLs.
+
+The primary checkout preserves the standard service ports. Each linked
+worktree derives stable ports and `*.localhost` names from its canonical path.
+
+Start services normally from any worktree:
+
+```sh
+pnpm dev:packages
+pnpm dev
+pnpm mcp
+```
+
+Do not copy `.env` files or secrets into a worktree. Add required local values
+through that worktree's environment instead.
+
+Set `WEB_AI_SDK_DEV_INSTANCE` to override the derived identity. Set a
+service-specific port variable if a generated port conflicts with another
+process. See the [root README](./README.md#parallel-development-worktrees) for
+the complete variable list.
+
+### Optional Paseo workflow
+
+The checked-in [`paseo.json`](./paseo.json) automates `pnpm dev:setup`. It also
+provides supervised service commands:
+
+Start a managed service from the worktree directory:
+
+```sh
+paseo script ls
+paseo script start packages
+paseo script start site
+paseo script start mcp
+```
+
+Paseo prints a distinct proxy URL for each branch and service. Its adapter maps
+the allocated port to the project's generic environment variables.
+
+Start `packages` with `site` when package source changes must reach a demo.
+
+Keep one editor in each worktree. Confirm the workspace path before editing,
+and archive the workspace only after preserving every required change.
+
 ## Change workflow
 
 1. Change one package or app at a time when possible.

--- a/README.md
+++ b/README.md
@@ -107,6 +107,77 @@ pnpm dev             # site at http://localhost:5173/, docs at /docs/
 
 The demos require a browser that supports the selected API. See [Browser support](./apps/site/src/content/docs/browser-support.mdx) for versions, flags, trials, and hardware requirements.
 
+### Parallel development worktrees
+
+Each linked worktree gets a stable development instance. The instance identity
+uses the worktree directory name and a hash of its canonical path.
+
+Set up any checkout or worktree with the same command:
+
+```sh
+pnpm dev:setup
+pnpm dev:info
+```
+
+`pnpm dev:setup` installs locked dependencies and builds the packages.
+`pnpm dev:info` prints the instance identity and local service URLs.
+
+The primary checkout keeps the standard ports. Linked worktrees receive stable
+ports and distinct `*.localhost` names:
+
+| Service | Primary checkout | Linked worktree port range |
+| --- | --- | --- |
+| Site | `http://localhost:5173/` | `20000-24999` |
+| Preview | `http://localhost:4173/` | `30000-34999` |
+| MCP | `http://localhost:8787/` | `40000-44999` |
+| MCP inspector | Wrangler default | `50000-54999` |
+
+A linked site URL uses this form:
+
+```text
+http://site--<instance>.web-ai-sdk.localhost:<port>/
+```
+
+Use these environment variables when you need explicit values:
+
+| Variable | Behavior |
+| --- | --- |
+| `WEB_AI_SDK_DEV_INSTANCE` | Overrides the derived development identity. |
+| `WEB_AI_SDK_HOST` | Overrides the local bind address. |
+| `WEB_AI_SDK_SITE_PORT` | Overrides the site port. |
+| `WEB_AI_SDK_PREVIEW_PORT` | Overrides the preview port. |
+| `WEB_AI_SDK_MCP_PORT` | Overrides the MCP server port. |
+| `WEB_AI_SDK_MCP_INSPECTOR_PORT` | Overrides the MCP inspector port. |
+
+The generated port can rarely conflict with another local process. Set the
+matching port variable when that happens.
+
+#### Optional Paseo integration
+
+The checked-in [`paseo.json`](./paseo.json) automates setup and process
+supervision. The project does not require Paseo for development isolation.
+
+Paseo provides these workspace scripts:
+
+| Script | Behavior |
+| --- | --- |
+| `site` | Runs the Astro site through a stable `*.localhost` proxy URL. |
+| `mcp` | Runs the local MCP Worker through a separate proxy URL. |
+| `packages` | Watches wrapper package builds during SDK changes. |
+| `preview` | Builds and previews the complete Pages artifact. |
+| `gate` | Runs the full quality gate without starting a service. |
+
+List the URLs and service state from a workspace:
+
+```sh
+paseo script ls
+paseo script start packages
+paseo script start site
+```
+
+Paseo allocates backend ports and exposes each service through a proxy URL. A
+small adapter passes each backend port through a generic variable listed above.
+
 ## Repo layout
 
 ```
@@ -124,6 +195,8 @@ The demos require a browser that supports the selected API. See [Browser support
 ├── apps/
 │   ├── site/           # @web-ai-sdk-apps/site (private; Astro site + Starlight docs)
 │   └── mcp/            # @web-ai-sdk-apps/mcp (private; web-ai-sdk MCP Worker)
+├── scripts/            # development instance and optional tool adapters
+├── paseo.json          # optional worktree setup and managed local services
 ├── .agents/agents.md           # agent instructions (AGENTS.md symlink kept at root)
 ├── README.md           # ← you are here
 └── …

--- a/apps/mcp/package.json
+++ b/apps/mcp/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "build": "pnpm docs:build && wrangler deploy --dry-run --outdir dist",
     "deploy": "pnpm docs:build && wrangler deploy",
-    "dev": "pnpm docs:build && wrangler dev",
+    "dev": "pnpm docs:build && node scripts/run-dev.mjs",
     "docs:build": "node scripts/build-docs.mjs",
     "test": "pnpm docs:build && vitest run",
     "test:watch": "pnpm docs:build && vitest",

--- a/apps/mcp/scripts/local-server.mjs
+++ b/apps/mcp/scripts/local-server.mjs
@@ -1,0 +1,32 @@
+import { fileURLToPath } from "node:url";
+import { resolveDevelopmentService } from "../../../scripts/development-instance.mjs";
+
+const repositoryRoot = fileURLToPath(new URL("../../../", import.meta.url));
+
+export function buildWranglerDevArgs(
+  env = process.env,
+  root = repositoryRoot,
+) {
+  const server = resolveDevelopmentService("mcp", root, env);
+  const inspector = resolveDevelopmentService("mcpInspector", root, env);
+
+  if (
+    server.instance.primary &&
+    !server.configured &&
+    !inspector.configured
+  ) {
+    return ["exec", "wrangler", "dev"];
+  }
+
+  return [
+    "exec",
+    "wrangler",
+    "dev",
+    "--ip",
+    server.bindHost ?? "127.0.0.1",
+    "--port",
+    String(server.port),
+    "--inspector-port",
+    String(inspector.port),
+  ];
+}

--- a/apps/mcp/scripts/local-server.test.mjs
+++ b/apps/mcp/scripts/local-server.test.mjs
@@ -1,0 +1,93 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { buildWranglerDevArgs } from "./local-server.mjs";
+
+const temporaryRoots = [];
+
+function createCheckout(primary) {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "web-ai-sdk-mcp-"));
+  temporaryRoots.push(root);
+
+  if (primary) {
+    fs.mkdirSync(path.join(root, ".git"));
+  } else {
+    fs.writeFileSync(path.join(root, ".git"), "gitdir: elsewhere");
+  }
+
+  return root;
+}
+
+afterEach(() => {
+  for (const root of temporaryRoots.splice(0)) {
+    fs.rmSync(root, { force: true, recursive: true });
+  }
+});
+
+describe("buildWranglerDevArgs", () => {
+  it("keeps Wrangler defaults in the primary checkout", () => {
+    expect(buildWranglerDevArgs({}, createCheckout(true))).toEqual([
+      "exec",
+      "wrangler",
+      "dev",
+    ]);
+  });
+
+  it("uses stable MCP and inspector ports in a linked worktree", () => {
+    const args = buildWranglerDevArgs({}, createCheckout(false));
+    const port = Number(args[args.indexOf("--port") + 1]);
+    const inspectorPort = Number(args[args.indexOf("--inspector-port") + 1]);
+
+    expect(args.slice(0, 5)).toEqual([
+      "exec",
+      "wrangler",
+      "dev",
+      "--ip",
+      "127.0.0.1",
+    ]);
+    expect(port).toBeGreaterThanOrEqual(40_000);
+    expect(port).toBeLessThan(45_000);
+    expect(inspectorPort).toBeGreaterThanOrEqual(50_000);
+    expect(inspectorPort).toBeLessThan(55_000);
+  });
+
+  it("accepts generic host, server, and inspector overrides", () => {
+    expect(
+      buildWranglerDevArgs(
+        {
+          WEB_AI_SDK_HOST: "127.0.0.1",
+          WEB_AI_SDK_MCP_INSPECTOR_PORT: "0",
+          WEB_AI_SDK_MCP_PORT: "24567",
+        },
+        createCheckout(true),
+      ),
+    ).toEqual([
+      "exec",
+      "wrangler",
+      "dev",
+      "--ip",
+      "127.0.0.1",
+      "--port",
+      "24567",
+      "--inspector-port",
+      "0",
+    ]);
+  });
+
+  it("rejects invalid generic ports", () => {
+    const root = createCheckout(true);
+
+    expect(() =>
+      buildWranglerDevArgs({ WEB_AI_SDK_MCP_PORT: "0" }, root),
+    ).toThrow("WEB_AI_SDK_MCP_PORT must be an integer from 1 through 65535.");
+    expect(() =>
+      buildWranglerDevArgs(
+        { WEB_AI_SDK_MCP_INSPECTOR_PORT: "12.5" },
+        root,
+      ),
+    ).toThrow(
+      "WEB_AI_SDK_MCP_INSPECTOR_PORT must be an integer from 0 through 65535.",
+    );
+  });
+});

--- a/apps/mcp/scripts/process-tree.test.mjs
+++ b/apps/mcp/scripts/process-tree.test.mjs
@@ -1,0 +1,60 @@
+import { once } from "node:events";
+import { setTimeout as delay } from "node:timers/promises";
+import { describe, expect, it } from "vitest";
+import {
+  spawnManagedProcess,
+  terminateProcessTree,
+} from "../../../scripts/process-tree.mjs";
+
+function isRunning(pid) {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function waitUntilStopped(pid) {
+  for (let attempt = 0; attempt < 50; attempt += 1) {
+    if (!isRunning(pid)) {
+      return true;
+    }
+
+    await delay(20);
+  }
+
+  return false;
+}
+
+describe("managed process trees", () => {
+  it.skipIf(process.platform === "win32")(
+    "terminates a spawned process and its descendants",
+    async () => {
+      const childSource = `
+        const { spawn } = require("node:child_process");
+        const grandchild = spawn(
+          process.execPath,
+          ["-e", "setInterval(() => {}, 1000)"],
+          { stdio: "ignore" },
+        );
+        process.stdout.write(String(grandchild.pid));
+        setInterval(() => {}, 1000);
+      `;
+      const child = spawnManagedProcess(
+        process.execPath,
+        ["-e", childSource],
+        { stdio: ["ignore", "pipe", "ignore"] },
+      );
+      const [output] = await once(child.stdout, "data");
+      const grandchildPid = Number(String(output));
+      const childExit = once(child, "exit");
+
+      expect(grandchildPid).toBeGreaterThan(0);
+      terminateProcessTree(child, "SIGTERM");
+      await childExit;
+
+      expect(await waitUntilStopped(grandchildPid)).toBe(true);
+    },
+  );
+});

--- a/apps/mcp/scripts/run-dev.mjs
+++ b/apps/mcp/scripts/run-dev.mjs
@@ -1,0 +1,19 @@
+import {
+  childProcessExitCode,
+  spawnManagedProcess,
+} from "../../../scripts/process-tree.mjs";
+import { buildWranglerDevArgs } from "./local-server.mjs";
+
+const pnpmCommand = process.platform === "win32" ? "pnpm.cmd" : "pnpm";
+const child = spawnManagedProcess(pnpmCommand, buildWranglerDevArgs(), {
+  stdio: "inherit",
+});
+
+child.once("error", (error) => {
+  console.error(error.message);
+  process.exitCode = 1;
+});
+
+child.once("exit", (code, signal) => {
+  process.exitCode = childProcessExitCode(code, signal);
+});

--- a/apps/mcp/vitest.config.ts
+++ b/apps/mcp/vitest.config.ts
@@ -3,6 +3,6 @@ import { defineConfig } from "vitest/config";
 export default defineConfig({
   test: {
     environment: "node",
-    include: ["src/**/*.test.ts"],
+    include: ["src/**/*.test.ts", "scripts/**/*.test.mjs"],
   },
 });

--- a/apps/site/astro.config.mjs
+++ b/apps/site/astro.config.mjs
@@ -3,6 +3,7 @@ import react from "@astrojs/react";
 import starlight from "@astrojs/starlight";
 import tailwindcss from "@tailwindcss/vite";
 import { defineConfig } from "astro/config";
+import { resolveLocalServer } from "./scripts/local-server.mjs";
 
 // Defaults to the custom-domain root. GitHub Pages builds override this with
 // SITE_BASE for project Pages or any other host prefix.
@@ -19,6 +20,7 @@ const preloadedFonts = [
 export default defineConfig({
   base,
   site: "https://web-ai-sdk.dev",
+  server: ({ command }) => resolveLocalServer(command),
   // Static meta-refresh stub so links to the pre-rename hook URL keep working.
   redirects: {
     "/docs/react/use-web-mcp/": "/docs/react/use-webmcp/",

--- a/apps/site/package.json
+++ b/apps/site/package.json
@@ -5,9 +5,9 @@
   "description": "Unified site for web-ai-sdk (Astro + Starlight docs + React islands)",
   "type": "module",
   "scripts": {
-    "dev": "astro dev --port 5173 --strictPort",
+    "dev": "astro dev --strictPort",
     "build": "astro build && node scripts/build-llms.mjs",
-    "preview": "astro preview --port 4173",
+    "preview": "astro preview",
     "test": "vitest run",
     "typecheck": "astro check",
     "og:build": "node scripts/build-og-image.mjs",

--- a/apps/site/scripts/development-instance.test.mjs
+++ b/apps/site/scripts/development-instance.test.mjs
@@ -1,0 +1,104 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  normalizeDevelopmentInstanceId,
+  resolveDevelopmentInstance,
+  resolveDevelopmentService,
+} from "../../../scripts/development-instance.mjs";
+
+const temporaryRoots = [];
+
+function createCheckout(name, primary) {
+  const parent = fs.mkdtempSync(
+    path.join(os.tmpdir(), "web-ai-sdk-instance-"),
+  );
+  const root = path.join(parent, name);
+  temporaryRoots.push(parent);
+  fs.mkdirSync(root);
+
+  if (primary) {
+    fs.mkdirSync(path.join(root, ".git"));
+  } else {
+    fs.writeFileSync(path.join(root, ".git"), "gitdir: elsewhere");
+  }
+
+  return root;
+}
+
+afterEach(() => {
+  for (const root of temporaryRoots.splice(0)) {
+    fs.rmSync(root, { force: true, recursive: true });
+  }
+});
+
+describe("development instances", () => {
+  it("uses the reserved default identity for the primary checkout", () => {
+    expect(
+      resolveDevelopmentInstance(createCheckout("sdk", true), {}),
+    ).toMatchObject({
+      id: "default",
+      portSlot: 0,
+      primary: true,
+      source: "primary-checkout",
+    });
+  });
+
+  it("derives a stable path-safe identity for a linked worktree", () => {
+    const root = createCheckout("Issue 224 ç", false);
+    const first = resolveDevelopmentInstance(root, {});
+    const second = resolveDevelopmentInstance(root, {});
+
+    expect(first).toEqual(second);
+    expect(first.id).toMatch(/^issue-224-c-[a-f0-9]{8}$/);
+    expect(first.primary).toBe(false);
+    expect(first.source).toBe("linked-worktree");
+    expect(first.portSlot).toBeGreaterThanOrEqual(0);
+    expect(first.portSlot).toBeLessThan(5_000);
+  });
+
+  it("supports an explicit tool-neutral instance override", () => {
+    const root = createCheckout("sdk", true);
+    const instance = resolveDevelopmentInstance(root, {
+      WEB_AI_SDK_DEV_INSTANCE: "Issue 227 / Review",
+    });
+
+    expect(instance).toMatchObject({
+      id: "issue-227-review",
+      primary: false,
+      source: "override",
+    });
+    expect(
+      resolveDevelopmentService("site", root, {
+        WEB_AI_SDK_DEV_INSTANCE: "Issue 227 / Review",
+      }).hostname,
+    ).toBe("site--issue-227-review.web-ai-sdk.localhost");
+  });
+
+  it("rejects empty and reserved normalized overrides", () => {
+    const root = createCheckout("sdk", true);
+
+    expect(() =>
+      resolveDevelopmentInstance(root, {
+        WEB_AI_SDK_DEV_INSTANCE: "!!!",
+      }),
+    ).toThrow(
+      "WEB_AI_SDK_DEV_INSTANCE must normalize to a non-reserved identifier.",
+    );
+    expect(() =>
+      resolveDevelopmentInstance(root, {
+        WEB_AI_SDK_DEV_INSTANCE: "default",
+      }),
+    ).toThrow(
+      "WEB_AI_SDK_DEV_INSTANCE must normalize to a non-reserved identifier.",
+    );
+  });
+
+  it("normalizes accents, separators, and length", () => {
+    expect(normalizeDevelopmentInstanceId("  Revisão / Issue 224  ")).toBe(
+      "revisao-issue-224",
+    );
+    expect(normalizeDevelopmentInstanceId("abcdefghij", 5)).toBe("abcde");
+  });
+});

--- a/apps/site/scripts/local-server.mjs
+++ b/apps/site/scripts/local-server.mjs
@@ -1,0 +1,21 @@
+import { fileURLToPath } from "node:url";
+import { resolveDevelopmentService } from "../../../scripts/development-instance.mjs";
+
+const repositoryRoot = fileURLToPath(new URL("../../../", import.meta.url));
+
+export function resolveLocalServer(
+  command,
+  env = process.env,
+  root = repositoryRoot,
+) {
+  const service = resolveDevelopmentService(
+    command === "dev" ? "site" : "preview",
+    root,
+    env,
+  );
+
+  return {
+    host: service.bindHost ?? false,
+    port: service.port,
+  };
+}

--- a/apps/site/scripts/local-server.test.mjs
+++ b/apps/site/scripts/local-server.test.mjs
@@ -1,0 +1,91 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { resolveLocalServer } from "./local-server.mjs";
+
+const temporaryRoots = [];
+
+function createCheckout(primary) {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "web-ai-sdk-site-"));
+  temporaryRoots.push(root);
+
+  if (primary) {
+    fs.mkdirSync(path.join(root, ".git"));
+  } else {
+    fs.writeFileSync(path.join(root, ".git"), "gitdir: elsewhere");
+  }
+
+  return root;
+}
+
+afterEach(() => {
+  for (const root of temporaryRoots.splice(0)) {
+    fs.rmSync(root, { force: true, recursive: true });
+  }
+});
+
+describe("resolveLocalServer", () => {
+  it("keeps the existing site defaults in the primary checkout", () => {
+    const root = createCheckout(true);
+
+    expect(resolveLocalServer("dev", {}, root)).toEqual({
+      host: false,
+      port: 5173,
+    });
+    expect(resolveLocalServer("preview", {}, root)).toEqual({
+      host: false,
+      port: 4173,
+    });
+  });
+
+  it("uses stable isolated addresses in a linked worktree", () => {
+    const root = createCheckout(false);
+    const first = resolveLocalServer("dev", {}, root);
+    const second = resolveLocalServer("dev", {}, root);
+
+    expect(first).toEqual(second);
+    expect(first.host).toBe("127.0.0.1");
+    expect(first.port).toBeGreaterThanOrEqual(20_000);
+    expect(first.port).toBeLessThan(25_000);
+  });
+
+  it("accepts generic host and port overrides", () => {
+    expect(
+      resolveLocalServer(
+        "dev",
+        {
+          WEB_AI_SDK_HOST: "0.0.0.0",
+          WEB_AI_SDK_SITE_PORT: "23456",
+        },
+        createCheckout(true),
+      ),
+    ).toEqual({
+      host: "0.0.0.0",
+      port: 23456,
+    });
+  });
+
+  it("rejects invalid generic ports", () => {
+    const root = createCheckout(true);
+
+    expect(() =>
+      resolveLocalServer(
+        "dev",
+        { WEB_AI_SDK_SITE_PORT: "not-a-port" },
+        root,
+      ),
+    ).toThrow(
+      "WEB_AI_SDK_SITE_PORT must be an integer from 1 through 65535.",
+    );
+    expect(() =>
+      resolveLocalServer(
+        "dev",
+        { WEB_AI_SDK_SITE_PORT: "65536" },
+        root,
+      ),
+    ).toThrow(
+      "WEB_AI_SDK_SITE_PORT must be an integer from 1 through 65535.",
+    );
+  });
+});

--- a/apps/site/src/content/docs/guides/webmcp.mdx
+++ b/apps/site/src/content/docs/guides/webmcp.mdx
@@ -30,7 +30,8 @@ const cleanup = registerTool({
     io: "input",
     target: "draft-2020-12",
   }),
-  execute: async ({ sku, quantity }) => addToCart(sku, quantity),
+  execute: async ({ sku, quantity }, options) =>
+    addToCart(sku, quantity, { signal: options?.signal }),
 });
 
 // Later, when the tool should no longer be exposed:
@@ -77,6 +78,10 @@ The browser returns `inputSchema` as serialized JSON. It also includes the regis
 ## Tool
 
 ```ts
+interface ToolExecuteCallbackOptions {
+  signal: AbortSignal;
+}
+
 interface Tool<TInput = unknown, TOutput = unknown> {
   name: string;
   title?: string;
@@ -85,7 +90,10 @@ interface Tool<TInput = unknown, TOutput = unknown> {
   readOnly?: boolean;
   destructive?: boolean;
   annotations?: ToolAnnotations;
-  execute: (input: TInput) => Promise<TOutput> | TOutput;
+  execute: (
+    input: TInput,
+    options?: ToolExecuteCallbackOptions,
+  ) => Promise<TOutput> | TOutput;
 }
 ```
 
@@ -106,6 +114,7 @@ interface ToolDefinition<
     input: InputSchema extends StandardSchemaV1
       ? StandardSchemaV1.InferOutput<InputSchema>
       : unknown,
+    options?: ToolExecuteCallbackOptions,
   ) =>
     | Promise<
         OutputSchema extends StandardSchemaV1
@@ -132,7 +141,7 @@ maintaining a second handwritten definition.
 | `name` <sup>required</sup> | `string` | Tool name. Must be unique within the model context. |
 | `title` | `string` | Human-readable title for host user interfaces. |
 | `description` <sup>required</sup> | `string` | What the tool does. Routed to the agent's tool selector. |
-| `execute` <sup>required</sup> | `(input) => Promise<T> \| T` | The function the agent calls. |
+| `execute` <sup>required</sup> | `(input, options?) => Promise<T> \| T` | The function the agent calls. `options.signal` reports browser cancellation. |
 | `input` | `StandardSchemaV1` | SDK-only input validator. Its parsed or transformed value is passed to `execute`. |
 | `output` | `StandardSchemaV1` | SDK-only resolved-output validator. Its parsed or transformed value is returned. |
 | `inputSchema` | `object` | JSON Schema describing the input shape. Some hosts validate against it before dispatch. |
@@ -145,6 +154,23 @@ maintaining a second handwritten definition.
 ## Registration cleanup
 
 `registerTool(tool, options?)` returns a cleanup function. It unregisters the tool and is safe to call more than once. Unsupported browsers return a no-op cleanup.
+
+## Execution cancellation
+
+The browser passes an execution `AbortSignal` through the callback's optional second argument. Forward it to cancellable work:
+
+```ts
+execute: async (input, options) =>
+  fetch("/api/tool", {
+    method: "POST",
+    body: JSON.stringify(input),
+    signal: options?.signal,
+  });
+```
+
+Older trial browsers can omit the options. The SDK does not create a replacement signal.
+
+Unregistering a tool does not cancel an execution that already started. Application code decides how to observe the execution signal.
 
 ## How it works
 

--- a/apps/site/src/content/docs/packages/webmcp.md
+++ b/apps/site/src/content/docs/packages/webmcp.md
@@ -42,8 +42,10 @@ const tools = [
     description: "List published blog posts.",
     readOnly: true,
     annotations: { untrustedContentHint: true },
-    execute: async () => {
-      const res = await fetch("/api/posts.json");
+    execute: async (_input, options) => {
+      const res = await fetch("/api/posts.json", {
+        signal: options?.signal,
+      });
       return { results: await res.json() };
     },
   },
@@ -62,11 +64,12 @@ const tools = [
       },
       required: ["name", "email", "subject", "message"],
     },
-    execute: async (input) => {
+    execute: async (input, options) => {
       const res = await fetch("/api/send-email", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify(input),
+        signal: options?.signal,
       });
       if (!res.ok) throw new Error(`HTTP ${res.status}`);
       return { ok: true };
@@ -82,6 +85,10 @@ cleanup();
 ```
 
 `registerTool(tool, options?)` registers a single tool and returns the cleanup. Re-registering a tool with the same name is safe; the previous registration is dropped first.
+
+The browser passes execution options as an optional second callback argument. Forward `options?.signal` to cancellable work. Older trial browsers can omit the options.
+
+Registration cleanup does not cancel an execution that already started. Application code decides how to handle the browser's execution signal.
 
 ## React
 
@@ -102,8 +109,11 @@ export function WebMCP({ isSignedIn }: { isSignedIn: boolean }) {
         io: "input",
         target: "draft-2020-12",
       }),
-      execute: async ({ query }) => {
-        const res = await fetch(`/api/posts.json?q=${encodeURIComponent(query)}`);
+      execute: async ({ query }, options) => {
+        const res = await fetch(
+          `/api/posts.json?q=${encodeURIComponent(query)}`,
+          { signal: options?.signal },
+        );
         return { results: await res.json() };
       },
     },
@@ -218,6 +228,10 @@ Feature-detect helper.
 ### `Tool<TInput, TOutput>`
 
 ```ts
+interface ToolExecuteCallbackOptions {
+  signal: AbortSignal;
+}
+
 interface Tool<TInput = unknown, TOutput = unknown> {
   name: string;
   title?: string; // human-readable host UI label
@@ -226,7 +240,10 @@ interface Tool<TInput = unknown, TOutput = unknown> {
   readOnly?: boolean; // shorthand for annotations.readOnlyHint
   destructive?: boolean; // shorthand for annotations.destructiveHint
   annotations?: ToolAnnotations; // raw passthrough, merged on top
-  execute: (input: TInput) => Promise<TOutput> | TOutput;
+  execute: (
+    input: TInput,
+    options?: ToolExecuteCallbackOptions,
+  ) => Promise<TOutput> | TOutput;
 }
 ```
 
@@ -252,6 +269,7 @@ interface ToolDefinition<
     input: InputSchema extends StandardSchemaV1
       ? StandardSchemaV1.InferOutput<InputSchema>
       : unknown,
+    options?: ToolExecuteCallbackOptions,
   ) =>
     | Promise<
         OutputSchema extends StandardSchemaV1
@@ -306,12 +324,13 @@ const cleanup = registerTool({
     io: "input",
     target: "draft-2020-12",
   }),
-  async execute({ name, email, subject, message }) {
+  async execute({ name, email, subject, message }, options) {
     // `name`, `email`, etc. are typed from the Zod schema.
     const res = await fetch("/api/send-email", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ name, email, subject, message }),
+      signal: options?.signal,
     });
     if (!res.ok) throw new Error(`HTTP ${res.status}`);
     return { ok: true };

--- a/apps/site/src/content/docs/react/use-webmcp.mdx
+++ b/apps/site/src/content/docs/react/use-webmcp.mdx
@@ -35,7 +35,14 @@ export function AgentTools({ isSignedIn }: { isSignedIn: boolean }) {
         io: "input",
         target: "draft-2020-12",
       }),
-      execute: async ({ sku }) => ({ ok: true, sku }),
+      execute: async ({ sku }, options) => {
+        const response = await fetch("/api/cart", {
+          method: "POST",
+          body: JSON.stringify({ sku }),
+          signal: options?.signal,
+        });
+        return response.json();
+      },
     },
     { enabled: isSignedIn },
   );
@@ -145,14 +152,19 @@ The browser validates the origins. The SDK owns the registration's `AbortSignal`
 
 ## State + reactivity
 
-The registered tool always delegates to the latest committed `execute` callback, so it can read live props and state without a manual ref bridge:
+The registered tool always delegates to the latest committed `execute` callback. It preserves the browser's execution options across rerenders.
 
 ```tsx
 export function SettingsTool({ pane }: { pane: string }) {
   useWebMCP({
     name: "open_settings",
     description: "Read the currently open settings pane",
-    execute: async () => ({ pane }),
+    execute: async (_input, options) => {
+      const response = await fetch(`/api/settings/${pane}`, {
+        signal: options?.signal,
+      });
+      return response.json();
+    },
   });
   return null;
 }
@@ -160,11 +172,15 @@ export function SettingsTool({ pane }: { pane: string }) {
 
 Rerendering `SettingsTool` with a new `pane` updates execution immediately without unregistering and re-registering the tool. This avoids duplicate-name races while keeping registration changes tied to the fields an agent host can discover.
 
+The browser can omit the second callback argument on older trial builds. Use `options?.signal` instead of creating a replacement signal.
+
 ## Cleanup
 
 Registration cleanup is automatic on unmount via `useEffect`'s return value. If you need imperative cleanup (e.g. log out flow), call the vanilla `registerTool` directly per tool and combine the cleanups: `const cleanups = tools.map(registerTool)`.
 
 The hook removes its `toolchange` subscription on unmount and ignores stale discovery promises. Set `enabled: false` to suspend registration and retrieval and return to `"idle"` state.
+
+Unmounting removes the registration. It does not cancel an execution that already started.
 
 ## Errors and unavailability
 
@@ -188,6 +204,7 @@ import type {
   Tool,
   ToolAnnotations,
   ToolDefinition,
+  ToolExecuteCallbackOptions,
   UseWebMCPOptions,
   UseWebMCPReturn,
   WebMCPStatus,
@@ -197,11 +214,18 @@ interface Tool {
   name: string;
   title?: string;
   description: string;
-  execute: (input: unknown) => Promise<unknown> | unknown;
+  execute: (
+    input: unknown,
+    options?: ToolExecuteCallbackOptions,
+  ) => Promise<unknown> | unknown;
   readOnly?: boolean;              // maps to annotations.readOnlyHint
   destructive?: boolean;           // compatibility shorthand
   annotations?: ToolAnnotations;   // raw passthrough; merges on top of shorthand
   inputSchema?: object;            // JSON Schema
+}
+
+interface ToolExecuteCallbackOptions {
+  signal: AbortSignal;
 }
 
 interface ToolDefinition<
@@ -215,6 +239,7 @@ interface ToolDefinition<
     input: InputSchema extends StandardSchemaV1
       ? StandardSchemaV1.InferOutput<InputSchema>
       : unknown,
+    options?: ToolExecuteCallbackOptions,
   ) =>
     | Promise<
         OutputSchema extends StandardSchemaV1

--- a/biome.json
+++ b/biome.json
@@ -12,6 +12,8 @@
       "!**/storybook-static",
       "!**/.astro",
       "!**/_site",
+      "!**/.claude/worktrees",
+      "!**/.codex/worktrees",
       "!**/.worktrees"
     ]
   },

--- a/package.json
+++ b/package.json
@@ -20,6 +20,8 @@
   },
   "scripts": {
     "dev": "pnpm --filter @web-ai-sdk-apps/site run dev",
+    "dev:info": "node scripts/development-info.mjs",
+    "dev:setup": "pnpm install --frozen-lockfile && pnpm build:packages",
     "dev:packages": "pnpm --filter \"./packages/**\" --filter \"!@web-ai-sdk/all\" -r --parallel run dev",
     "dev:sdk": "pnpm build:packages && pnpm --filter @web-ai-sdk/all run dev",
     "dev:apps": "pnpm dev",

--- a/packages/webmcp/README.md
+++ b/packages/webmcp/README.md
@@ -35,8 +35,10 @@ const tools = [
     description: "List published blog posts.",
     readOnly: true,
     annotations: { untrustedContentHint: true },
-    execute: async () => {
-      const res = await fetch("/api/posts.json");
+    execute: async (_input, options) => {
+      const res = await fetch("/api/posts.json", {
+        signal: options?.signal,
+      });
       return { results: await res.json() };
     },
   },
@@ -55,11 +57,12 @@ const tools = [
       },
       required: ["name", "email", "subject", "message"],
     },
-    execute: async (input) => {
+    execute: async (input, options) => {
       const res = await fetch("/api/send-email", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify(input),
+        signal: options?.signal,
       });
       if (!res.ok) throw new Error(`HTTP ${res.status}`);
       return { ok: true };
@@ -75,6 +78,10 @@ cleanup();
 ```
 
 `registerTool(tool, options?)` registers a single tool and returns the cleanup. Re-registering a tool with the same name is safe; the previous registration is dropped first.
+
+The browser passes execution options as an optional second callback argument. Forward `options?.signal` to cancellable work. Older trial browsers can omit the options.
+
+Registration cleanup does not cancel an execution that already started. Application code decides how to handle the browser's execution signal.
 
 ## React
 
@@ -95,8 +102,11 @@ export function WebMCP({ isSignedIn }: { isSignedIn: boolean }) {
         io: "input",
         target: "draft-2020-12",
       }),
-      execute: async ({ query }) => {
-        const res = await fetch(`/api/posts.json?q=${encodeURIComponent(query)}`);
+      execute: async ({ query }, options) => {
+        const res = await fetch(
+          `/api/posts.json?q=${encodeURIComponent(query)}`,
+          { signal: options?.signal },
+        );
         return { results: await res.json() };
       },
     },
@@ -211,6 +221,10 @@ Feature-detect helper.
 ### `Tool<TInput, TOutput>`
 
 ```ts
+interface ToolExecuteCallbackOptions {
+  signal: AbortSignal;
+}
+
 interface Tool<TInput = unknown, TOutput = unknown> {
   name: string;
   title?: string; // human-readable host UI label
@@ -219,7 +233,10 @@ interface Tool<TInput = unknown, TOutput = unknown> {
   readOnly?: boolean; // shorthand for annotations.readOnlyHint
   destructive?: boolean; // shorthand for annotations.destructiveHint
   annotations?: ToolAnnotations; // raw passthrough, merged on top
-  execute: (input: TInput) => Promise<TOutput> | TOutput;
+  execute: (
+    input: TInput,
+    options?: ToolExecuteCallbackOptions,
+  ) => Promise<TOutput> | TOutput;
 }
 ```
 
@@ -245,6 +262,7 @@ interface ToolDefinition<
     input: InputSchema extends StandardSchemaV1
       ? StandardSchemaV1.InferOutput<InputSchema>
       : unknown,
+    options?: ToolExecuteCallbackOptions,
   ) =>
     | Promise<
         OutputSchema extends StandardSchemaV1
@@ -299,12 +317,13 @@ const cleanup = registerTool({
     io: "input",
     target: "draft-2020-12",
   }),
-  async execute({ name, email, subject, message }) {
+  async execute({ name, email, subject, message }, options) {
     // `name`, `email`, etc. are typed from the Zod schema.
     const res = await fetch("/api/send-email", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ name, email, subject, message }),
+      signal: options?.signal,
     });
     if (!res.ok) throw new Error(`HTTP ${res.status}`);
     return { ok: true };

--- a/packages/webmcp/src/definition.ts
+++ b/packages/webmcp/src/definition.ts
@@ -1,4 +1,9 @@
-import type { Tool, ToolAnnotations, ToolMetadata } from "./tool.js";
+import type {
+  Tool,
+  ToolAnnotations,
+  ToolExecuteCallbackOptions,
+  ToolMetadata,
+} from "./tool.js";
 
 /**
  * Minimal Standard Schema V1 surface — see https://standardschema.dev. Any
@@ -91,6 +96,7 @@ export interface ToolDefinition<
     input: InputSchema extends StandardSchemaV1
       ? StandardSchemaV1.InferOutput<InputSchema>
       : unknown,
+    options?: ToolExecuteCallbackOptions,
   ) =>
     | Promise<
         OutputSchema extends StandardSchemaV1
@@ -120,6 +126,7 @@ export interface DefineToolOptions<
     input: InputSchema extends StandardSchemaV1
       ? StandardSchemaV1.InferInput<InputSchema>
       : unknown,
+    options?: ToolExecuteCallbackOptions,
   ) =>
     | Promise<
         OutputSchema extends StandardSchemaV1
@@ -135,7 +142,7 @@ export interface DefineToolOptions<
 export interface RegistrableTool extends ToolMetadata {
   input?: StandardSchemaV1;
   output?: StandardSchemaV1;
-  execute: (input: never) => unknown;
+  execute: (input: never, options?: ToolExecuteCallbackOptions) => unknown;
 }
 
 const validateWithSchema = async <Output>(
@@ -178,6 +185,7 @@ export const normalizeToolDefinition = (
 ): Tool => {
   const baseExecute = definition.execute as (
     input: unknown,
+    options?: ToolExecuteCallbackOptions,
   ) => Promise<unknown> | unknown;
   const inputSchema = validateInput ? definition.input : undefined;
   const outputSchema = definition.output;
@@ -186,7 +194,7 @@ export const normalizeToolDefinition = (
     return copyMetadata(definition, baseExecute);
   }
 
-  return copyMetadata(definition, async (input: unknown) => {
+  return copyMetadata(definition, async (input, options) => {
     const executeInput = inputSchema
       ? await validateWithSchema(
           inputSchema,
@@ -194,7 +202,7 @@ export const normalizeToolDefinition = (
           (issues) => new ToolValidationError(definition.name, issues),
         )
       : input;
-    const result = await baseExecute(executeInput);
+    const result = await baseExecute(executeInput, options);
     if (!outputSchema) return result;
     return validateWithSchema(
       outputSchema,

--- a/packages/webmcp/src/index.test.ts
+++ b/packages/webmcp/src/index.test.ts
@@ -12,6 +12,7 @@ import {
   subscribeToToolChanges,
   type Tool,
   type ToolDefinition,
+  type ToolExecuteCallbackOptions,
   ToolOutputValidationError,
   ToolValidationError,
   WebMCPUnavailableError,
@@ -23,7 +24,7 @@ interface RegisteredCall {
   description: string;
   inputSchema?: object;
   annotations?: Record<string, boolean>;
-  execute: (input: unknown) => unknown;
+  execute: (input: unknown, options?: ToolExecuteCallbackOptions) => unknown;
 }
 
 interface NativeRegisterOptions {
@@ -246,6 +247,73 @@ describe("registerTool", () => {
     expect(def).not.toHaveProperty("title");
     expect(def?.description).toBe("Returns pong.");
     await expect(def?.execute(undefined)).resolves.toEqual({ result: "pong" });
+  });
+
+  it("forwards the exact native execution signal to plain callbacks", () => {
+    const { registered } = installFakeModelContext();
+    const controller = new AbortController();
+    const callbackOptions = {
+      signal: controller.signal,
+    } satisfies ToolExecuteCallbackOptions;
+    const execute = vi.fn(
+      (_input: unknown, options?: ToolExecuteCallbackOptions) =>
+        options?.signal,
+    );
+
+    registerTool({
+      name: "signal-identity",
+      description: "Returns the execution signal.",
+      execute,
+    });
+
+    expect(
+      registered.get("signal-identity")?.execute({}, callbackOptions),
+    ).toBe(controller.signal);
+    expect(execute).toHaveBeenCalledWith({}, callbackOptions);
+  });
+
+  it("passes undefined when an older host omits execution options", () => {
+    const { registered } = installFakeModelContext();
+    const execute = vi.fn(
+      (_input: unknown, options?: ToolExecuteCallbackOptions) => options,
+    );
+
+    registerTool({
+      name: "legacy-options",
+      description: "Supports hosts without execution options.",
+      execute,
+    });
+
+    expect(registered.get("legacy-options")?.execute({})).toBeUndefined();
+    expect(execute).toHaveBeenCalledWith({});
+  });
+
+  it("preserves synchronous throws and callback rejections", async () => {
+    const { registered } = installFakeModelContext();
+    const syncFailure = new Error("sync failure");
+    const asyncFailure = new Error("async failure");
+
+    registerTool({
+      name: "sync-failure",
+      description: "Throws synchronously.",
+      execute: () => {
+        throw syncFailure;
+      },
+    });
+    registerTool({
+      name: "async-failure",
+      description: "Rejects asynchronously.",
+      execute: async () => {
+        throw asyncFailure;
+      },
+    });
+
+    expect(() => registered.get("sync-failure")?.execute({})).toThrow(
+      syncFailure,
+    );
+    await expect(registered.get("async-failure")?.execute({})).rejects.toBe(
+      asyncFailure,
+    );
   });
 
   it("forwards title when present", () => {
@@ -895,27 +963,45 @@ describe("Standard Schema tool definitions", () => {
 
   it("accepts schemas directly and passes transformed input to execute", async () => {
     const { registered } = installFakeModelContext();
-    const execute = vi.fn((count: number) => String(count + 1));
+    const controller = new AbortController();
+    const callbackOptions: ToolExecuteCallbackOptions = {
+      signal: controller.signal,
+    };
+    const execute = vi.fn(
+      (count: number, options?: ToolExecuteCallbackOptions) => {
+        expect(options).toBe(callbackOptions);
+        return String(count + 1);
+      },
+    );
 
     registerTool({
       name: "increment",
       description: "increments a numeric string",
       input: numericStringSchema,
       inputSchema: { type: "string", pattern: "^\\d+$" },
-      execute: (count) => {
+      execute: (count, options) => {
         expectTypeOf(count).toEqualTypeOf<number>();
-        return execute(count);
+        return execute(count, options);
       },
     });
 
-    await expect(registered.get("increment")?.execute("41")).resolves.toBe(
-      "42",
-    );
-    expect(execute).toHaveBeenCalledWith(41);
+    await expect(
+      registered.get("increment")?.execute("41", callbackOptions),
+    ).resolves.toBe("42");
+    expect(execute).toHaveBeenCalledWith(41, callbackOptions);
   });
 
   it("validates transformed outputs from synchronous and asynchronous schemas", async () => {
     const { registered } = installFakeModelContext();
+    const callbackOptions: ToolExecuteCallbackOptions = {
+      signal: new AbortController().signal,
+    };
+    const execute = vi.fn(
+      (_input: unknown, options?: ToolExecuteCallbackOptions) => {
+        expect(options).toBe(callbackOptions);
+        return "42";
+      },
+    );
     const asyncOutput: StandardSchemaV1<string, number> = {
       "~standard": {
         version: 1,
@@ -932,15 +1018,21 @@ describe("Standard Schema tool definitions", () => {
       name: "count",
       description: "returns a count",
       output: asyncOutput,
-      execute: async () => "42",
+      execute,
     });
 
-    await expect(registered.get("count")?.execute(undefined)).resolves.toBe(42);
+    await expect(
+      registered.get("count")?.execute(undefined, callbackOptions),
+    ).resolves.toBe(42);
+    expect(execute).toHaveBeenCalledWith(undefined, callbackOptions);
   });
 
   it("preserves typed input validation errors without validate ceremony", async () => {
     const { registered } = installFakeModelContext();
     const execute = vi.fn(() => ({ ok: true }));
+    const callbackOptions: ToolExecuteCallbackOptions = {
+      signal: new AbortController().signal,
+    };
 
     registerTool({
       name: "increment",
@@ -950,14 +1042,14 @@ describe("Standard Schema tool definitions", () => {
     });
 
     await expect(
-      registered.get("increment")?.execute("not-a-number"),
+      registered.get("increment")?.execute("not-a-number", callbackOptions),
     ).rejects.toMatchObject({
       name: "ToolValidationError",
       toolName: "increment",
       issues: [{ message: "output must be a numeric string" }],
     });
     await expect(
-      registered.get("increment")?.execute("not-a-number"),
+      registered.get("increment")?.execute("not-a-number", callbackOptions),
     ).rejects.toBeInstanceOf(ToolValidationError);
     expect(execute).not.toHaveBeenCalled();
   });
@@ -1054,6 +1146,30 @@ describe("Standard Schema tool definitions", () => {
     });
     const out = await (tool.execute as (input: unknown) => unknown)(123);
     expect(out).toEqual({ text: 123 });
+  });
+
+  it("forwards callback options through the deprecated definition wrapper", async () => {
+    const callbackOptions: ToolExecuteCallbackOptions = {
+      signal: new AbortController().signal,
+    };
+    const execute = vi.fn(
+      (text: string, options?: ToolExecuteCallbackOptions) => {
+        expect(options).toBe(callbackOptions);
+        return { text };
+      },
+    );
+    const tool = defineTool({
+      name: "deprecated-options",
+      description: "Forwards callback options.",
+      input: stringSchema("input"),
+      validate: true,
+      execute,
+    });
+
+    await expect(tool.execute("hello", callbackOptions)).resolves.toEqual({
+      text: "hello",
+    });
+    expect(execute).toHaveBeenCalledWith("hello", callbackOptions);
   });
 
   it("returns a Tool that registers via the existing surface", () => {

--- a/packages/webmcp/src/index.ts
+++ b/packages/webmcp/src/index.ts
@@ -19,6 +19,7 @@ import {
 import {
   type RegisteredToolMetadata,
   type Tool,
+  type ToolExecuteCallbackOptions,
   toRegisteredToolMetadata,
 } from "./tool.js";
 
@@ -32,10 +33,17 @@ export {
   ToolOutputValidationError,
   ToolValidationError,
 } from "./definition.js";
-export type { Tool, ToolAnnotations } from "./tool.js";
+export type {
+  Tool,
+  ToolAnnotations,
+  ToolExecuteCallbackOptions,
+} from "./tool.js";
 
 interface NativeToolDefinition extends RegisteredToolMetadata {
-  execute: (input: unknown) => Promise<unknown> | unknown;
+  execute: (
+    input: unknown,
+    options?: ToolExecuteCallbackOptions,
+  ) => Promise<unknown> | unknown;
 }
 
 /** Options forwarded to the native WebMCP registration. */

--- a/packages/webmcp/src/react/index.test.tsx
+++ b/packages/webmcp/src/react/index.test.tsx
@@ -1,7 +1,12 @@
 import { act, renderHook, waitFor } from "@testing-library/react";
 import { type ReactNode, StrictMode, useLayoutEffect } from "react";
 import { afterEach, describe, expect, expectTypeOf, it, vi } from "vitest";
-import type { StandardSchemaV1, Tool, ToolDefinition } from "../index.js";
+import type {
+  StandardSchemaV1,
+  Tool,
+  ToolDefinition,
+  ToolExecuteCallbackOptions,
+} from "../index.js";
 import {
   type RegisterToolOptions,
   type UseWebMCPOptions,
@@ -14,7 +19,7 @@ interface RegisteredCall {
   description: string;
   inputSchema?: object;
   annotations?: Record<string, boolean>;
-  execute: (input: unknown) => unknown;
+  execute: (input: unknown, options?: ToolExecuteCallbackOptions) => unknown;
 }
 
 type Host = "document" | "navigator";
@@ -414,8 +419,14 @@ describe("useWebMCP", () => {
     unmount();
   });
 
-  it("uses the latest execute callback without re-registering", () => {
+  it("forwards the exact signal to the latest callback without re-registering", () => {
     const { registered, registerTool } = installFakeModelContext();
+    const firstOptions: ToolExecuteCallbackOptions = {
+      signal: new AbortController().signal,
+    };
+    const secondOptions: ToolExecuteCallbackOptions = {
+      signal: new AbortController().signal,
+    };
 
     const { rerender, unmount } = renderHook(
       ({ value }: { value: number }) =>
@@ -424,20 +435,62 @@ describe("useWebMCP", () => {
             name: "live-state",
             description: "Read the latest state",
             annotations: { readOnlyHint: true },
-            execute: () => value,
+            execute: (_input, options) => ({ value, signal: options?.signal }),
           },
           { exposedTo: ["https://agent.example"] },
         ),
       { initialProps: { value: 1 } },
     );
     const registeredTool = registered.get("live-state");
-    expect(registeredTool?.execute(undefined)).toBe(1);
+    expect(registeredTool?.execute(undefined, firstOptions)).toEqual({
+      value: 1,
+      signal: firstOptions.signal,
+    });
 
     rerender({ value: 2 });
 
     expect(registerTool).toHaveBeenCalledTimes(1);
-    expect(registeredTool?.execute(undefined)).toBe(2);
+    expect(registeredTool?.execute(undefined, secondOptions)).toEqual({
+      value: 2,
+      signal: secondOptions.signal,
+    });
     unmount();
+  });
+
+  it("does not cancel active execution when unmounted", async () => {
+    const { registered, registerTool } = installFakeModelContext();
+    const executionController = new AbortController();
+    const callbackOptions: ToolExecuteCallbackOptions = {
+      signal: executionController.signal,
+    };
+    let finish: ((value: string) => void) | undefined;
+
+    const { unmount } = renderHook(() =>
+      useWebMCP({
+        name: "active-execution",
+        description: "Completes after unmount.",
+        execute: (_input, options) =>
+          new Promise<string>((resolve) => {
+            expect(options).toBe(callbackOptions);
+            finish = resolve;
+          }),
+      }),
+    );
+    const execution = registered
+      .get("active-execution")
+      ?.execute(undefined, callbackOptions);
+    const registrationSignal = registerTool.mock.calls[0]?.[1]?.signal;
+
+    expect(finish).toBeDefined();
+    unmount();
+
+    expect(registered.has("active-execution")).toBe(false);
+    expect(registrationSignal?.aborted).toBe(true);
+    expect(executionController.signal.aborted).toBe(false);
+    expect(() => unmount()).not.toThrow();
+
+    finish?.("done");
+    await expect(execution).resolves.toBe("done");
   });
 
   it("updates execute callbacks before consumer layout effects run", () => {

--- a/packages/webmcp/src/react/index.ts
+++ b/packages/webmcp/src/react/index.ts
@@ -20,7 +20,11 @@ import {
   registerTool,
   subscribeToToolChanges,
 } from "../index.js";
-import { type Tool, toRegisteredToolMetadata } from "../tool.js";
+import {
+  type Tool,
+  type ToolExecuteCallbackOptions,
+  toRegisteredToolMetadata,
+} from "../tool.js";
 
 export interface UseWebMCPOptions extends RegisterToolOptions, GetToolsOptions {
   /** Whether registration and discovery are active. Defaults to `true`. */
@@ -114,8 +118,8 @@ const wrapTools = (
     const tool: Tool = {
       name: definition.name,
       description: definition.description,
-      execute: (input: unknown) =>
-        (latestTools.current[index] ?? initialTool)?.execute(input),
+      execute: (input: unknown, options?: ToolExecuteCallbackOptions) =>
+        (latestTools.current[index] ?? initialTool)?.execute(input, options),
     };
     if (definition.title !== undefined) tool.title = definition.title;
     if (definition.inputSchema !== undefined) {
@@ -311,6 +315,7 @@ export type {
   Tool,
   ToolAnnotations,
   ToolDefinition,
+  ToolExecuteCallbackOptions,
 } from "../index.js";
 export {
   defineTool,

--- a/packages/webmcp/src/tool.ts
+++ b/packages/webmcp/src/tool.ts
@@ -25,9 +25,20 @@ export interface ToolMetadata {
   annotations?: ToolAnnotations;
 }
 
+/**
+ * Options supplied by the browser for one tool callback execution.
+ * Older trial hosts can omit the callback's optional second argument.
+ */
+export interface ToolExecuteCallbackOptions {
+  signal: AbortSignal;
+}
+
 export interface Tool<TInput = unknown, TOutput = unknown>
   extends ToolMetadata {
-  execute: (input: TInput) => Promise<TOutput> | TOutput;
+  execute: (
+    input: TInput,
+    options?: ToolExecuteCallbackOptions,
+  ) => Promise<TOutput> | TOutput;
 }
 
 export interface RegisteredToolMetadata {

--- a/paseo.json
+++ b/paseo.json
@@ -1,0 +1,30 @@
+{
+  "worktree": {
+    "setup": [
+      "pnpm dev:setup"
+    ],
+    "servicePorts": {
+      "range": "20000-29999"
+    }
+  },
+  "scripts": {
+    "site": {
+      "type": "service",
+      "command": "node scripts/paseo-service.mjs site"
+    },
+    "mcp": {
+      "type": "service",
+      "command": "node scripts/paseo-service.mjs mcp"
+    },
+    "packages": {
+      "command": "pnpm dev:packages"
+    },
+    "preview": {
+      "type": "service",
+      "command": "node scripts/paseo-service.mjs preview"
+    },
+    "gate": {
+      "command": "pnpm gate"
+    }
+  }
+}

--- a/scripts/development-info.mjs
+++ b/scripts/development-info.mjs
@@ -1,0 +1,19 @@
+import { fileURLToPath } from "node:url";
+import {
+  resolveDevelopmentInstance,
+  resolveDevelopmentService,
+} from "./development-instance.mjs";
+
+const root = fileURLToPath(new URL("../", import.meta.url));
+const instance = resolveDevelopmentInstance(root);
+
+console.log(`Development instance: ${instance.id}`);
+console.log(`Source: ${instance.source}`);
+
+for (const [label, service] of [
+  ["Site", "site"],
+  ["Preview", "preview"],
+  ["MCP", "mcp"],
+]) {
+  console.log(`${label}: ${resolveDevelopmentService(service, root).url}`);
+}

--- a/scripts/development-instance.mjs
+++ b/scripts/development-instance.mjs
@@ -1,0 +1,188 @@
+import crypto from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+
+const DEFAULT_INSTANCE_ID = "default";
+const INSTANCE_OVERRIDE_VARIABLE = "WEB_AI_SDK_DEV_INSTANCE";
+const HOST_OVERRIDE_VARIABLE = "WEB_AI_SDK_HOST";
+const MAX_OVERRIDE_LENGTH = 32;
+const MAX_SLUG_LENGTH = 18;
+const PORT_SLOT_COUNT = 5_000;
+
+const SERVICE_DEFINITIONS = Object.freeze({
+  site: Object.freeze({
+    defaultPort: 5_173,
+    isolatedPortBase: 20_000,
+    portVariable: "WEB_AI_SDK_SITE_PORT",
+  }),
+  preview: Object.freeze({
+    defaultPort: 4_173,
+    isolatedPortBase: 30_000,
+    portVariable: "WEB_AI_SDK_PREVIEW_PORT",
+  }),
+  mcp: Object.freeze({
+    defaultPort: 8_787,
+    isolatedPortBase: 40_000,
+    portVariable: "WEB_AI_SDK_MCP_PORT",
+  }),
+  mcpInspector: Object.freeze({
+    allowZero: true,
+    defaultPort: 9_229,
+    isolatedPortBase: 50_000,
+    portVariable: "WEB_AI_SDK_MCP_INSPECTOR_PORT",
+  }),
+});
+
+export function normalizeDevelopmentInstanceId(
+  value,
+  maximumLength = MAX_OVERRIDE_LENGTH,
+) {
+  return String(value ?? "")
+    .normalize("NFKD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, maximumLength)
+    .replace(/-+$/g, "");
+}
+
+function canonicalCheckoutRoot(root) {
+  const resolved = fs.realpathSync.native(path.resolve(root));
+  return process.platform === "win32" ? resolved.toLowerCase() : resolved;
+}
+
+function isPrimaryCheckout(root) {
+  try {
+    return fs.statSync(path.join(root, ".git")).isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+function hash(value) {
+  return crypto.createHash("sha256").update(value).digest("hex");
+}
+
+function derivedWorktreeIdentity(canonicalRoot) {
+  const slug =
+    normalizeDevelopmentInstanceId(
+      path.basename(canonicalRoot),
+      MAX_SLUG_LENGTH,
+    ) || "worktree";
+  const pathHash = hash(canonicalRoot);
+
+  return {
+    id: `${slug}-${pathHash.slice(0, 8)}`,
+    portSlot: Number.parseInt(pathHash.slice(0, 8), 16) % PORT_SLOT_COUNT,
+  };
+}
+
+function overrideIdentity(override) {
+  const id = normalizeDevelopmentInstanceId(override);
+
+  if (!id || id === DEFAULT_INSTANCE_ID) {
+    throw new Error(
+      `${INSTANCE_OVERRIDE_VARIABLE} must normalize to a non-reserved identifier.`,
+    );
+  }
+
+  return {
+    id,
+    portSlot: Number.parseInt(hash(id).slice(0, 8), 16) % PORT_SLOT_COUNT,
+  };
+}
+
+export function resolveDevelopmentInstance(root, environment = process.env) {
+  const canonicalRoot = canonicalCheckoutRoot(root);
+  const override = environment[INSTANCE_OVERRIDE_VARIABLE];
+  let identity;
+  let source;
+
+  if (override !== undefined && String(override).trim() !== "") {
+    identity = overrideIdentity(override);
+    source = "override";
+  } else if (isPrimaryCheckout(canonicalRoot)) {
+    identity = { id: DEFAULT_INSTANCE_ID, portSlot: 0 };
+    source = "primary-checkout";
+  } else {
+    identity = derivedWorktreeIdentity(canonicalRoot);
+    source = "linked-worktree";
+  }
+
+  return Object.freeze({
+    id: identity.id,
+    portSlot: identity.portSlot,
+    primary: identity.id === DEFAULT_INSTANCE_ID,
+    root: canonicalRoot,
+    source,
+  });
+}
+
+function parsePort(value, variable, allowZero = false) {
+  const normalized = value?.trim();
+
+  if (!normalized) {
+    return null;
+  }
+
+  const minimum = allowZero ? 0 : 1;
+  const message = `${variable} must be an integer from ${minimum} through 65535.`;
+
+  if (!/^\d+$/.test(normalized)) {
+    throw new Error(message);
+  }
+
+  const port = Number(normalized);
+
+  if (port < minimum || port > 65_535) {
+    throw new Error(message);
+  }
+
+  return port;
+}
+
+export function resolveDevelopmentService(
+  service,
+  root,
+  environment = process.env,
+) {
+  const definition = SERVICE_DEFINITIONS[service];
+
+  if (!definition) {
+    throw new Error(`Unknown development service: ${service}`);
+  }
+
+  const instance = resolveDevelopmentInstance(root, environment);
+  const configuredPort = parsePort(
+    environment[definition.portVariable],
+    definition.portVariable,
+    definition.allowZero,
+  );
+  const configuredHost = environment[HOST_OVERRIDE_VARIABLE]?.trim() || null;
+  const port =
+    configuredPort ??
+    (instance.primary
+      ? definition.defaultPort
+      : definition.isolatedPortBase + instance.portSlot);
+  const hostname = instance.primary
+    ? "localhost"
+    : `${service}--${instance.id}.web-ai-sdk.localhost`;
+
+  return Object.freeze({
+    bindHost: configuredHost ?? (instance.primary ? null : "127.0.0.1"),
+    configured: configuredPort !== null || configuredHost !== null,
+    hostname,
+    instance,
+    port,
+    portVariable: definition.portVariable,
+    url: `http://${hostname}:${port}/`,
+  });
+}
+
+export const developmentInstanceConstants = Object.freeze({
+  defaultInstanceId: DEFAULT_INSTANCE_ID,
+  hostOverrideVariable: HOST_OVERRIDE_VARIABLE,
+  instanceOverrideVariable: INSTANCE_OVERRIDE_VARIABLE,
+  portSlotCount: PORT_SLOT_COUNT,
+});

--- a/scripts/paseo-service.mjs
+++ b/scripts/paseo-service.mjs
@@ -1,0 +1,62 @@
+import {
+  childProcessExitCode,
+  spawnManagedProcess,
+} from "./process-tree.mjs";
+
+const SERVICES = Object.freeze({
+  site: Object.freeze({
+    args: ["dev"],
+    portVariable: "WEB_AI_SDK_SITE_PORT",
+  }),
+  preview: Object.freeze({
+    args: ["pages:preview"],
+    portVariable: "WEB_AI_SDK_PREVIEW_PORT",
+  }),
+  mcp: Object.freeze({
+    args: ["mcp"],
+    portVariable: "WEB_AI_SDK_MCP_PORT",
+  }),
+});
+
+const serviceName = process.argv[2];
+const service = SERVICES[serviceName];
+
+if (!service) {
+  console.error(`Unknown Paseo service: ${serviceName ?? "<missing>"}`);
+  process.exit(1);
+}
+
+const paseoPort = process.env.PASEO_PORT?.trim();
+
+if (!paseoPort) {
+  console.error("PASEO_PORT is required for a Paseo service.");
+  process.exit(1);
+}
+
+const pnpmCommand = process.platform === "win32" ? "pnpm.cmd" : "pnpm";
+const environment = {
+  ...process.env,
+  [service.portVariable]: paseoPort,
+  WEB_AI_SDK_HOST:
+    process.env.WEB_AI_SDK_HOST?.trim() ||
+    process.env.HOST?.trim() ||
+    "127.0.0.1",
+};
+
+if (serviceName === "mcp") {
+  environment.WEB_AI_SDK_MCP_INSPECTOR_PORT = "0";
+}
+
+const child = spawnManagedProcess(pnpmCommand, service.args, {
+  env: environment,
+  stdio: "inherit",
+});
+
+child.once("error", (error) => {
+  console.error(error.message);
+  process.exitCode = 1;
+});
+
+child.once("exit", (code, signal) => {
+  process.exitCode = childProcessExitCode(code, signal);
+});

--- a/scripts/process-tree.mjs
+++ b/scripts/process-tree.mjs
@@ -1,0 +1,64 @@
+import { spawn } from "node:child_process";
+
+const SIGNAL_EXIT_CODES = Object.freeze({
+  SIGHUP: 129,
+  SIGINT: 130,
+  SIGTERM: 143,
+});
+const TERMINATION_SIGNALS =
+  process.platform === "win32"
+    ? Object.freeze(["SIGINT", "SIGTERM"])
+    : Object.freeze(["SIGHUP", "SIGINT", "SIGTERM"]);
+
+export function terminateProcessTree(child, signal = "SIGTERM") {
+  if (!child.pid || child.exitCode !== null || child.signalCode !== null) {
+    return;
+  }
+
+  if (process.platform === "win32") {
+    const taskkill = spawn(
+      "taskkill",
+      ["/pid", String(child.pid), "/t", "/f"],
+      {
+        stdio: "ignore",
+        windowsHide: true,
+      },
+    );
+    taskkill.once("error", () => child.kill());
+    return;
+  }
+
+  try {
+    process.kill(-child.pid, signal);
+  } catch (error) {
+    if (error?.code !== "ESRCH") {
+      child.kill(signal);
+    }
+  }
+}
+
+export function spawnManagedProcess(command, args, options = {}) {
+  const child = spawn(command, args, {
+    ...options,
+    detached: process.platform !== "win32",
+  });
+  const signalHandlers = new Map();
+
+  for (const signal of TERMINATION_SIGNALS) {
+    const handler = () => terminateProcessTree(child, signal);
+    signalHandlers.set(signal, handler);
+    process.once(signal, handler);
+  }
+
+  child.once("close", () => {
+    for (const [signal, handler] of signalHandlers) {
+      process.removeListener(signal, handler);
+    }
+  });
+
+  return child;
+}
+
+export function childProcessExitCode(code, signal) {
+  return code ?? SIGNAL_EXIT_CODES[signal] ?? 1;
+}


### PR DESCRIPTION
## Summary

- export callback options containing the browser-provided `AbortSignal`
- preserve the options through plain, schema-aware, deprecated, and React callbacks
- support older trial browsers that omit execution options
- document cancellation forwarding and cleanup behavior
- add a minor changeset

## Validation

- `pnpm gate`
- WebMCP: 94 tests passed
- isolated development server responds with HTTP 200
- practical Chrome validation pending

## Dependency

This draft targets `chore/worktree-development` and depends on #232.

Closes #224