### PR TITLE
feat(webmcp): support consequentialHint tool annotations

### DIFF
--- a/.changeset/cute-bikes-like.md
+++ b/.changeset/cute-bikes-like.md
@@ -1,0 +1,6 @@
+---
+"@web-ai-sdk/webmcp": minor
+---
+
+Add the optional consequentialHint tool annotation. Preserve explicit values through registration and discovery, and document that the hint does not authorize execution or guarantee confirmation.
+  

--- a/apps/site/src/content/docs/guides/webmcp.mdx
+++ b/apps/site/src/content/docs/guides/webmcp.mdx
@@ -161,7 +161,7 @@ maintaining a second handwritten definition.
 | `inputSchema` | `object` | JSON Schema describing the input shape. Some hosts validate against it before dispatch. |
 | `readOnly` | `boolean` | Shorthand for `annotations.readOnlyHint = true`. |
 | `destructive` | `boolean` | Compatibility shorthand for `annotations.destructiveHint = true`. |
-| `annotations` | `ToolAnnotations` | Raw passthrough. The current draft defines `readOnlyHint` and `untrustedContentHint`; compatibility fields are described below. |
+| `annotations` | `ToolAnnotations` | Raw passthrough. The current draft defines `readOnlyHint`, `untrustedContentHint`, and `consequentialHint`; compatibility fields are described below. |
 
 </div>
 
@@ -221,7 +221,7 @@ const tools = await getTools({
 
 ## Annotations
 
-Annotations communicate intent to the agent. The current WebMCP draft defines `readOnlyHint` and `untrustedContentHint`. Use the latter when a tool returns external, user-generated, or otherwise untrusted content:
+Annotations communicate intent to the agent. The current WebMCP draft defines `readOnlyHint`, `untrustedContentHint`, and `consequentialHint`. Use `untrustedContentHint` when a tool returns external, user-generated, or otherwise untrusted content:
 
 ```ts
 registerTool({
@@ -239,6 +239,21 @@ registerTool({
 `untrustedContentHint` is a trust-boundary signal; it does not validate result shape, truth, freshness, or safety. `readOnly` remains shorthand for the draft's `readOnlyHint`.
 
 For source compatibility, the SDK retains `destructiveHint`, `idempotentHint`, `openWorldHint`, and the `destructive` shorthand as passthroughs for MCP-shaped and earlier WebMCP hosts. They are not defined by the current WebMCP draft, so current-draft browsers may ignore them. Raw `annotations` values merge on top of shorthand values.
+
+Set `annotations.consequentialHint: true` for tools that can cause significant real-world or difficult-to-reverse effects. A compatible host can use this hint when deciding whether to request confirmation.
+
+The hint is not authorization and does not guarantee a confirmation prompt. Applications must enforce authentication, authorization, validation, origin controls, and rate limits. The SDK does not add confirmation behavior.
+
+The SDK forwards explicit `true` and `false` values and leaves the property absent when omitted. Discovery preserves the metadata returned by the host. There is no shorthand, and the SDK does not infer this value from `destructiveHint`.
+
+```ts
+registerTool({
+  name: "submit_order",
+  description: "Submit the reviewed order.",
+  annotations: { consequentialHint: true },
+  execute: async () => submitReviewedOrder(),
+});
+```
 
 ## Tool design
 

--- a/apps/site/src/content/docs/packages/webmcp.md
+++ b/apps/site/src/content/docs/packages/webmcp.md
@@ -296,12 +296,13 @@ interface ToolDefinition<
 
 `title` is for human-facing host UI. `description` is consumed by the agent host; write it as an instruction to an LLM about when to call the tool.
 
-The current WebMCP draft defines `readOnlyHint` and `untrustedContentHint`. The SDK also retains `destructiveHint`, `idempotentHint`, `openWorldHint`, and the `destructive` shorthand as source-compatible passthroughs for MCP-shaped and earlier WebMCP hosts; current-draft browsers may ignore those compatibility fields.
+The current WebMCP draft defines `readOnlyHint`, `untrustedContentHint`, and `consequentialHint`. The SDK also retains `destructiveHint`, `idempotentHint`, `openWorldHint`, and the `destructive` shorthand as source-compatible passthroughs for MCP-shaped and earlier WebMCP hosts; current-draft browsers may ignore those compatibility fields.
 
 ```ts
 interface ToolAnnotations {
   readOnlyHint?: boolean;
   untrustedContentHint?: boolean;
+  consequentialHint?: boolean;
   destructiveHint?: boolean; // compatibility
   idempotentHint?: boolean; // compatibility
   openWorldHint?: boolean; // compatibility
@@ -373,9 +374,15 @@ The wrapper will only be removed in a documented breaking release.
 
 ## Safety
 
+Set `annotations.consequentialHint: true` for tools that can cause significant real-world or difficult-to-reverse effects. A compatible host can use this hint when deciding whether to request confirmation.
+
+The hint is not authorization and does not guarantee a confirmation prompt. Applications must enforce authentication, authorization, validation, origin controls, and rate limits. The SDK does not add confirmation behavior.
+
+The SDK forwards explicit `true` and `false` values and leaves the property absent when omitted. Discovery preserves the metadata returned by the host. There is no shorthand, and the SDK does not infer this value from `destructiveHint`.
+
 Set `annotations.untrustedContentHint: true` when results contain external, user-generated, or otherwise untrusted content. It is a trust-boundary signal for the host, not validation of the result's shape, truth, freshness, or safety.
 
-The compatibility shorthand `destructive: true` still communicates mutating intent to hosts that understand `destructiveHint`, but an annotation is not authorization. Confirm consequential actions with the user and defend sensitive operations server-side with authentication, authorization, validation, origin controls, and rate limits.
+The compatibility shorthand `destructive: true` communicates mutating intent to hosts that understand `destructiveHint`. Raw `annotations` values merge on top of shorthand values.
 
 ## Troubleshooting
 

--- a/apps/site/src/content/docs/react/use-webmcp.mdx
+++ b/apps/site/src/content/docs/react/use-webmcp.mdx
@@ -192,6 +192,18 @@ Direct definitions with `input` reject with `ToolValidationError` before applica
 
 `defineTool()` remains as a deprecated compatibility wrapper with its historical `validate: true` input-validation opt-in. New code should pass definitions directly to the hook.
 
+## Annotations
+
+Set `annotations.consequentialHint: true` for tools that can cause significant real-world or difficult-to-reverse effects. A compatible host can use this hint when deciding whether to request confirmation.
+
+The hint is not authorization and does not guarantee a confirmation prompt. Applications must enforce authentication, authorization, validation, origin controls, and rate limits. The SDK does not add confirmation behavior.
+
+The SDK forwards explicit `true` and `false` values and leaves the property absent when omitted. Discovery preserves the metadata returned by the host. There is no shorthand, and the SDK does not infer this value from `destructiveHint`.
+
+Pass the hint inside `annotations`, for example `annotations: { consequentialHint: true }`. Changes between `true`, `false`, and omission rebuild registration through the vanilla core. Equivalent annotation values do not rebuild registration.
+
+Raw `annotations` values merge on top of shorthand values.
+
 ## Reference
 
 ```ts
@@ -254,6 +266,7 @@ interface ToolDefinition<
 interface ToolAnnotations {
   readOnlyHint?: boolean;
   untrustedContentHint?: boolean;
+  consequentialHint?: boolean;
   destructiveHint?: boolean;       // compatibility
   idempotentHint?: boolean;        // compatibility
   openWorldHint?: boolean;         // compatibility

--- a/packages/webmcp/README.md
+++ b/packages/webmcp/README.md
@@ -289,12 +289,13 @@ interface ToolDefinition<
 
 `title` is for human-facing host UI. `description` is consumed by the agent host; write it as an instruction to an LLM about when to call the tool.
 
-The current WebMCP draft defines `readOnlyHint` and `untrustedContentHint`. The SDK also retains `destructiveHint`, `idempotentHint`, `openWorldHint`, and the `destructive` shorthand as source-compatible passthroughs for MCP-shaped and earlier WebMCP hosts; current-draft browsers may ignore those compatibility fields.
+The current WebMCP draft defines `readOnlyHint`, `untrustedContentHint`, and `consequentialHint`. The SDK also retains `destructiveHint`, `idempotentHint`, `openWorldHint`, and the `destructive` shorthand as source-compatible passthroughs for MCP-shaped and earlier WebMCP hosts; current-draft browsers may ignore those compatibility fields.
 
 ```ts
 interface ToolAnnotations {
   readOnlyHint?: boolean;
   untrustedContentHint?: boolean;
+  consequentialHint?: boolean;
   destructiveHint?: boolean; // compatibility
   idempotentHint?: boolean; // compatibility
   openWorldHint?: boolean; // compatibility
@@ -366,9 +367,15 @@ The wrapper will only be removed in a documented breaking release.
 
 ## Safety
 
+Set `annotations.consequentialHint: true` for tools that can cause significant real-world or difficult-to-reverse effects. A compatible host can use this hint when deciding whether to request confirmation.
+
+The hint is not authorization and does not guarantee a confirmation prompt. Applications must enforce authentication, authorization, validation, origin controls, and rate limits. The SDK does not add confirmation behavior.
+
+The SDK forwards explicit `true` and `false` values and leaves the property absent when omitted. Discovery preserves the metadata returned by the host. There is no shorthand, and the SDK does not infer this value from `destructiveHint`.
+
 Set `annotations.untrustedContentHint: true` when results contain external, user-generated, or otherwise untrusted content. It is a trust-boundary signal for the host, not validation of the result's shape, truth, freshness, or safety.
 
-The compatibility shorthand `destructive: true` still communicates mutating intent to hosts that understand `destructiveHint`, but an annotation is not authorization. Confirm consequential actions with the user and defend sensitive operations server-side with authentication, authorization, validation, origin controls, and rate limits.
+The compatibility shorthand `destructive: true` communicates mutating intent to hosts that understand `destructiveHint`. Raw `annotations` values merge on top of shorthand values.
 
 ## Troubleshooting
 

--- a/packages/webmcp/src/index.test.ts
+++ b/packages/webmcp/src/index.test.ts
@@ -165,6 +165,33 @@ describe("tool discovery and execution", () => {
     });
   });
 
+  it.each([true, false, undefined])(
+    "preserves discovered consequentialHint: %s",
+    async (consequentialHint) => {
+      const tool: RegisteredTool = {
+        ...discoveredTool(),
+        annotations:
+          consequentialHint === undefined
+            ? { readOnlyHint: true }
+            : { consequentialHint },
+      };
+      setModelContext("document", {
+        registerTool: vi.fn(),
+        getTools: vi.fn(async () => [tool]),
+      });
+
+      const [discovered] = await getTools();
+      expect(discovered).toBe(tool);
+      if (consequentialHint === undefined) {
+        expect(discovered?.annotations).not.toHaveProperty("consequentialHint");
+      } else {
+        expect(discovered?.annotations?.consequentialHint).toBe(
+          consequentialHint,
+        );
+      }
+    },
+  );
+
   it("serializes input and forwards execution options", async () => {
     const tool = discoveredTool();
     const executeNativeTool = vi.fn(async () => '{"echoed":"hello"}');
@@ -437,6 +464,55 @@ describe("registerTool", () => {
     expect(registered.get("external-search")?.annotations).toEqual({
       untrustedContentHint: false,
     });
+  });
+
+  it.each([true, false])(
+    "forwards consequentialHint: %s without changing raw annotation precedence",
+    (consequentialHint) => {
+      const { registered } = installFakeModelContext("document");
+      registerTool({
+        name: "consequential",
+        description: "Declares consequential effects.",
+        readOnly: true,
+        destructive: true,
+        annotations: {
+          consequentialHint,
+          readOnlyHint: false,
+          destructiveHint: false,
+        },
+        execute: () => ({}),
+      });
+      expect(registered.get("consequential")?.annotations).toEqual({
+        consequentialHint,
+        readOnlyHint: false,
+        destructiveHint: false,
+      });
+      expect(registered.get("consequential")).not.toHaveProperty(
+        "consequentialHint",
+      );
+    },
+  );
+
+  it("does not infer consequentialHint from destructive annotations", () => {
+    const { registered } = installFakeModelContext("document");
+    for (const metadata of [
+      { destructive: true },
+      { annotations: { destructiveHint: true } },
+    ]) {
+      const cleanup = registerTool({
+        name: "compatibility",
+        description: "Declares a compatibility hint.",
+        ...metadata,
+        execute: () => ({}),
+      });
+      expect(registered.get("compatibility")?.annotations).toEqual({
+        destructiveHint: true,
+      });
+      expect(registered.get("compatibility")?.annotations).not.toHaveProperty(
+        "consequentialHint",
+      );
+      cleanup();
+    }
   });
 
   it("omits annotations entirely when no flags are set", () => {

--- a/packages/webmcp/src/react/index.test.tsx
+++ b/packages/webmcp/src/react/index.test.tsx
@@ -344,6 +344,48 @@ describe("useWebMCP", () => {
     unmount();
   });
 
+  it("forwards consequentialHint and updates registration when its value or presence changes", () => {
+    const { registerTool, registered } = installFakeModelContext("document");
+    const { rerender, unmount } = renderHook(
+      ({ consequentialHint }: { consequentialHint: boolean | undefined }) =>
+        useWebMCP({
+          name: "consequential-change",
+          description: "Tracks consequential effects.",
+          input: stringSchema("input"),
+          annotations:
+            consequentialHint === undefined ? {} : { consequentialHint },
+          execute: (text) => text,
+        }),
+      { initialProps: { consequentialHint: true as boolean | undefined } },
+    );
+
+    expect(registered.get("consequential-change")?.annotations).toEqual({
+      consequentialHint: true,
+    });
+    rerender({ consequentialHint: true });
+    expect(registerTool).toHaveBeenCalledTimes(1);
+
+    rerender({ consequentialHint: false });
+    expect(registerTool).toHaveBeenCalledTimes(2);
+    expect(registered.get("consequential-change")?.annotations).toEqual({
+      consequentialHint: false,
+    });
+
+    rerender({ consequentialHint: undefined });
+    expect(registerTool).toHaveBeenCalledTimes(3);
+    expect(registered.get("consequential-change")).not.toHaveProperty(
+      "annotations",
+    );
+
+    rerender({ consequentialHint: true });
+    expect(registerTool).toHaveBeenCalledTimes(4);
+    expect(registered.get("consequential-change")?.annotations).toEqual({
+      consequentialHint: true,
+    });
+    unmount();
+    expect(registered.size).toBe(0);
+  });
+
   it("re-registers when an effective shorthand annotation changes", () => {
     const { registerTool } = installFakeModelContext();
 

--- a/packages/webmcp/src/tool.ts
+++ b/packages/webmcp/src/tool.ts
@@ -3,6 +3,8 @@ export interface ToolAnnotations {
   readOnlyHint?: boolean;
   /** Marks external or user-generated tool output as untrusted. */
   untrustedContentHint?: boolean;
+  /** Signals significant or difficult-to-reverse effects; does not authorize execution or guarantee confirmation. */
+  consequentialHint?: boolean;
   /** Compatibility passthrough for MCP-shaped and earlier WebMCP hosts. */
   destructiveHint?: boolean;
   /** Compatibility passthrough for MCP-shaped and earlier WebMCP hosts. */


### PR DESCRIPTION
Add optional `consequentialHint` typing with registration, discovery, and React regression tests. Document the safety boundary and include a minor changeset.

Validation: `pnpm gate` passed; 25 public-build Chrome 154 smoke checks passed. Chrome 152 omits the hint from native discovery.

Closes #240.
