### PR TITLE
chore(dev): clean worktree artifacts on teardown

### DIFF
--- a/.agents/agents.md
+++ b/.agents/agents.md
@@ -136,6 +136,8 @@ consumes package output. Run `pnpm gate` before any commit.
 - Give each parallel editor a separate workspace. Confirm its root and branch
   with `git rev-parse --show-toplevel` and `git status --short --branch`.
 - Run `pnpm dev:setup` in a new worktree before development starts.
+- Before removing or archiving a worktree, preserve required changes and stop
+  its services. Use its teardown hook, or run `pnpm dev:clean` before removal.
 - Do not overwrite or hide existing changes. If unexpected changes exist before
   work starts, stop and ask the user to commit or stash them.
 - Use a dedicated branch. Never commit, merge, or push directly to `main`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,6 +46,20 @@ pnpm dev
 pnpm mcp
 ```
 
+Before removing a linked worktree, preserve every required change and stop its
+services. Then preview and remove its generated artifacts:
+
+```sh
+pnpm dev:clean -- --dry-run
+pnpm dev:clean
+```
+
+`pnpm dev:clean` removes dependencies, caches, generated files, and build
+outputs from the current checkout. It preserves environment files, local
+configuration, scratch files, and the shared pnpm store.
+
+Remove the worktree with Git or its workspace manager after cleanup succeeds.
+
 Do not copy `.env` files or secrets into a worktree. Add required local values
 through that worktree's environment instead.
 
@@ -68,13 +82,21 @@ paseo script start site
 paseo script start mcp
 ```
 
+Archive a completed Paseo workspace with its workspace ID:
+
+```sh
+paseo workspace archive <workspace-id>
+```
+
+Archiving stops the workspace's owned terminals and services. The checked-in
+teardown hook then runs `pnpm dev:clean` before Paseo removes its worktree.
+
 Paseo prints a distinct proxy URL for each branch and service. Its adapter maps
 the allocated port to the project's generic environment variables.
 
 Start `packages` with `site` when package source changes must reach a demo.
 
-Keep one editor in each worktree. Confirm the workspace path before editing,
-and archive the workspace only after preserving every required change.
+Keep one editor in each worktree. Confirm the workspace path before editing.
 
 ## Change workflow
 

--- a/README.md
+++ b/README.md
@@ -152,6 +152,17 @@ Use these environment variables when you need explicit values:
 The generated port can rarely conflict with another local process. Set the
 matching port variable when that happens.
 
+Stop local services before removing a linked worktree. Preview and remove
+generated artifacts with the same tool-neutral commands in every checkout:
+
+```sh
+pnpm dev:clean -- --dry-run
+pnpm dev:clean
+```
+
+The cleanup stays inside the current checkout. It preserves environment files,
+local configuration, scratch files, and the shared pnpm store.
+
 #### Optional Paseo integration
 
 The checked-in [`paseo.json`](./paseo.json) automates setup and process
@@ -178,6 +189,10 @@ paseo script start site
 Paseo allocates backend ports and exposes each service through a proxy URL. A
 small adapter passes each backend port through a generic variable listed above.
 
+Paseo uses the project's `worktree.teardown` hook when it archives an owned
+worktree. The hook runs `pnpm dev:clean` after Paseo stops owned terminals and
+services.
+
 ## Repo layout
 
 ```
@@ -196,7 +211,7 @@ small adapter passes each backend port through a generic variable listed above.
 │   ├── site/           # @web-ai-sdk-apps/site (private; Astro site + Starlight docs)
 │   └── mcp/            # @web-ai-sdk-apps/mcp (private; web-ai-sdk MCP Worker)
 ├── scripts/            # development instance and optional tool adapters
-├── paseo.json          # optional worktree setup and managed local services
+├── paseo.json          # optional worktree lifecycle and managed local services
 ├── .agents/agents.md           # agent instructions (AGENTS.md symlink kept at root)
 ├── README.md           # ← you are here
 └── …

--- a/apps/site/scripts/development-clean.test.mjs
+++ b/apps/site/scripts/development-clean.test.mjs
@@ -1,0 +1,104 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  cleanDevelopmentArtifacts,
+  collectDevelopmentArtifacts,
+} from "../../../scripts/development-clean.mjs";
+
+const temporaryRoots = [];
+
+function createCheckout() {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "web-ai-sdk-clean-"));
+  temporaryRoots.push(root);
+
+  for (const directory of [
+    "node_modules",
+    ".pnpm-store",
+    "_site",
+    "apps/site/node_modules",
+    "apps/site/.astro",
+    "apps/site/dist",
+    "apps/site/src",
+    "apps/mcp/.wrangler",
+    "apps/mcp/src/generated",
+    "packages/prompt/node_modules",
+    "packages/prompt/dist",
+    ".ideas",
+  ]) {
+    fs.mkdirSync(path.join(root, directory), { recursive: true });
+  }
+
+  for (const file of [
+    ".env",
+    ".npmrc",
+    ".ideas/notes.md",
+    "apps/site/src/index.ts",
+  ]) {
+    fs.writeFileSync(path.join(root, file), "keep");
+  }
+
+  return root;
+}
+
+afterEach(() => {
+  for (const root of temporaryRoots.splice(0)) {
+    fs.rmSync(root, { force: true, recursive: true });
+  }
+});
+
+describe("development cleanup", () => {
+  it("removes only known generated artifacts", () => {
+    const root = createCheckout();
+    const removed = cleanDevelopmentArtifacts(root);
+
+    expect(removed).toContain("node_modules");
+    expect(removed).toContain(path.join("apps", "site", ".astro"));
+    expect(removed).toContain(path.join("apps", "mcp", ".wrangler"));
+    expect(removed).toContain(
+      path.join("apps", "mcp", "src", "generated"),
+    );
+    expect(removed).toContain(path.join("packages", "prompt", "dist"));
+    expect(fs.existsSync(path.join(root, "node_modules"))).toBe(false);
+    expect(fs.existsSync(path.join(root, "apps/site/dist"))).toBe(false);
+    expect(fs.readFileSync(path.join(root, ".env"), "utf8")).toBe("keep");
+    expect(fs.readFileSync(path.join(root, ".npmrc"), "utf8")).toBe("keep");
+    expect(fs.readFileSync(path.join(root, ".ideas/notes.md"), "utf8")).toBe(
+      "keep",
+    );
+    expect(fs.readFileSync(path.join(root, "apps/site/src/index.ts"), "utf8")).toBe(
+      "keep",
+    );
+  });
+
+  it("supports a dry run and repeated cleanup", () => {
+    const root = createCheckout();
+    const expected = collectDevelopmentArtifacts(root).map((artifact) =>
+      path.relative(root, artifact),
+    );
+
+    expect(cleanDevelopmentArtifacts(root, { dryRun: true })).toEqual(expected);
+    expect(fs.existsSync(path.join(root, "node_modules"))).toBe(true);
+
+    cleanDevelopmentArtifacts(root);
+    expect(cleanDevelopmentArtifacts(root)).toEqual([]);
+  });
+
+  it("does not follow an artifact symlink outside the checkout", () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "web-ai-sdk-clean-"));
+    const external = fs.mkdtempSync(
+      path.join(os.tmpdir(), "web-ai-sdk-clean-external-"),
+    );
+    temporaryRoots.push(root, external);
+    fs.writeFileSync(path.join(external, "keep.txt"), "keep");
+    fs.symlinkSync(external, path.join(root, "node_modules"), "dir");
+
+    cleanDevelopmentArtifacts(root);
+
+    expect(fs.existsSync(path.join(root, "node_modules"))).toBe(false);
+    expect(fs.readFileSync(path.join(external, "keep.txt"), "utf8")).toBe(
+      "keep",
+    );
+  });
+});

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   },
   "scripts": {
     "dev": "pnpm --filter @web-ai-sdk-apps/site run dev",
+    "dev:clean": "node scripts/development-clean.mjs",
     "dev:info": "node scripts/development-info.mjs",
     "dev:setup": "pnpm install --frozen-lockfile && pnpm build:packages",
     "dev:packages": "pnpm --filter \"./packages/**\" --filter \"!@web-ai-sdk/all\" -r --parallel run dev",

--- a/paseo.json
+++ b/paseo.json
@@ -3,6 +3,9 @@
     "setup": [
       "pnpm dev:setup"
     ],
+    "teardown": [
+      "pnpm dev:clean"
+    ],
     "servicePorts": {
       "range": "20000-29999"
     }

--- a/scripts/development-clean.mjs
+++ b/scripts/development-clean.mjs
@@ -1,0 +1,155 @@
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const ROOT_ARTIFACTS = [
+  ".astro",
+  ".pnpm-store",
+  ".turbo",
+  "_site",
+  "coverage",
+  "dist",
+  "node_modules",
+  "storybook-static",
+];
+
+const WORKSPACE_ARTIFACTS = [
+  ".astro",
+  ".turbo",
+  "coverage",
+  "dist",
+  "node_modules",
+  "storybook-static",
+];
+
+const FIXED_ARTIFACTS = ["apps/mcp/.wrangler", "apps/mcp/src/generated"];
+
+function isMissing(error) {
+  return error && typeof error === "object" && error.code === "ENOENT";
+}
+
+function assertInsideRoot(root, target) {
+  const relative = path.relative(root, target);
+
+  if (!relative || relative.startsWith(`..${path.sep}`) || path.isAbsolute(relative)) {
+    throw new Error(`Refusing to clean a path outside the checkout: ${target}`);
+  }
+
+  return relative;
+}
+
+function listWorkspaceDirectories(root, scope) {
+  const scopePath = path.join(root, scope);
+
+  try {
+    return fs
+      .readdirSync(scopePath, { withFileTypes: true })
+      .filter((entry) => entry.isDirectory())
+      .map((entry) => path.join(scopePath, entry.name));
+  } catch (error) {
+    if (isMissing(error)) return [];
+    throw error;
+  }
+}
+
+export function collectDevelopmentArtifacts(root) {
+  const resolvedRoot = path.resolve(root);
+  const candidates = ROOT_ARTIFACTS.map((artifact) =>
+    path.join(resolvedRoot, artifact),
+  );
+
+  for (const scope of ["apps", "packages"]) {
+    for (const workspace of listWorkspaceDirectories(resolvedRoot, scope)) {
+      for (const artifact of WORKSPACE_ARTIFACTS) {
+        candidates.push(path.join(workspace, artifact));
+      }
+    }
+  }
+
+  for (const artifact of FIXED_ARTIFACTS) {
+    candidates.push(path.join(resolvedRoot, artifact));
+  }
+
+  return candidates
+    .filter((candidate) => {
+      assertInsideRoot(resolvedRoot, candidate);
+
+      try {
+        fs.lstatSync(candidate);
+        return true;
+      } catch (error) {
+        if (isMissing(error)) return false;
+        throw error;
+      }
+    })
+    .sort((left, right) => right.length - left.length);
+}
+
+export function cleanDevelopmentArtifacts(root, options = {}) {
+  const resolvedRoot = path.resolve(root);
+  const artifacts = collectDevelopmentArtifacts(resolvedRoot);
+
+  if (!options.dryRun) {
+    for (const artifact of artifacts) {
+      fs.rmSync(artifact, { force: true, recursive: true });
+    }
+  }
+
+  return artifacts.map((artifact) => path.relative(resolvedRoot, artifact));
+}
+
+function findDevelopmentRoot(start) {
+  let current = path.resolve(start);
+
+  while (true) {
+    const packagePath = path.join(current, "package.json");
+    const workspacePath = path.join(current, "pnpm-workspace.yaml");
+
+    try {
+      const packageJson = JSON.parse(fs.readFileSync(packagePath, "utf8"));
+
+      if (packageJson.name === "web-ai-sdk" && fs.existsSync(workspacePath)) {
+        return current;
+      }
+    } catch (error) {
+      if (!isMissing(error) && !(error instanceof SyntaxError)) throw error;
+    }
+
+    const parent = path.dirname(current);
+    if (parent === current) {
+      throw new Error("Could not find the web-ai-sdk checkout root.");
+    }
+    current = parent;
+  }
+}
+
+function parseOptions(args) {
+  const options = args.filter((argument) => argument !== "--");
+  const unknown = options.filter((argument) => argument !== "--dry-run");
+  if (unknown.length > 0) {
+    throw new Error(`Unknown option: ${unknown[0]}`);
+  }
+
+  return { dryRun: options.includes("--dry-run") };
+}
+
+function run() {
+  const options = parseOptions(process.argv.slice(2));
+  const root = findDevelopmentRoot(process.cwd());
+  const artifacts = cleanDevelopmentArtifacts(root, options);
+  const action = options.dryRun ? "Would remove" : "Removed";
+
+  if (artifacts.length === 0) {
+    console.log("No generated development artifacts found.");
+    return;
+  }
+
+  console.log(`${action} ${artifacts.length} generated artifact paths:`);
+  for (const artifact of artifacts.sort()) console.log(`- ${artifact}`);
+}
+
+const isDirectRun =
+  process.argv[1] &&
+  path.resolve(process.argv[1]) === path.resolve(fileURLToPath(import.meta.url));
+
+if (isDirectRun) run();


### PR DESCRIPTION
## Summary

- add a tool-neutral worktree cleanup command with dry-run support
- run cleanup through the optional Paseo teardown hook
- preserve environment files, local configuration, scratch files, and the shared pnpm store
- document teardown responsibilities for contributors and coding agents

## Validation

- `pnpm gate`
- `pnpm dev:clean -- --dry-run`
- `paseo script ls --json`
